### PR TITLE
Quickfix nil pointer dereference in IsClusterHealthy

### DIFF
--- a/pkg/service/client_manager.go
+++ b/pkg/service/client_manager.go
@@ -52,7 +52,7 @@ func (f *DefaultClientFactory) IsClusterHealthy(client backup.AerospikeClient) b
 		return false
 	}
 
-	info, err := node.RequestInfo(nil, "status")
+	info, err := node.RequestInfo(client.GetDefaultInfoPolicy(), "status")
 	return err == nil && info["status"] == "ok"
 }
 


### PR DESCRIPTION
I don't know why it was nil, it looks like a merge conflict I missed