### PR TITLE
APPS-1325 Delete failed backups

### DIFF
--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -166,7 +166,7 @@ func (h *BackupRoutineHandler) waitForFullBackups(
 		err := handler.Wait(ctx)
 		if err != nil {
 			backupFailureCounter.Inc()
-			slog.Info("delete failed backup folder",
+			slog.Info("Delete failed backup folder",
 				slog.String("path", backupFolder),
 			)
 			h.deleteFolder(ctx, backupFolder, logger) // cleanup on failure
@@ -178,7 +178,9 @@ func (h *BackupRoutineHandler) waitForFullBackups(
 			return err
 		}
 	}
-	backupDurationGauge.Set(float64(time.Since(startTime).Milliseconds()))
+	duration := float64(time.Since(startTime).Milliseconds())
+	logger.Info("Finished full backup", slog.Float64("duration_ms", duration))
+	backupDurationGauge.Set(duration)
 	return nil
 }
 

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -108,7 +108,7 @@ func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now ti
 		return err
 	}
 
-	err = h.waitForFullBackups(ctx, now)
+	err = h.waitForFullBackups(ctx, now, logger)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now ti
 		h.deleteFolder(ctx, h.backend.incrementalBackupsPath, logger)
 	}
 
-	h.writeClusterConfiguration(ctx, client.AerospikeClient(), now)
+	h.writeClusterConfiguration(ctx, client.AerospikeClient(), now, logger)
 	return nil
 }
 
@@ -157,17 +157,20 @@ func (h *BackupRoutineHandler) startFullBackupForAllNamespaces(
 	return nil
 }
 
