### PR TITLE
APPS-1335 Don't save namespace handler if it fails to start

### DIFF
--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -354,8 +354,8 @@ func (h *BackupRoutineHandler) waitForIncrementalBackups(
 		}
 
 		backupFolder := getIncrementalPathForNamespace(h.routineName, namespace, backupTimestamp)
-		// delete if the backup file is empty
-		if handler.GetStats().IsEmpty() {
+		// delete backup files if the backup is empty or failed
+		if err != nil || handler.GetStats().IsEmpty() {
 			h.deleteFolder(ctx, backupFolder)
 			continue
 		}

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -224,7 +224,8 @@ func (h *BackupRoutineHandler) createTimebounds(fullBackup bool, now time.Time) 
 	)
 
 	if !fullBackup {
-		fromTime = &h.state.LastFullRun
+		lastRun := h.state.LastRun()
+		fromTime = &lastRun
 	}
 
 	if h.backupFullPolicy.IsSealed() {

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -192,7 +192,7 @@ func (h *BackupRoutineHandler) startNamespaceBackup(
 	ctx context.Context, namespace string, now time.Time, client *backup.Client,
 ) BackupHandler {
 	backupFolder := getFullPath(h.routineName, h.backupFullPolicy, namespace, now)
-	timebounds := h.createTimebounds(now)
+	timebounds := h.createTimebounds(true, now)
 
 	return startBackup(
 		ctx,
@@ -211,11 +211,21 @@ func (h *BackupRoutineHandler) startNamespaceBackup(
 	)
 }
 
-func (h *BackupRoutineHandler) createTimebounds(now time.Time) model.TimeBounds {
-	if h.backupFullPolicy.IsSealed() {
-		return *model.NewTimeBoundsTo(now)
+func (h *BackupRoutineHandler) createTimebounds(fullBackup bool, now time.Time) model.TimeBounds {
+	var (
+		fromTime *time.Time
+		toTime   *time.Time
+	)
+
+	if !fullBackup {
+		fromTime = &h.state.LastFullRun
 	}
-	return model.TimeBounds{}
+
+	if h.backupFullPolicy.IsSealed() {
+		toTime = &now
+	}
+
+	return model.TimeBounds{FromTime: fromTime, ToTime: toTime}
 }
 
 func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context) error {
@@ -267,6 +277,7 @@ func (h *BackupRoutineHandler) deleteFolder(ctx context.Context, path string) {
 
 func (h *BackupRoutineHandler) runIncrementalBackup(ctx context.Context, now time.Time) {
 	if h.skipIncrementalBackup() {
+		incrBackupSkippedCounter.Inc()
 		return
 	}
 
@@ -355,19 +366,11 @@ func (h *BackupRoutineHandler) runIncrementalBackupInternal(ctx context.Context,
 	return nil
 }
 
-func (h *BackupRoutineHandler) createIncremenralTimeBounds(now time.Time) *model.TimeBounds {
-	timebounds := model.NewTimeBoundsFrom(h.state.LastRun())
-	if h.backupFullPolicy.IsSealed() {
-		timebounds.ToTime = &now
-	}
-	return timebounds
-}
-
 func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
 	ctx context.Context, namespace string, now time.Time, client *backup.Client,
 ) BackupHandler {
 	backupFolder := getIncrementalPathForNamespace(h.routineName, namespace, now)
-	timebounds := h.createIncremenralTimeBounds(now)
+	timebounds := h.createTimebounds(false, now)
 
 	return startBackup(
 		ctx,
@@ -375,7 +378,7 @@ func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
 		func(ctx context.Context) (BackupHandler, error) { // start backup.
 			return h.backupService.BackupRun(ctx,
 				h.backupRoutine, h.backupIncrPolicy, client, h.storage, h.secretAgent,
-				*timebounds, namespace, backupFolder)
+				timebounds, namespace, backupFolder)
 		},
 		func(ctx context.Context) { // on fail.
 			h.deleteFolder(ctx, backupFolder)

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -130,7 +130,7 @@ func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time)
 	})
 
 	if err != nil {
-		h.logger.Error("Failed running full backup", slog.Any("error", err))
+		h.logger.Error("Full backup failed", slog.Any("error", err))
 		backupFailureCounter.Inc()
 	} else {
 		h.logger.Debug("Finished full backup")
@@ -288,7 +288,7 @@ func (h *BackupRoutineHandler) runIncrementalBackup(ctx context.Context, now tim
 	})
 	if err != nil {
 		incrBackupFailureCounter.Inc()
-		h.logger.Error("Failed running incremental backup", slog.Any("error", err))
+		h.logger.Error("Incremental backup failed", slog.Any("error", err))
 	} else {
 		incrBackupCounter.Inc()
 		incrBackupDurationGauge.Set(float64(duration.Milliseconds()))

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -26,7 +26,7 @@ type BackupRoutineHandler struct {
 	storage             model.Storage
 	secretAgent         *model.SecretAgent
 	state               *model.BackupState
-	retry               Executor
+	retry               executor
 	clientManager       ClientManager
 	logger              *slog.Logger
 	clusterConfigWriter ClusterConfigWriter
@@ -100,7 +100,7 @@ func newBackupRoutineHandler(
 		storage:          backupStorage,
 		secretAgent:      backupRoutine.SecretAgent,
 		state:            backupBackend.ReadState(),
-		retry: NewRetryExecutor(
+		retry: newRetryExecutor(
 			time.Duration(backupPolicy.GetRetryDelayOrDefault())*time.Millisecond,
 			int(backupPolicy.GetMaxRetriesOrDefault()),
 			logger),
@@ -171,7 +171,7 @@ func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now ti
 	return nil
 }
 
-func (h *BackupRoutineHandler) prepareCluster(retry Executor) (*backup.Client, []string, error) {
+func (h *BackupRoutineHandler) prepareCluster(retry executor) (*backup.Client, []string, error) {
 	var (
 		client     *backup.Client
 		namespaces []string
@@ -314,7 +314,7 @@ func (h *BackupRoutineHandler) skipIncrementalBackup() bool {
 }
 
 func (h *BackupRoutineHandler) runIncrementalBackupInternal(ctx context.Context, now time.Time) error {
-	client, namespaces, err := h.prepareCluster(&SimpleExecutor{})
+	client, namespaces, err := h.prepareCluster(&simpleExecutor{})
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
 
 	return startBackup(
 		ctx,
-		&SimpleExecutor{},
+		&simpleExecutor{},
 		func(ctx context.Context) (BackupHandler, error) { // start backup.
 			return h.backupService.BackupRun(ctx,
 				h.backupRoutine, h.backupIncrPolicy, client, h.storage, h.secretAgent,

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -333,6 +333,7 @@ func (h *BackupRoutineHandler) startIncrementalBackupForAllNamespaces(
 			h.logger.Warn("could not start backup",
 				slog.String("namespace", namespace),
 				slog.Any("err", err))
+			continue
 		}
 		h.incrBackupHandlers[namespace] = handler
 	}

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -124,14 +124,18 @@ func getNamespacesToBackup(namespaces []string, client backup.AerospikeClient) (
 }
 
 func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time) {
-	if len(h.fullBackupHandlers) > 0 {
-		h.logger.Info("Full backup is currently in progress, skipping full backup")
-		return
+	if err := h.runFullBackupInternal(ctx, now); err != nil {
+		h.logger.Error("failed running full backup", slog.Any("error", err))
+		backupFailureCounter.Inc()
+	} else {
+		backupCounter.Inc()
 	}
+}
 
+func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now time.Time) error {
 	client, namespaces, err := h.prepareClusterWithRetries()
 	if err != nil {
-		return
+		return err
 	}
 
 	defer func() {
@@ -145,11 +149,8 @@ func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time)
 
 	err = h.waitForFullBackups(ctx)
 	if err != nil {
-		return
+		return err
 	}
-
-	// increment backupCounter metric
-	backupCounter.Inc()
 
 	// update the state
 	h.state.SetLastFullRun(now)
@@ -159,6 +160,8 @@ func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time)
 	}
 
 	h.clusterConfigWriter.Write(ctx, client.AerospikeClient(), now)
+
+	return nil
 }
 
 func (h *BackupRoutineHandler) prepareClusterWithRetries() (*backup.Client, []string, error) {

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -333,6 +333,7 @@ func (h *BackupRoutineHandler) startIncrementalBackupForAllNamespaces(
 			h.logger.Warn("could not start backup",
 				slog.String("namespace", namespace),
 				slog.Any("err", err))
+			h.deleteFolder(ctx, backupFolder)
 			continue
 		}
 		h.incrBackupHandlers[namespace] = handler

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -307,41 +307,6 @@ func (h *BackupRoutineHandler) skipIncrementalBackup() bool {
 	return false
 }
 
-func (h *BackupRoutineHandler) waitForIncrementalBackups(
-	ctx context.Context, backupTimestamp time.Time,
-) error {
-	startTime := time.Now() // startTime is only used to measure backup time
-	var (
-		aggregatedErr error
-		hasBackup     bool
-	)
-	for _, handler := range h.incrBackupHandlers {
-		err := handler.Wait(ctx)
-		if err != nil {
-			aggregatedErr = errors.Join(aggregatedErr, err)
-			continue
-		}
-		if handler.GetStats() != nil && !handler.GetStats().IsEmpty() {
-			hasBackup = true
-		}
-	}
-
-	if !hasBackup {
-		// No backup data was written, we should delete the root folder.
-		h.deleteFolder(ctx, getIncrementalTimestampPath(h.routineName, backupTimestamp))
-	}
-
-	incrBackupDurationGauge.Set(float64(time.Since(startTime).Milliseconds()))
-	return aggregatedErr
-}
-
-func (h *BackupRoutineHandler) GetCurrentStat() *model.CurrentBackups {
-	return &model.CurrentBackups{
-		Full:        currentBackupStatus(h.fullBackupHandlers),
-		Incremental: currentBackupStatus(h.incrBackupHandlers),
-	}
-}
-
 func (h *BackupRoutineHandler) runIncrementalBackupInternal(ctx context.Context, now time.Time) error {
 	client, namespaces, err := h.prepareCluster(&SimpleExecutor{})
 	if err != nil {
@@ -394,4 +359,39 @@ func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
 			return h.writeBackupMetadata(ctx, stats, now, namespace, backupFolder)
 		},
 	)
+}
+
+func (h *BackupRoutineHandler) waitForIncrementalBackups(
+	ctx context.Context, backupTimestamp time.Time,
+) error {
+	startTime := time.Now() // startTime is only used to measure backup time
+	var (
+		aggregatedErr error
+		hasBackup     bool
+	)
+	for _, handler := range h.incrBackupHandlers {
+		err := handler.Wait(ctx)
+		if err != nil {
+			aggregatedErr = errors.Join(aggregatedErr, err)
+			continue
+		}
+		if handler.GetStats() != nil && !handler.GetStats().IsEmpty() {
+			hasBackup = true
+		}
+	}
+
+	if !hasBackup {
+		// No backup data was written, we should delete the root folder.
+		h.deleteFolder(ctx, getIncrementalTimestampPath(h.routineName, backupTimestamp))
+	}
+
+	incrBackupDurationGauge.Set(float64(time.Since(startTime).Milliseconds()))
+	return aggregatedErr
+}
+
+func (h *BackupRoutineHandler) GetCurrentStat() *model.CurrentBackups {
+	return &model.CurrentBackups{
+		Full:        currentBackupStatus(h.fullBackupHandlers),
+		Incremental: currentBackupStatus(h.incrBackupHandlers),
+	}
 }

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -25,7 +25,7 @@ type BackupRoutineHandler struct {
 	storage             model.Storage
 	secretAgent         *model.SecretAgent
 	state               *model.BackupState
-	retry               *RetryService
+	retry               Executor
 	clientManager       ClientManager
 	logger              *slog.Logger
 	clusterConfigWriter ClusterConfigWriter
@@ -99,7 +99,7 @@ func newBackupRoutineHandler(
 		storage:          backupStorage,
 		secretAgent:      backupRoutine.SecretAgent,
 		state:            backupBackend.ReadState(),
-		retry: NewRetryService(
+		retry: NewRetryExecutor(
 			time.Duration(backupPolicy.GetRetryDelayOrDefault())*time.Millisecond,
 			int(backupPolicy.GetMaxRetriesOrDefault()),
 			logger),
@@ -125,15 +125,16 @@ func getNamespacesToBackup(namespaces []string, client backup.AerospikeClient) (
 
 func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time) {
 	if err := h.runFullBackupInternal(ctx, now); err != nil {
-		h.logger.Error("failed running full backup", slog.Any("error", err))
+		h.logger.Error("Failed running full backup", slog.Any("error", err))
 		backupFailureCounter.Inc()
 	} else {
+		h.logger.Debug("Finished full backup")
 		backupCounter.Inc()
 	}
 }
 
 func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now time.Time) error {
-	client, namespaces, err := h.prepareClusterWithRetries()
+	client, namespaces, err := h.prepareCluster(h.retry)
 	if err != nil {
 		return err
 	}
@@ -164,13 +165,13 @@ func (h *BackupRoutineHandler) runFullBackupInternal(ctx context.Context, now ti
 	return nil
 }
 
-func (h *BackupRoutineHandler) prepareClusterWithRetries() (*backup.Client, []string, error) {
+func (h *BackupRoutineHandler) prepareCluster(retry Executor) (*backup.Client, []string, error) {
 	var (
 		client     *backup.Client
 		namespaces []string
 	)
 
-	err := h.retry.retry("cluster connection", func() error {
+	err := retry.run("cluster connection", func() error {
 		var err error
 		client, err = h.clientManager.GetClient(h.backupRoutine.SourceCluster)
 		if err != nil {
@@ -193,7 +194,7 @@ func (h *BackupRoutineHandler) startNamespaceBackup(
 	backupFolder := getFullPath(h.routineName, h.backupFullPolicy, namespace, now)
 	timebounds := h.createTimebounds(now)
 
-	return startRetryableBackup(
+	return startBackup(
 		ctx,
 		h.retry,
 		func(ctx context.Context) (BackupHandler, error) { // start backup.
@@ -223,17 +224,12 @@ func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context) error {
 	var aggregatedErr error
 	for _, handler := range h.fullBackupHandlers {
 		if err := handler.Wait(ctx); err != nil {
-			backupFailureCounter.Inc()
 			aggregatedErr = errors.Join(aggregatedErr, err)
 		}
 	}
 
 	durationMs := float64(time.Since(startTime).Milliseconds())
 	backupDurationGauge.Set(durationMs)
-
-	if aggregatedErr == nil {
-		h.logger.Debug("Finished full backup", slog.Float64("duration_ms", durationMs))
-	}
 
 	return aggregatedErr
 }
@@ -274,25 +270,13 @@ func (h *BackupRoutineHandler) runIncrementalBackup(ctx context.Context, now tim
 		return
 	}
 
-	client, err := h.clientManager.GetClient(h.backupRoutine.SourceCluster)
-	if err != nil {
-		h.logger.Error("cannot create backup client", slog.Any("err", err))
-		return
+	if err := h.runIncrementalBackupInternal(ctx, now); err != nil {
+		incrBackupFailureCounter.Inc()
+		h.logger.Error("Failed running incremental backup", slog.Any("error", err))
+	} else {
+		incrBackupCounter.Inc()
+		h.logger.Debug("Finished incremental backup")
 	}
-
-	defer func() {
-		h.clientManager.Close(client)
-		clear(h.incrBackupHandlers)
-	}()
-
-	h.startIncrementalBackupForAllNamespaces(ctx, client, now)
-
-	h.waitForIncrementalBackups(ctx, now)
-	// increment incrBackupCounter metric
-	incrBackupCounter.Inc()
-
-	// update the state
-	h.state.SetLastIncrRun(now)
 }
 
 func (h *BackupRoutineHandler) skipIncrementalBackup() bool {
@@ -312,69 +296,32 @@ func (h *BackupRoutineHandler) skipIncrementalBackup() bool {
 	return false
 }
 
-func (h *BackupRoutineHandler) startIncrementalBackupForAllNamespaces(
-	ctx context.Context, client *backup.Client, upperBound time.Time) {
-	timebounds := model.NewTimeBoundsFrom(h.state.LastRun())
-	if h.backupFullPolicy.IsSealed() {
-		timebounds.ToTime = &upperBound
-	}
-
-	clear(h.incrBackupHandlers)
-
-	namespaces, err := getNamespacesToBackup(h.namespaces, client.AerospikeClient())
-	if err != nil {
-		return
-	}
-
-	for _, namespace := range namespaces {
-		backupFolder := getIncrementalPathForNamespace(h.routineName, namespace, upperBound)
-		handler, err := h.backupService.BackupRun(ctx,
-			h.backupRoutine, h.backupIncrPolicy, client, h.storage, h.secretAgent,
-			*timebounds, namespace, backupFolder)
-		if err != nil {
-			incrBackupFailureCounter.Inc()
-			h.logger.Warn("could not start backup",
-				slog.String("namespace", namespace),
-				slog.Any("err", err))
-			h.deleteFolder(ctx, backupFolder)
-			continue
-		}
-		h.incrBackupHandlers[namespace] = handler
-	}
-}
-
 func (h *BackupRoutineHandler) waitForIncrementalBackups(
 	ctx context.Context, backupTimestamp time.Time,
-) {
+) error {
 	startTime := time.Now() // startTime is only used to measure backup time
-	hasBackup := false
-	for namespace, handler := range h.incrBackupHandlers {
+	var (
+		aggregatedErr error
+		hasBackup     bool
+	)
+	for _, handler := range h.incrBackupHandlers {
 		err := handler.Wait(ctx)
 		if err != nil {
-			h.logger.Warn("Failed incremental backup",
-				slog.Any("err", err))
-			incrBackupFailureCounter.Inc()
-		}
-
-		backupFolder := getIncrementalPathForNamespace(h.routineName, namespace, backupTimestamp)
-		// delete backup files if the backup is empty or failed
-		if err != nil || handler.GetStats().IsEmpty() {
-			h.deleteFolder(ctx, backupFolder)
+			aggregatedErr = errors.Join(aggregatedErr, err)
 			continue
 		}
-		if err := h.writeBackupMetadata(ctx, handler.GetStats(), backupTimestamp, namespace, backupFolder); err != nil {
-			h.logger.Error("Could not Write backup metadata",
-				slog.String("folder", backupFolder),
-				slog.Any("err", err))
+		if handler.GetStats() != nil && !handler.GetStats().IsEmpty() {
+			hasBackup = true
 		}
-		hasBackup = true
 	}
 
 	if !hasBackup {
+		// No backup data was written, we should delete the root folder.
 		h.deleteFolder(ctx, getIncrementalTimestampPath(h.routineName, backupTimestamp))
 	}
 
 	incrBackupDurationGauge.Set(float64(time.Since(startTime).Milliseconds()))
+	return aggregatedErr
 }
 
 func (h *BackupRoutineHandler) GetCurrentStat() *model.CurrentBackups {
@@ -382,4 +329,66 @@ func (h *BackupRoutineHandler) GetCurrentStat() *model.CurrentBackups {
 		Full:        currentBackupStatus(h.fullBackupHandlers),
 		Incremental: currentBackupStatus(h.incrBackupHandlers),
 	}
+}
+
+func (h *BackupRoutineHandler) runIncrementalBackupInternal(ctx context.Context, now time.Time) error {
+	client, namespaces, err := h.prepareCluster(&SimpleExecutor{})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		h.clientManager.Close(client)
+		clear(h.incrBackupHandlers)
+	}()
+
+	for _, namespace := range namespaces {
+		h.incrBackupHandlers[namespace] = h.startIncrementalNamespaceBackup(ctx, namespace, now, client)
+	}
+
+	err = h.waitForIncrementalBackups(ctx, now)
+	if err != nil {
+		return err
+	}
+
+	h.state.SetLastIncrRun(now)
+	return nil
+}
+
+func (h *BackupRoutineHandler) createIncremenralTimeBounds(now time.Time) *model.TimeBounds {
+	timebounds := model.NewTimeBoundsFrom(h.state.LastRun())
+	if h.backupFullPolicy.IsSealed() {
+		timebounds.ToTime = &now
+	}
+	return timebounds
+}
+
+func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
+	ctx context.Context, namespace string, now time.Time, client *backup.Client,
+) BackupHandler {
+	backupFolder := getIncrementalPathForNamespace(h.routineName, namespace, now)
+	timebounds := h.createIncremenralTimeBounds(now)
+
+	return startBackup(
+		ctx,
+		&SimpleExecutor{},
+		func(ctx context.Context) (BackupHandler, error) { // start backup.
+			return h.backupService.BackupRun(ctx,
+				h.backupRoutine, h.backupIncrPolicy, client, h.storage, h.secretAgent,
+				*timebounds, namespace, backupFolder)
+		},
+		func(ctx context.Context) { // on fail.
+			h.deleteFolder(ctx, backupFolder)
+		},
+		func(ctx context.Context, stats *models.BackupStats) error { // on success.
+			if stats.IsEmpty() {
+				// Backup finished successfully, but there were no records to back up.
+				// We need to delete empty backup folders.
+				h.deleteFolder(ctx, backupFolder)
+				return nil
+			}
+
+			return h.writeBackupMetadata(ctx, stats, now, namespace, backupFolder)
+		},
+	)
 }

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -236,9 +236,9 @@ func (h *BackupRoutineHandler) createTimebounds(fullBackup bool, now time.Time) 
 
 func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context) error {
 	var aggregatedErr error
-	for _, handler := range h.fullBackupHandlers {
+	for ns, handler := range h.fullBackupHandlers {
 		if err := handler.Wait(ctx); err != nil {
-			aggregatedErr = errors.Join(aggregatedErr, err)
+			aggregatedErr = errors.Join(aggregatedErr, fmt.Errorf("namespace %s: %w", ns, err))
 		}
 	}
 
@@ -373,10 +373,10 @@ func (h *BackupRoutineHandler) waitForIncrementalBackups(
 		aggregatedErr error
 		hasBackup     bool
 	)
-	for _, handler := range h.incrBackupHandlers {
+	for ns, handler := range h.incrBackupHandlers {
 		err := handler.Wait(ctx)
 		if err != nil {
-			aggregatedErr = errors.Join(aggregatedErr, err)
+			aggregatedErr = errors.Join(aggregatedErr, fmt.Errorf("namespace %s: %w", ns, err))
 			continue
 		}
 		if handler.GetStats() != nil && !handler.GetStats().IsEmpty() {

--- a/pkg/service/backup_routine_handler.go
+++ b/pkg/service/backup_routine_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v2/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v2/pkg/service/storage"
+	"github.com/aerospike/aerospike-backup-service/v2/pkg/util"
 	"github.com/aerospike/backup-go"
 	"github.com/aerospike/backup-go/models"
 )
@@ -124,11 +125,16 @@ func getNamespacesToBackup(namespaces []string, client backup.AerospikeClient) (
 }
 
 func (h *BackupRoutineHandler) runFullBackup(ctx context.Context, now time.Time) {
-	if err := h.runFullBackupInternal(ctx, now); err != nil {
+	duration, err := util.MeasureDuration(func() error {
+		return h.runFullBackupInternal(ctx, now)
+	})
+
+	if err != nil {
 		h.logger.Error("Failed running full backup", slog.Any("error", err))
 		backupFailureCounter.Inc()
 	} else {
 		h.logger.Debug("Finished full backup")
+		backupDurationGauge.Set(float64(duration.Milliseconds()))
 		backupCounter.Inc()
 	}
 }
@@ -229,17 +235,12 @@ func (h *BackupRoutineHandler) createTimebounds(fullBackup bool, now time.Time) 
 }
 
 func (h *BackupRoutineHandler) waitForFullBackups(ctx context.Context) error {
-	startTime := time.Now()
-
 	var aggregatedErr error
 	for _, handler := range h.fullBackupHandlers {
 		if err := handler.Wait(ctx); err != nil {
 			aggregatedErr = errors.Join(aggregatedErr, err)
 		}
 	}
-
-	durationMs := float64(time.Since(startTime).Milliseconds())
-	backupDurationGauge.Set(durationMs)
 
 	return aggregatedErr
 }
@@ -281,11 +282,15 @@ func (h *BackupRoutineHandler) runIncrementalBackup(ctx context.Context, now tim
 		return
 	}
 
-	if err := h.runIncrementalBackupInternal(ctx, now); err != nil {
+	duration, err := util.MeasureDuration(func() error {
+		return h.runIncrementalBackupInternal(ctx, now)
+	})
+	if err != nil {
 		incrBackupFailureCounter.Inc()
 		h.logger.Error("Failed running incremental backup", slog.Any("error", err))
 	} else {
 		incrBackupCounter.Inc()
+		incrBackupDurationGauge.Set(float64(duration.Milliseconds()))
 		h.logger.Debug("Finished incremental backup")
 	}
 }
@@ -364,7 +369,6 @@ func (h *BackupRoutineHandler) startIncrementalNamespaceBackup(
 func (h *BackupRoutineHandler) waitForIncrementalBackups(
 	ctx context.Context, backupTimestamp time.Time,
 ) error {
-	startTime := time.Now() // startTime is only used to measure backup time
 	var (
 		aggregatedErr error
 		hasBackup     bool
@@ -385,7 +389,6 @@ func (h *BackupRoutineHandler) waitForIncrementalBackups(
 		h.deleteFolder(ctx, getIncrementalTimestampPath(h.routineName, backupTimestamp))
 	}
 
-	incrBackupDurationGauge.Set(float64(time.Since(startTime).Milliseconds()))
 	return aggregatedErr
 }
 

--- a/pkg/service/backup_routine_handler_test.go
+++ b/pkg/service/backup_routine_handler_test.go
@@ -109,7 +109,7 @@ func setupTestHandler(
 		state:              &model.BackupState{},
 		storage:            &model.LocalStorage{Path: "/tmp"},
 		logger:             slog.Default(),
-		retry:              NewRetryService(0, 1, slog.Default()),
+		retry:              NewRetryExecutor(0, 1, slog.Default()),
 	}
 }
 

--- a/pkg/service/backup_routine_handler_test.go
+++ b/pkg/service/backup_routine_handler_test.go
@@ -109,7 +109,7 @@ func setupTestHandler(
 		state:              &model.BackupState{},
 		storage:            &model.LocalStorage{Path: "/tmp"},
 		logger:             slog.Default(),
-		retry:              NewRetryExecutor(0, 1, slog.Default()),
+		retry:              newRetryExecutor(0, 1, slog.Default()),
 	}
 }
 

--- a/pkg/service/estimates.go
+++ b/pkg/service/estimates.go
@@ -9,7 +9,10 @@ import (
 func currentBackupStatus(handlers map[string]BackupHandler) *model.RunningJob {
 	activeHandlers := 0
 
-	var total, done uint64
+	var (
+		total, done uint64
+		startTime   time.Time
+	)
 	for _, handler := range handlers {
 		if handler.GetStats() == nil {
 			continue
@@ -18,26 +21,17 @@ func currentBackupStatus(handlers map[string]BackupHandler) *model.RunningJob {
 		activeHandlers++
 		done += handler.GetStats().GetReadRecords()
 		total += handler.GetStats().TotalRecords
+		// These are the backups of multiple namespaces in the same routine.
+		// Therefore, picking any of those is valid, since they started at
+		// the same time.
+		startTime = handler.GetStats().StartTime
 	}
 
-	if activeHandlers == 0 {
+	if activeHandlers == 0 { // no running jobs
 		return nil
 	}
 
-	// These are the backups of multiple namespaces in the same routine.
-	// Therefore, picking any of those is valid, since they started at
-	// the same time.
-	startTime := getAnyHandler(handlers).GetStats().StartTime
-
 	return NewRunningJob(startTime, done, total)
-}
-
-func getAnyHandler(m map[string]BackupHandler) BackupHandler {
-	for _, value := range m {
-		return value
-	}
-
-	return nil
 }
 
 // RestoreJobStatus returns the status of a restore job.

--- a/pkg/service/metrics.go
+++ b/pkg/service/metrics.go
@@ -12,7 +12,7 @@ var (
 	backupCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "aerospike_backup_service_runs_total",
-			Help: "Backup runs counter.",
+			Help: "Successful backup runs counter",
 		})
 	// a counter metric for incremental backup run number
 	incrBackupCounter = prometheus.NewCounter(

--- a/pkg/service/metrics.go
+++ b/pkg/service/metrics.go
@@ -18,7 +18,7 @@ var (
 	incrBackupCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "aerospike_backup_service_incremental_runs_total",
-			Help: "Incremental backup runs counter.",
+			Help: "Successful incremental backup runs counter.",
 		})
 	// a counter metric for backup skip number
 	backupSkippedCounter = prometheus.NewCounter(

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -8,20 +8,30 @@ import (
 	"time"
 )
 
-// RetryService is a service for retrying a function with a specified interval
+type Executor interface {
+	run(label string, f func() error) error
+}
+
+type SimpleExecutor struct{}
+
+func (e *SimpleExecutor) run(_ string, f func() error) error {
+	return f()
+}
+
+// RetryExecutor is a service for retrying a function with a specified interval
 // and a maximum number of attempts.
-type RetryService struct {
+type RetryExecutor struct {
 	logger        *slog.Logger
 	retryInterval time.Duration
 	maxAttempts   int
 }
 
-// NewRetryService returns a new RetryService instance.
-//   - retryInterval is the interval between retry attempts
-//   - maxAttempts is the maximum number of retry attempts
-//   - logger is used for logging retry attempts and errors
-func NewRetryService(retryInterval time.Duration, maxAttempts int, logger *slog.Logger) *RetryService {
-	return &RetryService{
+// NewRetryExecutor returns a new RetryExecutor instance.
+//   - retryInterval is the interval between run attempts
+//   - maxAttempts is the maximum number of run attempts
+//   - logger is used for logging run attempts and errors
+func NewRetryExecutor(retryInterval time.Duration, maxAttempts int, logger *slog.Logger) Executor {
+	return &RetryExecutor{
 		logger:        logger,
 		retryInterval: retryInterval,
 		maxAttempts:   maxAttempts,
@@ -30,7 +40,7 @@ func NewRetryService(retryInterval time.Duration, maxAttempts int, logger *slog.
 
 // retry attempts to execute the given function up to maxAttempts with the specified retryInterval.
 // If all attempts fail, it returns an error.
-func (r *RetryService) retry(label string, f func() error) error {
+func (r *RetryExecutor) run(label string, f func() error) error {
 	var lastErr error
 	for attempt := 1; attempt <= r.maxAttempts; attempt++ {
 		lastErr = f()

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -27,9 +27,9 @@ type RetryExecutor struct {
 }
 
 // NewRetryExecutor returns a new RetryExecutor instance.
-//   - retryInterval is the interval between run attempts
-//   - maxAttempts is the maximum number of run attempts
-//   - logger is used for logging run attempts and errors
+//   - retryInterval is the interval between retry attempts
+//   - maxAttempts is the maximum number of retry attempts
+//   - logger is used for logging retry attempts and errors
 func NewRetryExecutor(retryInterval time.Duration, maxAttempts int, logger *slog.Logger) Executor {
 	return &RetryExecutor{
 		logger:        logger,

--- a/pkg/service/retry_service.go
+++ b/pkg/service/retry_service.go
@@ -8,30 +8,32 @@ import (
 	"time"
 )
 
-type Executor interface {
+// executor defines an interface for executing functions with retries.
+// label defines a job, it is only used in logs and error messages.
+type executor interface {
 	run(label string, f func() error) error
 }
 
-type SimpleExecutor struct{}
+type simpleExecutor struct{}
 
-func (e *SimpleExecutor) run(_ string, f func() error) error {
+func (e *simpleExecutor) run(_ string, f func() error) error {
 	return f()
 }
 
-// RetryExecutor is a service for retrying a function with a specified interval
+// retryExecutor is a service for retrying a function with a specified interval
 // and a maximum number of attempts.
-type RetryExecutor struct {
+type retryExecutor struct {
 	logger        *slog.Logger
 	retryInterval time.Duration
 	maxAttempts   int
 }
 
-// NewRetryExecutor returns a new RetryExecutor instance.
+// newRetryExecutor returns a new retryExecutor instance.
 //   - retryInterval is the interval between retry attempts
 //   - maxAttempts is the maximum number of retry attempts
 //   - logger is used for logging retry attempts and errors
-func NewRetryExecutor(retryInterval time.Duration, maxAttempts int, logger *slog.Logger) Executor {
-	return &RetryExecutor{
+func newRetryExecutor(retryInterval time.Duration, maxAttempts int, logger *slog.Logger) executor {
+	return &retryExecutor{
 		logger:        logger,
 		retryInterval: retryInterval,
 		maxAttempts:   maxAttempts,
@@ -40,7 +42,7 @@ func NewRetryExecutor(retryInterval time.Duration, maxAttempts int, logger *slog
 
 // retry attempts to execute the given function up to maxAttempts with the specified retryInterval.
 // If all attempts fail, it returns an error.
-func (r *RetryExecutor) run(label string, f func() error) error {
+func (r *retryExecutor) run(label string, f func() error) error {
 	var lastErr error
 	for attempt := 1; attempt <= r.maxAttempts; attempt++ {
 		lastErr = f()

--- a/pkg/service/retry_service_test.go
+++ b/pkg/service/retry_service_test.go
@@ -12,12 +12,12 @@ import (
 
 const timeout = 100 * time.Millisecond
 
-var r = NewRetryService(timeout, 3, slog.Default())
+var r = NewRetryExecutor(timeout, 3, slog.Default())
 
 func Test_timer(t *testing.T) {
 	counterLock := sync.Mutex{}
 	retryCounter := 2
-	err := r.retry("test", func() error {
+	err := r.run("test", func() error {
 		counterLock.Lock()
 		defer counterLock.Unlock()
 		if retryCounter > 0 {
@@ -40,7 +40,7 @@ func Test_timer_expires(t *testing.T) {
 	counterLock := sync.Mutex{}
 	retryCounter := 0
 	const attempts = 3
-	_ = r.retry("test", func() error {
+	_ = r.run("test", func() error {
 		counterLock.Lock()
 		defer counterLock.Unlock()
 		retryCounter++
@@ -67,8 +67,8 @@ func Test_timerRunTwice(t *testing.T) {
 		}
 		return nil
 	}
-	_ = r.retry("test", f)
-	_ = r.retry("test", f)
+	_ = r.run("test", f)
+	_ = r.run("test", f)
 
 	time.Sleep(1 * time.Second)
 	counterLock.Lock()

--- a/pkg/service/retry_service_test.go
+++ b/pkg/service/retry_service_test.go
@@ -12,7 +12,7 @@ import (
 
 const timeout = 100 * time.Millisecond
 
-var r = NewRetryExecutor(timeout, 3, slog.Default())
+var r = newRetryExecutor(timeout, 3, slog.Default())
 
 func Test_timer(t *testing.T) {
 	counterLock := sync.Mutex{}

--- a/pkg/service/retryable_backup_handler.go
+++ b/pkg/service/retryable_backup_handler.go
@@ -16,9 +16,9 @@ type retryableBackupHandler struct {
 
 var _ BackupHandler = (*retryableBackupHandler)(nil)
 
-func startRetryableBackup(
+func startBackup(
 	ctx context.Context,
-	retry *RetryService,
+	retry Executor,
 	start func(ctx context.Context) (BackupHandler, error),
 	onFail func(ctx context.Context),
 	onSuccess func(ctx context.Context, stats *models.BackupStats) error,
@@ -27,9 +27,9 @@ func startRetryableBackup(
 		errCh: make(chan error, 1),
 	}
 
-	// Helper to retry onSuccess only
+	// Helper to run onSuccess only
 	retryOnSuccess := func(handler BackupHandler) error {
-		err := retry.retry("write metadata", func() error {
+		err := retry.run("write metadata", func() error {
 			return onSuccess(ctx, handler.GetStats())
 		})
 		if err != nil {
@@ -60,7 +60,7 @@ func startRetryableBackup(
 
 	// Start the backup process with retries
 	go func() {
-		h.errCh <- retry.retry("backup", processBackup)
+		h.errCh <- retry.run("backup", processBackup)
 	}()
 
 	return h

--- a/pkg/service/retryable_backup_handler.go
+++ b/pkg/service/retryable_backup_handler.go
@@ -18,7 +18,7 @@ var _ BackupHandler = (*retryableBackupHandler)(nil)
 
 func startBackup(
 	ctx context.Context,
-	retry Executor,
+	retry executor,
 	start func(ctx context.Context) (BackupHandler, error),
 	onFail func(ctx context.Context),
 	onSuccess func(ctx context.Context, stats *models.BackupStats) error,

--- a/pkg/service/retryable_backup_handler.go
+++ b/pkg/service/retryable_backup_handler.go
@@ -27,7 +27,7 @@ func startBackup(
 		errCh: make(chan error, 1),
 	}
 
-	// Helper to run onSuccess only
+	// Helper to retry onSuccess only
 	retryOnSuccess := func(handler BackupHandler) error {
 		err := retry.run("write metadata", func() error {
 			return onSuccess(ctx, handler.GetStats())

--- a/pkg/service/retryable_backup_handler_test.go
+++ b/pkg/service/retryable_backup_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var retry = NewRetryExecutor(time.Millisecond, 3, slog.Default())
+var retry = newRetryExecutor(time.Millisecond, 3, slog.Default())
 
 func TestStartRetryableBackup_SuccessfulFirstAttempt(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/service/retryable_backup_handler_test.go
+++ b/pkg/service/retryable_backup_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var retry = NewRetryService(time.Millisecond, 3, slog.Default())
+var retry = NewRetryExecutor(time.Millisecond, 3, slog.Default())
 
 func TestStartRetryableBackup_SuccessfulFirstAttempt(t *testing.T) {
 	ctx := context.Background()
@@ -38,7 +38,7 @@ func TestStartRetryableBackup_SuccessfulFirstAttempt(t *testing.T) {
 		return nil
 	}
 
-	handler := startRetryableBackup(ctx, retry, start, onFail, onSuccess)
+	handler := startBackup(ctx, retry, start, onFail, onSuccess)
 	err := handler.Wait(ctx)
 
 	assert.NoError(t, err)
@@ -78,7 +78,7 @@ func TestStartRetryableBackup_WaitFailsThenSucceeds(t *testing.T) {
 		return nil
 	}
 
-	handler := startRetryableBackup(ctx, retry, start, onFail, onSuccess)
+	handler := startBackup(ctx, retry, start, onFail, onSuccess)
 	err := handler.Wait(ctx)
 
 	assert.NoError(t, err)
@@ -117,7 +117,7 @@ func TestStartRetryableBackup_ContextCancellation(t *testing.T) {
 		return nil
 	}
 
-	handler := startRetryableBackup(ctx, retry, start, onFail, onSuccess)
+	handler := startBackup(ctx, retry, start, onFail, onSuccess)
 
 	<-waitCalled
 
@@ -155,7 +155,7 @@ func TestStartRetryableBackup_AllWaitAttemptsFail(t *testing.T) {
 		return nil
 	}
 
-	handler := startRetryableBackup(ctx, retry, start, onFail, onSuccess)
+	handler := startBackup(ctx, retry, start, onFail, onSuccess)
 	err := handler.Wait(ctx)
 
 	assert.Error(t, err)
@@ -183,7 +183,7 @@ func TestStartRetryableBackup_StartFails(t *testing.T) {
 		return nil
 	}
 
-	handler := startRetryableBackup(ctx, retry, start, onFail, onSuccess)
+	handler := startBackup(ctx, retry, start, onFail, onSuccess)
 	err := handler.Wait(ctx)
 
 	assert.Error(t, err)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 )
 
 // Ptr returns a pointer to the given object.
@@ -67,4 +68,10 @@ func MissingElements(subset, superset []string) []string {
 	}
 
 	return missing
+}
+
+func MeasureDuration(f func() error) (time.Duration, error) {
+	startTime := time.Now()
+	err := f()
+	return time.Since(startTime), err
 }


### PR DESCRIPTION
The actual error was a permission to AS cluster

time=2024-11-13T13:24:00.236Z level=INFO source=:0 msg="ERROR error reading record backup.client.id=asd.aerospike.com backup.handler.id=2cbaae67-c10b-47ba-8d31-fa6ca1b133dc backup.handler.type=backup backup.handler.storage=s3 backup.reader.id=e52efeb8-cb20-4220-911c-af2ba5ed2550 backup.reader.type=record backup.error=\"ResultCode: **FAIL_FORBIDDEN**, Iteration: 0, InDoubt: false, Node: BC40300000A0142 10.0.0.3:4333: Operation not allowed at this time\\n  ResultCode: FAIL_FORBIDDEN, Iteration: 0, InDoubt: false, Node: <nil>: Operation not allowed at this time\""

So, backup failed to start and returned error. But unfortunately, there was no _continue_ in error handling, so failed (nil) handler was added to the map and caused crash. Thats an old bug, we didn't got it before because we had no connection issues, in our negative tests we only tested no connection to databased, but not access denied.