### PR TITLE
APPS-1252 Optimize validation for S3

### DIFF
--- a/pkg/model/storage.go
+++ b/pkg/model/storage.go
@@ -3,6 +3,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -58,6 +59,11 @@ func (s *Storage) Validate() error {
 	if s.Type == S3 {
 		if s.S3Region == nil || len(*s.S3Region) == 0 {
 			return errors.New("s3 region is not specified")
+		}
+
+		_, err := url.Parse(*s.Path)
+		if err != nil {
+			return fmt.Errorf("failed to parse S3 storage path: %w", err)
 		}
 	}
 	if s.S3LogLevel != nil &&

--- a/pkg/service/backup_backend.go
+++ b/pkg/service/backup_backend.go
@@ -51,11 +51,7 @@ func newBackend(config *model.Config, routineName string) *BackupBackend {
 			fullBackupInProgress:   &atomic.Bool{},
 		}
 	case model.S3:
-		s3Context, err := NewS3Context(storage)
-		if err != nil {
-			panic(err)
-		}
-
+		s3Context := NewS3Context(storage)
 		routinePath := filepath.Join(s3Context.path, routineName)
 		return &BackupBackend{
 			StorageAccessor:        s3Context,

--- a/pkg/service/configuration_manager_s3.go
+++ b/pkg/service/configuration_manager_s3.go
@@ -26,7 +26,6 @@ var _ S3ManagerBuilder = &S3ManagerBuilderImpl{}
 
 func (builder S3ManagerBuilderImpl) NewS3ConfigurationManager(configStorage *model.Storage,
 ) (ConfigurationManager, error) {
-
 	err := configStorage.Validate()
 	if err != nil {
 		return nil, err

--- a/pkg/service/configuration_manager_s3.go
+++ b/pkg/service/configuration_manager_s3.go
@@ -26,18 +26,14 @@ var _ S3ManagerBuilder = &S3ManagerBuilderImpl{}
 
 func (builder S3ManagerBuilderImpl) NewS3ConfigurationManager(configStorage *model.Storage,
 ) (ConfigurationManager, error) {
-	s3Context, err := NewS3Context(configStorage)
-	if err != nil {
-		return nil, err
-	}
 
-	err = configStorage.Validate()
+	err := configStorage.Validate()
 	if err != nil {
 		return nil, err
 	}
 
 	return &S3ConfigurationManager{
-		s3Context,
+		NewS3Context(configStorage),
 	}, nil
 }
 

--- a/pkg/service/restore_data.go
+++ b/pkg/service/restore_data.go
@@ -238,11 +238,7 @@ func validateStorageContainsBackup(storage *model.Storage) (uint64, error) {
 	case model.Local:
 		return validatePathContainsBackup(*storage.Path)
 	case model.S3:
-		s3context, err := NewS3Context(storage)
-		if err != nil {
-			return 0, err
-		}
-		return s3context.ValidateStorageContainsBackup()
+		return NewS3Context(storage).ValidateStorageContainsBackup()
 	}
 	return 0, nil
 }

--- a/pkg/service/s3_context.go
+++ b/pkg/service/s3_context.go
@@ -77,7 +77,9 @@ func checkBucket(ctx context.Context, client *s3.Client, bucket string) {
 	})
 
 	if err != nil {
-		slog.Warn("AWS S3 Bucket don't exist", slog.String("bucket", bucket), "err", err)
+		slog.Warn("AWS S3 Bucket don't exist",
+			slog.String("bucket", bucket),
+			slog.Any("err", err))
 	}
 }
 

--- a/pkg/service/s3_context.go
+++ b/pkg/service/s3_context.go
@@ -34,15 +34,11 @@ type S3Context struct {
 var _ StorageAccessor = (*S3Context)(nil)
 
 // NewS3Context returns a new S3Context.
-// Panics on any error during initialization.
-func NewS3Context(storage *model.Storage) (*S3Context, error) {
+func NewS3Context(storage *model.Storage) *S3Context {
 	// Load the SDK's configuration from environment and shared config, and
 	// create the client with this.
 	ctx := context.TODO()
-	cfg, err := createConfig(ctx, storage)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load S3 SDK configuration: %w", err)
-	}
+	cfg := createConfig(ctx, storage)
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 		if storage.S3EndpointOverride != nil && *storage.S3EndpointOverride != "" {
@@ -51,39 +47,53 @@ func NewS3Context(storage *model.Storage) (*S3Context, error) {
 		o.UsePathStyle = true
 	})
 
-	bucket, path, err := util.ParseS3Path(*storage.Path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse S3 storage path: %w", err)
-	}
+	// storage path is already validated.
+	bucket, parsedPath, _ := util.ParseS3Path(*storage.Path)
 
-	// Check if the bucket exists
-	_, err = client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucket),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error checking S3 bucket %s existence: %w", bucket, err)
-	}
+	go checkBucket(ctx, client, bucket)
 
 	s := &S3Context{
 		ctx:    ctx,
 		client: client,
 		bucket: bucket,
-		path:   path,
+		path:   parsedPath,
 	}
 
 	s.metadataCache = util.NewLoadingCache(ctx, func(path string) (*model.BackupMetadata, error) {
 		return s.readMetadata(path)
 	})
-	return s, nil
+	return s
 }
 