-func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context, backupTimestamp time.Time) error {
+func (h *BackupRoutineHandler) waitForFullBackups(
+	ctx context.Context, backupTimestamp time.Time, logger *slog.Logger,
+) error {
 	startTime := time.Now() // startTime is only used to measure backup time
 	for namespace, handler := range h.fullBackupHandlers {
+		backupFolder := getFullPath(h.backend.fullBackupsPath, h.backupFullPolicy, namespace, backupTimestamp)
 		err := handler.Wait(ctx)
 		if err != nil {
 			backupFailureCounter.Inc()
+			h.deleteFolder(ctx, backupFolder, logger) // cleanup on failure
 			return fmt.Errorf("error during backup namespace %s, routine %s: %w",
 				namespace, h.routineName, err)
 		}
 
-		backupFolder := getFullPath(h.backend.fullBackupsPath, h.backupFullPolicy, namespace, backupTimestamp)
 		if err := h.writeBackupMetadata(ctx, handler.GetStats(), backupTimestamp, namespace, backupFolder); err != nil {
 			return err
 		}
@@ -177,10 +180,8 @@ func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context, backupTim
 }
 
 func (h *BackupRoutineHandler) writeClusterConfiguration(
-	ctx context.Context, client backup.AerospikeClient, now time.Time,
+	ctx context.Context, client backup.AerospikeClient, now time.Time, logger *slog.Logger,
 ) {
-	logger := slog.Default().With(slog.String("routine", h.routineName))
-
 	infos := getClusterConfiguration(client)
 	if len(infos) == 0 {
 		logger.Warn("Could not read aerospike configuration")

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -166,6 +166,9 @@ func (h *BackupRoutineHandler) waitForFullBackups(
 		err := handler.Wait(ctx)
 		if err != nil {
 			backupFailureCounter.Inc()
+			slog.Info("delete failed backup folder",
+				slog.String("path", backupFolder),
+			)
 			h.deleteFolder(ctx, backupFolder, logger) // cleanup on failure
 			return fmt.Errorf("error during backup namespace %s, routine %s: %w",
 				namespace, h.routineName, err)

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -179,7 +179,7 @@ func (h *BackupRoutineHandler) waitForFullBackups(
 		}
 	}
 	duration := float64(time.Since(startTime).Milliseconds())
-	logger.Info("Finished full backup", slog.Float64("duration_ms", duration))
+	logger.Debug("Finished full backup", slog.Float64("duration_ms", duration))
 	backupDurationGauge.Set(duration)
 	return nil
 }

--- a/pkg/service/client_manager.go
+++ b/pkg/service/client_manager.go
@@ -111,7 +111,7 @@ func isClusterHealthy(client backup.AerospikeClient) bool {
 		return false
 	}
 
-	info, err := node.RequestInfo(nil, "status")
+	info, err := node.RequestInfo(client.GetDefaultInfoPolicy(), "status")
 	return err == nil && info["status"] == "ok"
 }
 

--- a/pkg/service/client_manager.go
+++ b/pkg/service/client_manager.go
@@ -99,7 +99,7 @@ func (cm *ClientManagerImpl) GetClient(cluster *model.AerospikeCluster) (*backup
 }
 
 // getExistingClient tries to get an existing client from the cache.
-// Returns nil if client doesn't exist, error is client is not connected.
+// Returns nil if client doesn't exist, error if client is not connected.
 func (cm *ClientManagerImpl) getExistingClient(cluster *model.AerospikeCluster) (*backup.Client, error) {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()

--- a/pkg/service/client_manager.go
+++ b/pkg/service/client_manager.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -60,11 +61,15 @@ func NewClientManager(aerospikeClientFactory AerospikeClientFactory, closeDelay 
 
 // GetClient returns a backup client by aerospike cluster name (new or cached).
 func (cm *ClientManagerImpl) GetClient(cluster *model.AerospikeCluster) (*backup.Client, error) {
-	if client := cm.getExistingClient(cluster); client != nil {
+	client, err := cm.getExistingClient(cluster)
+	if err != nil {
+		return nil, err
+	}
+	if client != nil {
 		return client, nil
 	}
 
-	client, err := cm.createClient(cluster)
+	client, err = cm.createClient(cluster)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create backup client: %w", err)
 	}
@@ -74,16 +79,40 @@ func (cm *ClientManagerImpl) GetClient(cluster *model.AerospikeCluster) (*backup
 
 // getExistingClient tries to get an existing client from the cache.
 // Returns nil if client doesn't exist.
-func (cm *ClientManagerImpl) getExistingClient(cluster *model.AerospikeCluster) *backup.Client {
+func (cm *ClientManagerImpl) getExistingClient(cluster *model.AerospikeCluster) (*backup.Client, error) {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 
 	if info, exists := cm.clients[cluster]; exists {
+		if !isClusterHealthy(info.client.AerospikeClient()) {
+			return nil, errors.New("aerospike cluster connection lost")
+		}
+
 		cm.incrementRef(info)
-		return info.client
+		return info.client, nil
 	}
 
-	return nil
+	return nil, nil
+}
+
+// isClusterHealthy checks if the cluster is connected and responding
+func isClusterHealthy(client backup.AerospikeClient) bool {
+	if client == nil {
+		return false
+	}
+
+	cluster := client.Cluster()
+	if !cluster.IsConnected() {
+		return false
+	}
+
+	node, err := cluster.GetRandomNode()
+	if err != nil { // No nodes available
+		return false
+	}
+
+	info, err := node.RequestInfo(nil, "status")
+	return err == nil && info["status"] == "ok"
 }
 
 // storeClient attempts to store the client in the cache.

--- a/pkg/service/client_manager.go
+++ b/pkg/service/client_manager.go
@@ -20,9 +20,10 @@ type ClientManager interface {
 	Close(*backup.Client)
 }
 
-// AerospikeClientFactory defines an interface for creating new clients.
+// AerospikeClientFactory defines an interface for creating and checking clients.
 type AerospikeClientFactory interface {
 	NewClientWithPolicyAndHost(policy *as.ClientPolicy, hosts ...*as.Host) (backup.AerospikeClient, error)
+	IsClusterHealthy(client backup.AerospikeClient) bool
 }
 
 // DefaultClientFactory is the default implementation of AerospikeClientFactory.
@@ -33,6 +34,26 @@ func (f *DefaultClientFactory) NewClientWithPolicyAndHost(
 	policy *as.ClientPolicy, hosts ...*as.Host,
 ) (backup.AerospikeClient, error) {
 	return as.NewClientWithPolicyAndHost(policy, hosts...)
+}
+
+// IsClusterHealthy checks if the cluster is connected and responding.
+func (f *DefaultClientFactory) IsClusterHealthy(client backup.AerospikeClient) bool {
+	if client == nil {
+		return false
+	}
+
+	cluster := client.Cluster()
+	if !cluster.IsConnected() {
+		return false
+	}
+
+	node, err := cluster.GetRandomNode()
+	if err != nil {
+		return false
+	}
+
+	info, err := node.RequestInfo(nil, "status")
+	return err == nil && info["status"] == "ok"
 }
 
 // ClientManagerImpl implements [ClientManager].
@@ -78,13 +99,13 @@ func (cm *ClientManagerImpl) GetClient(cluster *model.AerospikeCluster) (*backup
 }
 
 // getExistingClient tries to get an existing client from the cache.
-// Returns nil if client doesn't exist.
+// Returns nil if client doesn't exist, error is client is not connected.
 func (cm *ClientManagerImpl) getExistingClient(cluster *model.AerospikeCluster) (*backup.Client, error) {
 	cm.mu.RLock()
 	defer cm.mu.RUnlock()
 
 	if info, exists := cm.clients[cluster]; exists {
-		if !isClusterHealthy(info.client.AerospikeClient()) {
+		if !cm.clientFactory.IsClusterHealthy(info.client.AerospikeClient()) {
 			return nil, errors.New("aerospike cluster connection lost")
 		}
 
@@ -93,26 +114,6 @@ func (cm *ClientManagerImpl) getExistingClient(cluster *model.AerospikeCluster) 
 	}
 
 	return nil, nil
-}
-
-// isClusterHealthy checks if the cluster is connected and responding
-func isClusterHealthy(client backup.AerospikeClient) bool {
-	if client == nil {
-		return false
-	}
-
-	cluster := client.Cluster()
-	if !cluster.IsConnected() {
-		return false
-	}
-
-	node, err := cluster.GetRandomNode()
-	if err != nil { // No nodes available
-		return false
-	}
-
-	info, err := node.RequestInfo(client.GetDefaultInfoPolicy(), "status")
-	return err == nil && info["status"] == "ok"
 }
 
 // storeClient attempts to store the client in the cache.

--- a/pkg/service/client_manager_test.go
+++ b/pkg/service/client_manager_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/aerospike/backup-go/mocks"
 	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockClientFactory is a mock implementation of the AerospikeClientFactory interface.
 type MockClientFactory struct {
-	ShouldFail bool
+	ShouldFail            bool
+	IsClusterDisconnected bool
 }
 
 var cluster = &model.AerospikeCluster{
@@ -33,12 +35,8 @@ func (f *MockClientFactory) NewClientWithPolicyAndHost(_ *as.ClientPolicy, _ ...
 	return m, nil
 }
 
-func assertClientExists(t *testing.T, clientManager *ClientManagerImpl, cl *model.AerospikeCluster, shouldExist bool) {
-	t.Helper()
-	clientManager.mu.Lock()
-	defer clientManager.mu.Unlock()
-	_, exists := clientManager.clients[cl]
-	assert.Equal(t, shouldExist, exists)
+func (f *MockClientFactory) IsClusterHealthy(_ backup.AerospikeClient) bool {
+	return !f.IsClusterDisconnected
 }
 
 func Test_GetClient(t *testing.T) {
@@ -57,6 +55,20 @@ func Test_GetClient(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, client2)
 	assert.Equal(t, client, client2)
+}
+
+func Test_GetClient_UnhealthyConnection(t *testing.T) {
+	clientManager := NewClientManager(
+		&MockClientFactory{IsClusterDisconnected: true},
+		10*time.Second,
+	)
+
+	_, _ = clientManager.GetClient(cluster)
+	// Try to get client - should fail due to unhealthy connection
+	client, err := clientManager.GetClient(cluster)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "aerospike cluster connection lost")
+	assert.Nil(t, client)
 }
 
 func Test_CreateClient(t *testing.T) {
@@ -157,4 +169,12 @@ func Test_Close_NotExisting(t *testing.T) {
 	clientManager.Close(client)
 
 	aeroClient.AssertExpectations(t)
+}
+
+func assertClientExists(t *testing.T, clientManager *ClientManagerImpl, cl *model.AerospikeCluster, shouldExist bool) {
+	t.Helper()
+	clientManager.mu.Lock()
+	defer clientManager.mu.Unlock()
+	_, exists := clientManager.clients[cl]
+	assert.Equal(t, shouldExist, exists)
 }

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -42,6 +42,7 @@ func (r *RetryService) retry(f func() error, retryInterval time.Duration, n int3
 
 	logger.Info("Execution failed, retry scheduled",
 		slog.Any("retryInterval", retryInterval),
+		slog.Any("attempts", n-1),
 		slog.Any("err", err))
 
 	r.timer = time.AfterFunc(retryInterval, func() {

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -25,7 +25,7 @@ func NewRetryService(label string) *RetryService {
 func (r *RetryService) retry(f func() error, retryInterval time.Duration, n int32) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	logger := slog.Default().With(slog.String("label", r.label))
+	logger := slog.Default().With(slog.String("routine", r.label))
 
 	r.clearTimer()
 	err := f()

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -25,7 +25,7 @@ func NewRetryService(label string) *RetryService {
 func (r *RetryService) retry(f func() error, retryInterval time.Duration, n int32) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	logger := slog.Default().With(slog.String("routine", r.label))
+	logger := slog.Default().With(slog.String("label", r.label))
 
 	r.clearTimer()
 	err := f()


### PR DESCRIPTION
PR is fixing unstable integration tests after introducing client cache
1) Delete failed full backup (per namespace)
2) Check connection status before getting client from cache