### PR TITLE
APPS-1345 Round time to millis

### DIFF
--- a/internal/server/handlers/backup.go
+++ b/internal/server/handlers/backup.go
@@ -192,7 +192,7 @@ func (s *Service) readBackupsForRoutine(w http.ResponseWriter, r *http.Request, 
 
 func readBackupsLogic(ctx context.Context,
 	backends service.BackendsHolder,
-	timeBounds *model.TimeBounds,
+	timeBounds model.TimeBounds,
 	isFullBackup bool,
 ) (map[string][]model.BackupDetails, error) {
 	result := make(map[string][]model.BackupDetails)
@@ -210,7 +210,7 @@ func readBackupsLogic(ctx context.Context,
 
 func backupsReadFunction(
 	backend service.BackupListReader, fullBackup bool,
-) func(context.Context, *model.TimeBounds) ([]model.BackupDetails, error) {
+) func(context.Context, model.TimeBounds) ([]model.BackupDetails, error) {
 	if fullBackup {
 		return backend.FullBackupList
 	}

--- a/internal/server/handlers/handlers_test.go
+++ b/internal/server/handlers/handlers_test.go
@@ -123,16 +123,16 @@ func (mock restoreManagerMock) RetrieveConfiguration(routine string, _ time.Time
 
 type backupListReaderMock struct{}
 
-func (mock backupListReaderMock) FullBackupList(_ context.Context, timebounds *model.TimeBounds,
+func (mock backupListReaderMock) FullBackupList(_ context.Context, timebounds model.TimeBounds,
 ) ([]model.BackupDetails, error) {
-	if timebounds == nil {
+	if timebounds == (model.TimeBounds{}) {
 		return nil, errTest
 	}
 	return []model.BackupDetails{testBackupDetails()}, nil
 }
-func (mock backupListReaderMock) IncrementalBackupList(_ context.Context, timebounds *model.TimeBounds,
+func (mock backupListReaderMock) IncrementalBackupList(_ context.Context, timebounds model.TimeBounds,
 ) ([]model.BackupDetails, error) {
-	if timebounds == nil {
+	if timebounds == (model.TimeBounds{}) {
 		return nil, errTest
 	}
 	return []model.BackupDetails{testBackupDetails()}, nil
@@ -150,9 +150,9 @@ func (mock backupListReaderMock) FindLastFullBackup(_ time.Time) ([]model.Backup
 }
 
 func (mock backupListReaderMock) FindIncrementalBackupsForNamespace(
-	_ context.Context, bounds *model.TimeBounds, _ string,
+	_ context.Context, bounds model.TimeBounds, _ string,
 ) ([]model.BackupDetails, error) {
-	if bounds == nil {
+	if bounds == (model.TimeBounds{}) {
 		return nil, errTest
 	}
 	return []model.BackupDetails{testBackupDetails()}, nil

--- a/pkg/dto/time_bounds.go
+++ b/pkg/dto/time_bounds.go
@@ -16,43 +16,31 @@ type TimeBounds struct {
 }
 
 // NewTimeBounds creates a new TimeBounds using provided fromTime and toTime values.
-func NewTimeBounds(fromTime, toTime *time.Time) (*TimeBounds, error) {
+func NewTimeBounds(fromTime, toTime *time.Time) (TimeBounds, error) {
 	if fromTime != nil && toTime != nil && fromTime.After(*toTime) {
-		return nil, errors.New("fromTime should be less than toTime")
+		return TimeBounds{}, errors.New("fromTime should be less than toTime")
 	}
-	return &TimeBounds{FromTime: fromTime, ToTime: toTime}, nil
+	return TimeBounds{FromTime: fromTime, ToTime: toTime}, nil
 }
 
-func (t *TimeBounds) ToModel() *model.TimeBounds {
-	return &model.TimeBounds{
+func (t *TimeBounds) ToModel() model.TimeBounds {
+	return model.TimeBounds{
 		FromTime: t.FromTime,
 		ToTime:   t.ToTime,
 	}
 }
 
-// NewTimeBoundsTo creates a new TimeBounds until the provided toTime.
-func NewTimeBoundsTo(toTime time.Time) *TimeBounds {
-	timeBounds, _ := NewTimeBounds(nil, &toTime) // validation only make sense with two parameters.
-	return timeBounds
-}
-
-// NewTimeBoundsFrom creates a new TimeBounds from the provided fromTime.
-func NewTimeBoundsFrom(fromTime time.Time) *TimeBounds {
-	timeBounds, _ := NewTimeBounds(&fromTime, nil) // validation only makes sense with two parameters.
-	return timeBounds
-}
-
 // NewTimeBoundsFromString creates a TimeBounds from the string representation of
 // time boundaries (string is given as epoch time millis).
-func NewTimeBoundsFromString(from, to string) (*TimeBounds, error) {
+func NewTimeBoundsFromString(from, to string) (TimeBounds, error) {
 	fromTime, err := parseTimestamp(from)
 	if err != nil {
-		return nil, err
+		return TimeBounds{}, err
 	}
 
 	toTime, err := parseTimestamp(to)
 	if err != nil {
-		return nil, err
+		return TimeBounds{}, err
 	}
 
 	return NewTimeBounds(fromTime, toTime)

--- a/pkg/model/time_bounds.go
+++ b/pkg/model/time_bounds.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 )
 
@@ -14,57 +13,21 @@ type TimeBounds struct {
 }
 
 // NewTimeBounds creates a new TimeBounds using provided fromTime and toTime values.
-func NewTimeBounds(fromTime, toTime *time.Time) (*TimeBounds, error) {
+func NewTimeBounds(fromTime, toTime *time.Time) (TimeBounds, error) {
 	if fromTime != nil && toTime != nil && fromTime.After(*toTime) {
-		return nil, errors.New("fromTime should be less than toTime")
+		return TimeBounds{}, errors.New("fromTime should be less than toTime")
 	}
-	return &TimeBounds{FromTime: fromTime, ToTime: toTime}, nil
+	return TimeBounds{FromTime: fromTime, ToTime: toTime}, nil
 }
 
 // NewTimeBoundsTo creates a new TimeBounds until the provided toTime.
-func NewTimeBoundsTo(toTime time.Time) *TimeBounds {
-	timeBounds, _ := NewTimeBounds(nil, &toTime) // validation only make sense with two parameters.
-	return timeBounds
+func NewTimeBoundsTo(toTime time.Time) TimeBounds {
+	return TimeBounds{ToTime: &toTime}
 }
 
 // NewTimeBoundsFrom creates a new TimeBounds from the provided fromTime.
-func NewTimeBoundsFrom(fromTime time.Time) *TimeBounds {
-	timeBounds, _ := NewTimeBounds(&fromTime, nil) // validation only makes sense with two parameters.
-	return timeBounds
-}
-
-// NewTimeBoundsFromString creates a TimeBounds from the string representation of
-// time boundaries (string is given as epoch time millis).
-func NewTimeBoundsFromString(from, to string) (*TimeBounds, error) {
-	fromTime, err := parseTimestamp(from)
-	if err != nil {
-		return nil, err
-	}
-
-	toTime, err := parseTimestamp(to)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewTimeBounds(fromTime, toTime)
-}
-
-func parseTimestamp(value string) (*time.Time, error) {
-	if len(value) == 0 {
-		return nil, nil
-	}
-
-	intValue, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return nil, err
-	}
-
-	if intValue < 0 {
-		return nil, fmt.Errorf("timestamp should be positive or zero, got %d", intValue)
-	}
-
-	result := time.UnixMilli(intValue)
-	return &result, nil
+func NewTimeBoundsFrom(fromTime time.Time) TimeBounds {
+	return TimeBounds{FromTime: &fromTime}
 }
 
 // Contains verifies if the given value lies within FromTime (inclusive) and ToTime (exclusive).

--- a/pkg/service/backup_backend.go
+++ b/pkg/service/backup_backend.go
@@ -38,9 +38,8 @@ func newBackend(routineName string, routine *model.BackupRoutine) *BackupBackend
 }
 
 func (b *BackupBackend) ReadState() *model.BackupState {
-	to := model.NewTimeBoundsTo(time.Now())
-	fullBackupList, _ := b.FullBackupList(context.Background(), to)
-	incrementalBackupList, _ := b.IncrementalBackupList(context.Background(), to)
+	fullBackupList, _ := b.FullBackupList(context.Background(), model.TimeBounds{})
+	incrementalBackupList, _ := b.IncrementalBackupList(context.Background(), model.TimeBounds{})
 
 	return &model.BackupState{
 		LastFullRun: lastBackupTime(fullBackupList),
@@ -50,7 +49,7 @@ func (b *BackupBackend) ReadState() *model.BackupState {
 
 func lastBackupTime(b []model.BackupDetails) time.Time {
 	if len(b) > 0 {
-		return latestBackupBeforeTime(b, time.Now())[0].Created
+		return latestBackupBeforeTime(b, nil)[0].Created
 	}
 
 	return time.Time{}
@@ -67,18 +66,18 @@ func (b *BackupBackend) WriteBackupMetadata(ctx context.Context, path string, me
 }
 
 // FullBackupList returns a list of available full backups.
-func (b *BackupBackend) FullBackupList(ctx context.Context, timeBounds *model.TimeBounds,
+func (b *BackupBackend) FullBackupList(ctx context.Context, timeBounds model.TimeBounds,
 ) ([]model.BackupDetails, error) {
 	return b.readMetadataList(ctx, timeBounds, true)
 }
 
 // IncrementalBackupList returns a list of available incremental backups.
-func (b *BackupBackend) IncrementalBackupList(ctx context.Context, timeBounds *model.TimeBounds,
+func (b *BackupBackend) IncrementalBackupList(ctx context.Context, timeBounds model.TimeBounds,
 ) ([]model.BackupDetails, error) {
 	return b.readMetadataList(ctx, timeBounds, false)
 }
 
-func (b *BackupBackend) readMetadataList(ctx context.Context, timebounds *model.TimeBounds, isFullBackup bool,
+func (b *BackupBackend) readMetadataList(ctx context.Context, timebounds model.TimeBounds, isFullBackup bool,
 ) ([]model.BackupDetails, error) {
 	backupRoot := getBackupRootPath(b.routineName, isFullBackup)
 	files, err := storage.ReadFiles(ctx, b.storage, backupRoot, metadataFile, timebounds.FromTime)
@@ -114,7 +113,7 @@ func (b *BackupBackend) FindLastFullBackup(toTime time.Time) ([]model.BackupDeta
 		return nil, fmt.Errorf("cannot read full backup list: %w", err)
 	}
 
-	fullBackup := latestBackupBeforeTime(fullBackupList, toTime) // it's a list of namespaces
+	fullBackup := latestBackupBeforeTime(fullBackupList, &toTime) // it's a list of namespaces
 	if len(fullBackup) == 0 {
 		return nil, fmt.Errorf("%w: %s", errBackupNotFound, toTime)
 	}
@@ -123,13 +122,13 @@ func (b *BackupBackend) FindLastFullBackup(toTime time.Time) ([]model.BackupDeta
 
 // latestBackupBeforeTime returns list of backups with same creation time,
 // latest before upperBound.
-func latestBackupBeforeTime(allBackups []model.BackupDetails, upperBound time.Time,
+func latestBackupBeforeTime(allBackups []model.BackupDetails, upperBound *time.Time,
 ) []model.BackupDetails {
 	var result []model.BackupDetails
 	var latestTime time.Time
 	for i := range allBackups {
 		current := &allBackups[i]
-		if current.Created.After(upperBound) {
+		if upperBound != nil && current.Created.After(*upperBound) {
 			continue
 		}
 
@@ -145,7 +144,7 @@ func latestBackupBeforeTime(allBackups []model.BackupDetails, upperBound time.Ti
 
 // FindIncrementalBackupsForNamespace returns all incremental backups in given range, sorted by time.
 func (b *BackupBackend) FindIncrementalBackupsForNamespace(
-	ctx context.Context, bounds *model.TimeBounds, namespace string,
+	ctx context.Context, bounds model.TimeBounds, namespace string,
 ) ([]model.BackupDetails, error) {
 	allIncrementalBackupList, err := b.IncrementalBackupList(ctx, bounds)
 	if err != nil {

--- a/pkg/service/backup_job.go
+++ b/pkg/service/backup_job.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"sync/atomic"
-	"time"
 
+	"github.com/aerospike/aerospike-backup-service/v2/pkg/util"
 	"github.com/reugn/go-quartz/quartz"
 )
 
@@ -28,9 +28,9 @@ func (j *backupJob) Execute(ctx context.Context) error {
 		defer j.isRunning.Store(false)
 		switch j.jobType {
 		case jobTypeFull:
-			j.handler.runFullBackup(ctx, time.Now())
+			j.handler.runFullBackup(ctx, util.NowWithZeroNanoseconds())
 		case jobTypeIncremental:
-			j.handler.runIncrementalBackup(ctx, time.Now())
+			j.handler.runIncrementalBackup(ctx, util.NowWithZeroNanoseconds())
 		default:
 			logger.Error("Unsupported backup type")
 		}

--- a/pkg/service/backup_list_reader.go
+++ b/pkg/service/backup_list_reader.go
@@ -12,12 +12,12 @@ type BackupListReader interface {
 	// FullBackupList returns a list of available full backups.
 	// The parameters are timestamp filters by creation time (epoch millis),
 	// where from is inclusive and to is exclusive.
-	FullBackupList(ctx context.Context, timebounds *model.TimeBounds) ([]model.BackupDetails, error)
+	FullBackupList(ctx context.Context, timebounds model.TimeBounds) ([]model.BackupDetails, error)
 
 	// IncrementalBackupList returns a list of available incremental backups.
 	// The parameters are timestamp filters by creation time (epoch millis),
 	// where from is inclusive and to is exclusive.
-	IncrementalBackupList(ctx context.Context, timebounds *model.TimeBounds) ([]model.BackupDetails, error)
+	IncrementalBackupList(ctx context.Context, timebounds model.TimeBounds) ([]model.BackupDetails, error)
 
 	// ReadClusterConfiguration return backed up cluster configuration as a compressed zip.
 	ReadClusterConfiguration(path string) ([]byte, error)
@@ -27,6 +27,6 @@ type BackupListReader interface {
 	FindLastFullBackup(toTime time.Time) ([]model.BackupDetails, error)
 
 	// FindIncrementalBackupsForNamespace returns all incremental backups in given range, sorted by time.
-	FindIncrementalBackupsForNamespace(ctx context.Context, bounds *model.TimeBounds, namespace string,
+	FindIncrementalBackupsForNamespace(ctx context.Context, bounds model.TimeBounds, namespace string,
 	) ([]model.BackupDetails, error)
 }

--- a/pkg/service/restore_data_test.go
+++ b/pkg/service/restore_data_test.go
@@ -79,7 +79,7 @@ func makeTestRestoreService() *dataRestorer {
 type BackendMock struct {
 }
 
-func (m *BackendMock) FindIncrementalBackupsForNamespace(_ context.Context, _ *model.TimeBounds, _ string,
+func (m *BackendMock) FindIncrementalBackupsForNamespace(_ context.Context, _ model.TimeBounds, _ string,
 ) ([]model.BackupDetails, error) {
 	return []model.BackupDetails{{
 		BackupMetadata: model.BackupMetadata{
@@ -100,7 +100,7 @@ func (m *BackendMock) ReadClusterConfiguration(_ string) ([]byte, error) {
 	return []byte{}, nil
 }
 
-func (*BackendMock) FullBackupList(_ context.Context, _ *model.TimeBounds) ([]model.BackupDetails, error) {
+func (*BackendMock) FullBackupList(_ context.Context, _ model.TimeBounds) ([]model.BackupDetails, error) {
 	return []model.BackupDetails{{
 		BackupMetadata: model.BackupMetadata{
 			Created:   time.UnixMilli(5),
@@ -110,7 +110,7 @@ func (*BackendMock) FullBackupList(_ context.Context, _ *model.TimeBounds) ([]mo
 	}}, nil
 }
 
-func (*BackendMock) IncrementalBackupList(_ context.Context, _ *model.TimeBounds) ([]model.BackupDetails, error) {
+func (*BackendMock) IncrementalBackupList(_ context.Context, _ model.TimeBounds) ([]model.BackupDetails, error) {
 	return []model.BackupDetails{{
 		BackupMetadata: model.BackupMetadata{
 			Created:   time.UnixMilli(10),
@@ -149,7 +149,7 @@ func (*BackendFailMock) FindLastFullBackup(_ time.Time) ([]model.BackupDetails, 
 type BackendFailMock struct {
 }
 
-func (m *BackendFailMock) FindIncrementalBackupsForNamespace(_ context.Context, _ *model.TimeBounds, _ string,
+func (m *BackendFailMock) FindIncrementalBackupsForNamespace(_ context.Context, _ model.TimeBounds, _ string,
 ) ([]model.BackupDetails, error) {
 	return nil, nil
 }
@@ -158,11 +158,11 @@ func (m *BackendFailMock) ReadClusterConfiguration(_ string) ([]byte, error) {
 	return nil, errors.New("mock error")
 }
 
-func (*BackendFailMock) FullBackupList(_ context.Context, _ *model.TimeBounds) ([]model.BackupDetails, error) {
+func (*BackendFailMock) FullBackupList(_ context.Context, _ model.TimeBounds) ([]model.BackupDetails, error) {
 	return nil, errors.New("mock error")
 }
 
-func (*BackendFailMock) IncrementalBackupList(_ context.Context, _ *model.TimeBounds) ([]model.BackupDetails, error) {
+func (*BackendFailMock) IncrementalBackupList(_ context.Context, _ model.TimeBounds) ([]model.BackupDetails, error) {
 	return nil, errors.New("mock error")
 }
 
@@ -203,13 +203,35 @@ func TestLatestFullBackupBeforeTime(t *testing.T) {
 		{BackupMetadata: model.BackupMetadata{Created: time.UnixMilli(30)}},
 	}
 
-	result := latestBackupBeforeTime(backupList, time.UnixMilli(25))
+	toTime := time.UnixMilli(25)
+	result := latestBackupBeforeTime(backupList, &toTime)
 
 	if result == nil {
 		t.Error("Expected a non-nil result, but got nil")
 	}
 	if len(result) != 2 {
 		t.Errorf("Expected 2 backups")
+	}
+	if result[0] != backupList[1] {
+		t.Errorf("Expected the latest backup, but got %+v", result)
+	}
+}
+
+func TestLatestFullBackupEqualTime(t *testing.T) {
+	backupList := []model.BackupDetails{
+		{BackupMetadata: model.BackupMetadata{Created: time.UnixMilli(10)}},
+		{BackupMetadata: model.BackupMetadata{Created: time.UnixMilli(20)}}, // Should be the latest full backup
+		{BackupMetadata: model.BackupMetadata{Created: time.UnixMilli(30)}},
+	}
+
+	toTime := time.UnixMilli(20)
+	result := latestBackupBeforeTime(backupList, &toTime)
+
+	if result == nil {
+		t.Error("Expected a non-nil result, but got nil")
+	}
+	if len(result) != 1 {
+		t.Errorf("Expected 1 backup")
 	}
 	if result[0] != backupList[1] {
 		t.Errorf("Expected the latest backup, but got %+v", result)
@@ -223,7 +245,8 @@ func TestLatestFullBackupBeforeTime_NotFound(t *testing.T) {
 		{BackupMetadata: model.BackupMetadata{Created: time.UnixMilli(30)}},
 	}
 
-	result := latestBackupBeforeTime(backupList, time.UnixMilli(5))
+	toTime := time.UnixMilli(5)
+	result := latestBackupBeforeTime(backupList, &toTime)
 
 	if result != nil {
 		t.Errorf("Expected a non result, but got %+v", result)

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -75,3 +75,8 @@ func MeasureDuration(f func() error) (time.Duration, error) {
 	err := f()
 	return time.Since(startTime), err
 }
+
+func NowWithZeroNanoseconds() time.Time {
+	now := time.Now()
+	return now.Truncate(time.Millisecond)
+}


### PR DESCRIPTION
Whenever we run the backup we use timestamp with 0 nanoseconds.
I also reviewed time bounds logic: always pass it by value, not by pointer, to avoid potential NPE