### PR TITLE
Add OpenAPI Produces tag to api-docs handler

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -35,6 +35,10 @@ const docTemplate = `{
         },
         "/api-docs/": {
             "get": {
+                "description": "Serves the API documentation in Swagger UI format.",
+                "produces": [
+                    "text/html"
+                ],
                 "tags": [
                     "System"
                 ],
@@ -42,7 +46,10 @@ const docTemplate = `{
                 "operationId": "api-docs",
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -28,6 +28,10 @@
         },
         "/api-docs/": {
             "get": {
+                "description": "Serves the API documentation in Swagger UI format.",
+                "produces": [
+                    "text/html"
+                ],
                 "tags": [
                     "System"
                 ],
@@ -35,7 +39,10 @@
                 "operationId": "api-docs",
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -602,10 +602,15 @@ paths:
       - System
   /api-docs/:
     get:
+      description: Serves the API documentation in Swagger UI format.
       operationId: api-docs
+      produces:
+      - text/html
       responses:
         "200":
           description: OK
+          schema:
+            type: string
       summary: OpenAPI specification endpoint.
       tags:
       - System

--- a/internal/server/system_handlers.go
+++ b/internal/server/system_handlers.go
@@ -72,10 +72,12 @@ func metricsActionHandler() http.Handler {
 }
 
 // @Summary     OpenAPI specification endpoint.
+// @Description Serves the API documentation in Swagger UI format.
 // @ID          api-docs
 // @Tags        System
 // @Router      /api-docs/ [get]
-// @Success 	200
+// @Produce     html
+// @Success 	200 {string} string
 func apiDocsActionHandler() http.Handler {
 	return httpSwagger.Handler()
 }


### PR DESCRIPTION
It's required for automation project to actually test the response