-func createConfig(ctx context.Context, storage *model.Storage) (aws.Config, error) {
+// checkBucket verifies if the S3 bucket exists.
+// As a side effect, it also ensures that the S3 service is available (network connectivity)
+// and the provided credentials are valid.
+// If the bucket doesn't exist at startup or AWS is unavailable, a warning is logged.
+// However, it's not critical as the bucket only needs to be available during backup/restore operations.
+// This function is executed in a goroutine to avoid blocking the initialization process.
+func checkBucket(ctx context.Context, client *s3.Client, bucket string) {
+	_, err := client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+
+	if err != nil {
+		slog.Warn("AWS S3 Bucket don't exist", slog.String("bucket", bucket), "err", err)
+	}
+}
+
+func createConfig(ctx context.Context, storage *model.Storage) aws.Config {
 	storage.SetDefaultProfile()
-	return config.LoadDefaultConfig(
+	cfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithSharedConfigProfile(*storage.S3Profile),
 		config.WithRegion(*storage.S3Region),
 	)
+
+	if err != nil {
+		panic(fmt.Sprintf("failed loading config, %v", err))
+	}
+
+	return cfg
 }
 
 func (s *S3Context) readBackupState(stateFilePath string, state *model.BackupState) error {

--- a/pkg/service/s3_context.go
+++ b/pkg/service/s3_context.go
@@ -91,7 +91,7 @@ func createConfig(ctx context.Context, storage *model.Storage) aws.Config {
 		config.WithRegion(*storage.S3Region),
 	)
 
-	if err != nil {
+	if err != nil { //TODO: handle panic
 		panic(fmt.Sprintf("failed loading config, %v", err))
 	}
 

--- a/pkg/service/s3_context_test.go
+++ b/pkg/service/s3_context_test.go
@@ -17,14 +17,14 @@ var contexts []S3Context
 var minioContext *S3Context
 
 func init() {
-	minioContext, _ = NewS3Context(&model.Storage{
+	minioContext = NewS3Context(&model.Storage{
 		Type:               model.S3,
 		Path:               ptr.String("s3://as-backup-bucket/storageMinio"),
 		S3Profile:          ptr.String("minio"),
 		S3Region:           ptr.String("eu-central-1"),
 		S3EndpointOverride: ptr.String("http://localhost:9000"),
 	})
-	s3Context, _ := NewS3Context(&model.Storage{
+	s3Context := NewS3Context(&model.Storage{
 		Type:     model.S3,
 		Path:     ptr.String("s3://as-backup-integration-test/storageAws"),
 		S3Region: ptr.String("eu-central-1"),

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -32,7 +32,7 @@ type RestoreHandler interface {
 	Wait() error
 }
 
-// RestoreHandler represents a backup handler returned by the backup client.
+// BackupHandler represents a backup handler returned by the backup client.
 type BackupHandler interface {
 	// GetStats returns the statistics of the backup job.
 	GetStats() *models.BackupStats


### PR DESCRIPTION
Apply took long, because for every routine we checked s3 connection.
1) Don't fail if bucket (or S3 in general) is not available on startup. We will fail on actual backup anyway.
2) Move parsing of path into validation, to simplify process.