### PR TITLE
APPS-1932 Add support for rack-aware backup

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -82,7 +82,7 @@
             "nullable": true
           },
           "prefer-racks": {
-            "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+            "description": "The list of acceptable racks in order of preference.",
             "type": "array",
             "items": {
               "type": "integer"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -82,7 +82,7 @@
             "nullable": true
           },
           "prefer-racks": {
-            "description": "The list of acceptable racks in order of preference.",
+            "description": "The list of acceptable racks in order of preference.\nNodes in prefer-racks[0] are chosen first.\nIf a node is not found in prefer-racks[0], then nodes in prefer-racks[1] are searched, and so on.",
             "type": "array",
             "items": {
               "type": "integer"
@@ -485,8 +485,8 @@
             "type": "string",
             "nullable": true
           },
-          "racks": {
-            "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
+          "rack-list": {
+            "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
             "type": "array",
             "items": {
               "type": "integer"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -486,7 +486,7 @@
             "nullable": true
           },
           "rack-list": {
-            "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
+            "description": "RackList specifies the Aerospike Server rack IDs from which to read records\nduring backup.\nIf provided, only nodes belonging to these specified racks will be scanned.\nIf the list is empty or omitted, no rack filtering is applied.",
             "type": "array",
             "items": {
               "type": "integer"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -81,6 +81,14 @@
             "example": 100,
             "nullable": true
           },
+          "prefer-racks": {
+            "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "nullable": true
+          },
           "seed-nodes": {
             "description": "The seed nodes details.",
             "type": "array",
@@ -477,15 +485,12 @@
             "type": "string",
             "nullable": true
           },
-          "prefer-racks": {
-            "description": "The list of Aerospike Server rack IDs to prioritize when reading records during backup.\nThis is optional and can be used to optimize for rack-aware deployments.",
+          "racks": {
+            "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
             "type": "array",
             "items": {
               "type": "integer"
             },
-            "example": [
-              0
-            ],
             "nullable": true
           },
           "secret-agent": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1687,6 +1687,14 @@ const docTemplate = `{
                     "x-nullable": true,
                     "example": 100
                 },
+                "prefer-racks": {
+                    "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    },
+                    "x-nullable": true
+                },
                 "seed-nodes": {
                     "description": "The seed nodes details.",
                     "type": "array",
@@ -2083,16 +2091,13 @@ const docTemplate = `{
                     "type": "string",
                     "x-nullable": true
                 },
-                "prefer-racks": {
-                    "description": "The list of Aerospike Server rack IDs to prioritize when reading records during backup.\nThis is optional and can be used to optimize for rack-aware deployments.",
+                "racks": {
+                    "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
                     "type": "array",
                     "items": {
                         "type": "integer"
                     },
-                    "x-nullable": true,
-                    "example": [
-                        0
-                    ]
+                    "x-nullable": true
                 },
                 "secret-agent": {
                     "description": "The name of a Secret Agent to read secrets from (optional).",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1688,7 +1688,7 @@ const docTemplate = `{
                     "example": 100
                 },
                 "prefer-racks": {
-                    "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+                    "description": "The list of acceptable racks in order of preference.",
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1688,7 +1688,7 @@ const docTemplate = `{
                     "example": 100
                 },
                 "prefer-racks": {
-                    "description": "The list of acceptable racks in order of preference.",
+                    "description": "The list of acceptable racks in order of preference.\nNodes in prefer-racks[0] are chosen first.\nIf a node is not found in prefer-racks[0], then nodes in prefer-racks[1] are searched, and so on.",
                     "type": "array",
                     "items": {
                         "type": "integer"
@@ -2091,8 +2091,8 @@ const docTemplate = `{
                     "type": "string",
                     "x-nullable": true
                 },
-                "racks": {
-                    "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
+                "rack-list": {
+                    "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2092,7 +2092,7 @@ const docTemplate = `{
                     "x-nullable": true
                 },
                 "rack-list": {
-                    "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
+                    "description": "RackList specifies the Aerospike Server rack IDs from which to read records\nduring backup.\nIf provided, only nodes belonging to these specified racks will be scanned.\nIf the list is empty or omitted, no rack filtering is applied.",
                     "type": "array",
                     "items": {
                         "type": "integer"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2020,7 +2020,7 @@
                         "nullable": true
                     },
                     "prefer-racks": {
-                        "description": "The list of acceptable racks in order of preference.",
+                        "description": "The list of acceptable racks in order of preference.\nNodes in prefer-racks[0] are chosen first.\nIf a node is not found in prefer-racks[0], then nodes in prefer-racks[1] are searched, and so on.",
                         "type": "array",
                         "items": {
                             "type": "integer"
@@ -2423,8 +2423,8 @@
                         "type": "string",
                         "nullable": true
                     },
-                    "racks": {
-                        "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
+                    "rack-list": {
+                        "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
                         "type": "array",
                         "items": {
                             "type": "integer"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2020,7 +2020,7 @@
                         "nullable": true
                     },
                     "prefer-racks": {
-                        "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+                        "description": "The list of acceptable racks in order of preference.",
                         "type": "array",
                         "items": {
                             "type": "integer"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2019,6 +2019,14 @@
                         "example": 100,
                         "nullable": true
                     },
+                    "prefer-racks": {
+                        "description": "PreferRacks defines the list of acceptable racks in order of preference.",
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "nullable": true
+                    },
                     "seed-nodes": {
                         "description": "The seed nodes details.",
                         "type": "array",
@@ -2415,15 +2423,12 @@
                         "type": "string",
                         "nullable": true
                     },
-                    "prefer-racks": {
-                        "description": "The list of Aerospike Server rack IDs to prioritize when reading records during backup.\nThis is optional and can be used to optimize for rack-aware deployments.",
+                    "racks": {
+                        "description": "The list of Aerospike Server rack IDs to use when reading records during backup.",
                         "type": "array",
                         "items": {
                             "type": "integer"
                         },
-                        "example": [
-                            0
-                        ],
                         "nullable": true
                     },
                     "secret-agent": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2424,7 +2424,7 @@
                         "nullable": true
                     },
                     "rack-list": {
-                        "description": "The list of Aerospike Server rack IDs to use when reading records during backup.\nOnly nodes from selected racks will be scanned.",
+                        "description": "RackList specifies the Aerospike Server rack IDs from which to read records\nduring backup.\nIf provided, only nodes belonging to these specified racks will be scanned.\nIf the list is empty or omitted, no rack filtering is applied.",
                         "type": "array",
                         "items": {
                             "type": "integer"

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -31,6 +31,8 @@ type AerospikeCluster struct {
 	// This property helps reduce the load on the cluster and is shared among all backups using the cluster.
 	// Default: unlimited.
 	MaxParallelScans *int `yaml:"max-parallel-scans,omitempty" json:"max-parallel-scans,omitempty" example:"100" extensions:"x-nullable"`
+	// PreferRacks defines the list of acceptable racks in order of preference.
+	PreferRacks []int `yaml:"prefer-racks,omitempty" json:"prefer-racks,omitempty" extensions:"x-nullable"`
 }
 
 // Validate validates the Aerospike cluster entity.
@@ -58,6 +60,15 @@ func (a *AerospikeCluster) Validate() error {
 
 	if err := a.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls validation error: %w", err)
+	}
+
+	for i, rack := range a.PreferRacks {
+		if rack < 0 {
+			return errValidationNegative(fmt.Sprintf("prefer-racks[%d]", i), rack)
+		}
+		if rack > maxRack {
+			return fmt.Errorf("rack id %d invalid, should not exceed %d", rack, maxRack)
+		}
 	}
 
 	return nil
@@ -128,6 +139,7 @@ func (a *AerospikeCluster) fromModel(m *model.AerospikeCluster, config *model.Ba
 		a.TLS.fromModel(m.TLS)
 	}
 	a.MaxParallelScans = m.MaxParallelScans
+	a.PreferRacks = m.PreferRacks
 }
 
 func (a *AerospikeCluster) ToModel(config *model.Config) (*model.AerospikeCluster, error) {
@@ -144,6 +156,7 @@ func (a *AerospikeCluster) ToModel(config *model.Config) (*model.AerospikeCluste
 		Credentials:          credentials,
 		TLS:                  a.TLS.toModel(),
 		MaxParallelScans:     a.MaxParallelScans,
+		PreferRacks:          a.PreferRacks,
 	}, nil
 }
 

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -32,6 +32,8 @@ type AerospikeCluster struct {
 	// Default: unlimited.
 	MaxParallelScans *int `yaml:"max-parallel-scans,omitempty" json:"max-parallel-scans,omitempty" example:"100" extensions:"x-nullable"`
 	// The list of acceptable racks in order of preference.
+	// Nodes in prefer-racks[0] are chosen first.
+	// If a node is not found in prefer-racks[0], then nodes in prefer-racks[1] are searched, and so on.
 	PreferRacks []int `yaml:"prefer-racks,omitempty" json:"prefer-racks,omitempty" extensions:"x-nullable"`
 }
 

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -31,7 +31,7 @@ type AerospikeCluster struct {
 	// This property helps reduce the load on the cluster and is shared among all backups using the cluster.
 	// Default: unlimited.
 	MaxParallelScans *int `yaml:"max-parallel-scans,omitempty" json:"max-parallel-scans,omitempty" example:"100" extensions:"x-nullable"`
-	// PreferRacks defines the list of acceptable racks in order of preference.
+	// The list of acceptable racks in order of preference.
 	PreferRacks []int `yaml:"prefer-racks,omitempty" json:"prefer-racks,omitempty" extensions:"x-nullable"`
 }
 

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -37,6 +37,7 @@ type BackupRoutine struct {
 	// The list of backup bin names (optional, an empty list implies backing up all bins) extensions:"x-nullable".
 	BinList []string `yaml:"bin-list,omitempty" json:"bin-list,omitempty" example:"dataBin" extensions:"x-nullable"`
 	// The list of Aerospike Server rack IDs to use when reading records during backup.
+	// Only nodes from selected racks will be scanned.
 	RackList []int `yaml:"rack-list,omitempty" json:"rack-list,omitempty" extensions:"x-nullable"`
 
 	// PartitionList defines the list of partitions to include in the backup.

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -37,7 +37,7 @@ type BackupRoutine struct {
 	// The list of backup bin names (optional, an empty list implies backing up all bins) extensions:"x-nullable".
 	BinList []string `yaml:"bin-list,omitempty" json:"bin-list,omitempty" example:"dataBin" extensions:"x-nullable"`
 	// The list of Aerospike Server rack IDs to use when reading records during backup.
-	Racks []int `yaml:"racks,omitempty" json:"racks,omitempty" extensions:"x-nullable"`
+	RackList []int `yaml:"rack-list,omitempty" json:"rack-list,omitempty" extensions:"x-nullable"`
 
 	// PartitionList defines the list of partitions to include in the backup.
 	// The format supports individual partitions or ranges.
@@ -80,7 +80,7 @@ func (r *BackupRoutine) Validate() error {
 			return fmt.Errorf("incremental backup interval string '%s' invalid: %w", r.IntervalCron, err)
 		}
 	}
-	for i, rack := range r.Racks {
+	for i, rack := range r.RackList {
 		if rack < 0 {
 			return errValidationNegative(fmt.Sprintf("racks[%d]", i), rack)
 		}
@@ -196,7 +196,7 @@ func (r *BackupRoutine) ToModel(config *model.BackupConfig) (*model.BackupRoutin
 		Namespaces:       *r.Namespaces,
 		SetList:          r.SetList,
 		BinList:          r.BinList,
-		Racks:            r.Racks,
+		RackList:         r.RackList,
 		PartitionList:    r.PartitionList,
 		NodeList:         r.NodeList,
 		Disabled:         r.Disabled,
@@ -252,7 +252,7 @@ func (r *BackupRoutine) fromModel(m *model.BackupRoutine, config *model.BackupCo
 	r.Namespaces = &m.Namespaces
 	r.SetList = m.SetList
 	r.BinList = m.BinList
-	r.Racks = m.Racks
+	r.RackList = m.RackList
 	r.PartitionList = m.PartitionList
 	r.NodeList = m.NodeList
 	r.Disabled = m.Disabled

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -83,7 +83,7 @@ func (r *BackupRoutine) Validate() error {
 	}
 	for i, rack := range r.RackList {
 		if rack < 0 {
-			return errValidationNegative(fmt.Sprintf("racks[%d]", i), rack)
+			return errValidationNegative(fmt.Sprintf("rack-list[%d]", i), rack)
 		}
 		if rack > maxRack {
 			return fmt.Errorf("rack id %d invalid, should not exceed %d", rack, maxRack)

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -36,7 +36,7 @@ type BackupRoutine struct {
 	SetList []string `yaml:"set-list,omitempty" json:"set-list,omitempty" example:"set1" extensions:"x-nullable"`
 	// The list of backup bin names (optional, an empty list implies backing up all bins) extensions:"x-nullable".
 	BinList []string `yaml:"bin-list,omitempty" json:"bin-list,omitempty" example:"dataBin" extensions:"x-nullable"`
-	// RackList specifies the Aerospike Server rack IDs from which to read records 
+	// RackList specifies the Aerospike Server rack IDs from which to read records
 	// during backup.
 	// If provided, only nodes belonging to these specified racks will be scanned.
 	// If the list is empty or omitted, no rack filtering is applied.

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -36,9 +36,8 @@ type BackupRoutine struct {
 	SetList []string `yaml:"set-list,omitempty" json:"set-list,omitempty" example:"set1" extensions:"x-nullable"`
 	// The list of backup bin names (optional, an empty list implies backing up all bins) extensions:"x-nullable".
 	BinList []string `yaml:"bin-list,omitempty" json:"bin-list,omitempty" example:"dataBin" extensions:"x-nullable"`
-	// The list of Aerospike Server rack IDs to prioritize when reading records during backup.
-	// This is optional and can be used to optimize for rack-aware deployments.
-	PreferRacks []int `yaml:"prefer-racks,omitempty" json:"prefer-racks,omitempty" example:"0" extensions:"x-nullable"`
+	// The list of Aerospike Server rack IDs to use when reading records during backup.
+	Racks []int `yaml:"racks,omitempty" json:"racks,omitempty" extensions:"x-nullable"`
 
 	// PartitionList defines the list of partitions to include in the backup.
 	// The format supports individual partitions or ranges.
@@ -81,9 +80,9 @@ func (r *BackupRoutine) Validate() error {
 			return fmt.Errorf("incremental backup interval string '%s' invalid: %w", r.IntervalCron, err)
 		}
 	}
-	for i, rack := range r.PreferRacks {
+	for i, rack := range r.Racks {
 		if rack < 0 {
-			return errValidationNegative(fmt.Sprintf("prefer-racks[%d]", i), rack)
+			return errValidationNegative(fmt.Sprintf("racks[%d]", i), rack)
 		}
 		if rack > maxRack {
 			return fmt.Errorf("rack id %d invalid, should not exceed %d", rack, maxRack)
@@ -197,7 +196,7 @@ func (r *BackupRoutine) ToModel(config *model.BackupConfig) (*model.BackupRoutin
 		Namespaces:       *r.Namespaces,
 		SetList:          r.SetList,
 		BinList:          r.BinList,
-		PreferRacks:      r.PreferRacks,
+		Racks:            r.Racks,
 		PartitionList:    r.PartitionList,
 		NodeList:         r.NodeList,
 		Disabled:         r.Disabled,
@@ -253,7 +252,7 @@ func (r *BackupRoutine) fromModel(m *model.BackupRoutine, config *model.BackupCo
 	r.Namespaces = &m.Namespaces
 	r.SetList = m.SetList
 	r.BinList = m.BinList
-	r.PreferRacks = m.PreferRacks
+	r.Racks = m.Racks
 	r.PartitionList = m.PartitionList
 	r.NodeList = m.NodeList
 	r.Disabled = m.Disabled

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -36,8 +36,10 @@ type BackupRoutine struct {
 	SetList []string `yaml:"set-list,omitempty" json:"set-list,omitempty" example:"set1" extensions:"x-nullable"`
 	// The list of backup bin names (optional, an empty list implies backing up all bins) extensions:"x-nullable".
 	BinList []string `yaml:"bin-list,omitempty" json:"bin-list,omitempty" example:"dataBin" extensions:"x-nullable"`
-	// The list of Aerospike Server rack IDs to use when reading records during backup.
-	// Only nodes from selected racks will be scanned.
+	// RackList specifies the Aerospike Server rack IDs from which to read records 
+	// during backup.
+	// If provided, only nodes belonging to these specified racks will be scanned.
+	// If the list is empty or omitted, no rack filtering is applied.
 	RackList []int `yaml:"rack-list,omitempty" json:"rack-list,omitempty" extensions:"x-nullable"`
 
 	// PartitionList defines the list of partitions to include in the backup.

--- a/pkg/dto/decoder/deprecated_fields.go
+++ b/pkg/dto/decoder/deprecated_fields.go
@@ -13,4 +13,7 @@ var deprecatedFields = map[string]map[string]string{
 	"dto.Storage": {
 		"type": "is deprecated, use nested storage objects instead (see https://aerospike.com/docs/tools/backup-service/release-notes/3.0.0-abs-release-notes#storage )",
 	},
+	"dto.BackupRoutine": {
+		"prefer-racks": "is moved to aerospike-cluster.prefer-racks",
+	},
 }

--- a/pkg/model/aerospike_cluster.go
+++ b/pkg/model/aerospike_cluster.go
@@ -33,6 +33,8 @@ type AerospikeCluster struct {
 	TLS *TLS
 	// Specifies the maximum number of parallel scans per the cluster.
 	MaxParallelScans *int
+	// PreferRacks defines the list of acceptable racks in order of preference.
+	PreferRacks []int
 }
 
 // GetUser safely returns the username.
@@ -103,6 +105,10 @@ func (c *AerospikeCluster) Hash() string {
 
 	if c.MaxParallelScans != nil {
 		fmt.Fprintf(hasher, "%d:", *c.MaxParallelScans)
+	}
+
+	for _, rackID := range c.PreferRacks {
+		fmt.Fprintf(hasher, "%d:", rackID)
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil))

--- a/pkg/model/backup_routine.go
+++ b/pkg/model/backup_routine.go
@@ -2,11 +2,11 @@ package model
 
 // BackupRoutine represents a scheduled backup operation routine.
 type BackupRoutine struct {
-	// The name of the corresponding backup policy.
+	// The corresponding backup policy.
 	BackupPolicy *BackupPolicy
-	// The name of the corresponding source cluster.
+	// The corresponding source cluster.
 	SourceCluster *AerospikeCluster
-	// The name of the corresponding storage provider configuration.
+	// The corresponding storage provider configuration.
 	Storage Storage
 	// The Secret Agent configuration for the routine (optional).
 	SecretAgent *SecretAgent

--- a/pkg/model/backup_routine.go
+++ b/pkg/model/backup_routine.go
@@ -21,7 +21,7 @@ type BackupRoutine struct {
 	// The list of backup bin names (optional, an empty list implies backing up all bins).
 	BinList []string
 	// A list of Aerospike Server rack IDs to use when reading records for a backup.
-	Racks []int
+	RackList []int
 	// Back up list of partition filters. Partition filters can be ranges or individual partitions.
 	// Default number of partitions to back up: 0 to 4095: all partitions.
 	PartitionList string

--- a/pkg/model/backup_routine.go
+++ b/pkg/model/backup_routine.go
@@ -20,8 +20,8 @@ type BackupRoutine struct {
 	SetList []string
 	// The list of backup bin names (optional, an empty list implies backing up all bins).
 	BinList []string
-	// A list of Aerospike Server rack IDs to prefer when reading records for a backup.
-	PreferRacks []int
+	// A list of Aerospike Server rack IDs to use when reading records for a backup.
+	Racks []int
 	// Back up list of partition filters. Partition filters can be ranges or individual partitions.
 	// Default number of partitions to back up: 0 to 4095: all partitions.
 	PartitionList string

--- a/pkg/service/aerospike/client_factory.go
+++ b/pkg/service/aerospike/client_factory.go
@@ -82,6 +82,11 @@ func clientPolicy(c *model.AerospikeCluster) *as.ClientPolicy {
 	policy.ConnectionQueueSize = 256
 	policy.LimitConnectionsToQueueSize = false
 
+	if len(c.PreferRacks) > 0 {
+		policy.RackAware = true
+		policy.RackIds = c.PreferRacks // prioritise these racks
+	}
+
 	return policy
 }
 

--- a/pkg/service/backupexecutor/scan.go
+++ b/pkg/service/backupexecutor/scan.go
@@ -98,7 +98,7 @@ func makeBackupConfig(
 
 	config.MetricsEnabled = true
 
-	config.RackList = backupRoutine.Racks // backup only these racks
+	config.RackList = backupRoutine.RackList // backup only these racks
 
 	return config, nil
 }

--- a/pkg/service/backupexecutor/scan.go
+++ b/pkg/service/backupexecutor/scan.go
@@ -75,22 +75,11 @@ func makeBackupConfig(
 	config.FileLimit = uint64(backupPolicy.GetFileLimitOrDefault() * megabyte) // lib expects limit in bytes.
 	config.RecordsPerSecond = ptr.ValueOrZero(backupPolicy.RecordsPerSecond)
 	config.Bandwidth = ptr.ValueOrZero(backupPolicy.Bandwidth) * megabyte // lib expects file size in bytes.
+	config.ScanPolicy = scanPolicy(backupPolicy, backupRoutine, timeBounds)
+	config.RackList = backupRoutine.RackList // backup only these racks
 
 	config.ModBefore = timeBounds.ToTime
 	config.ModAfter = timeBounds.FromTime
-
-	config.ScanPolicy = as.NewScanPolicy()
-	if backupPolicy.TotalTimeout != nil {
-		config.ScanPolicy.TotalTimeout = *backupPolicy.TotalTimeout
-	}
-
-	config.ScanPolicy.SocketTimeout = calculateSocketTimeout(backupRoutine, isFullBackup(timeBounds), time.Now())
-	config.ScanPolicy.UseCompression = ptr.ValueOrZero(backupPolicy.UseCompression)
-	config.ScanPolicy.MaxConcurrentNodes = ptr.ValueOrZero(backupPolicy.MaxConcurrentNodes)
-
-	config.ScanPolicy.MaxRetries = 10
-	config.ScanPolicy.SleepBetweenRetries = 1 * time.Second
-	config.ScanPolicy.SleepMultiplier = 2
 
 	config.CompressionPolicy = makeCompressionPolicy(backupPolicy)
 	config.EncryptionPolicy = makeEncryptionPolicy(backupPolicy)
@@ -98,9 +87,32 @@ func makeBackupConfig(
 
 	config.MetricsEnabled = true
 
-	config.RackList = backupRoutine.RackList // backup only these racks
-
 	return config, nil
+}
+
+func scanPolicy(
+	backupPolicy *model.BackupPolicy,
+	backupRoutine *model.BackupRoutine,
+	timeBounds model.TimeBounds,
+) *as.ScanPolicy {
+	scanPolicy := as.NewScanPolicy()
+	if backupPolicy.TotalTimeout != nil {
+		scanPolicy.TotalTimeout = *backupPolicy.TotalTimeout
+	}
+
+	scanPolicy.SocketTimeout = calculateSocketTimeout(backupRoutine, isFullBackup(timeBounds), time.Now())
+	scanPolicy.UseCompression = ptr.ValueOrZero(backupPolicy.UseCompression)
+	scanPolicy.MaxConcurrentNodes = ptr.ValueOrZero(backupPolicy.MaxConcurrentNodes)
+
+	scanPolicy.MaxRetries = 10
+	scanPolicy.SleepBetweenRetries = 1 * time.Second
+	scanPolicy.SleepMultiplier = 2
+
+	if len(backupRoutine.SourceCluster.PreferRacks) > 0 {
+		scanPolicy.ReplicaPolicy = as.PREFER_RACK
+	}
+
+	return scanPolicy
 }
 
 // calculateSocketTimeout calculates socket timeout for the given backup routine and timestamp.

--- a/pkg/service/backupexecutor/scan.go
+++ b/pkg/service/backupexecutor/scan.go
@@ -98,7 +98,7 @@ func makeBackupConfig(
 
 	config.MetricsEnabled = true
 
-	config.RackList = backupRoutine.PreferRacks
+	config.RackList = backupRoutine.Racks // backup only these racks
 
 	return config, nil
 }

--- a/pkg/service/backupexecutor/scan_test.go
+++ b/pkg/service/backupexecutor/scan_test.go
@@ -121,6 +121,7 @@ func TestMakeBackupConfigWithFullBackup(t *testing.T) {
 			TLSCAString:    ptr.Of("ca-string"),
 			IsBase64:       ptr.Of(true),
 		},
+		SourceCluster: &model.AerospikeCluster{},
 	}
 
 	// Full backup has FromTime == nil
@@ -187,6 +188,7 @@ func TestMakeBackupConfigWithIncrementalBackup(t *testing.T) {
 		NodeList:         []string{"node1", "node2"},
 		IncrIntervalCron: "@hourly",
 		SecretAgent:      &model.SecretAgent{},
+		SourceCluster:    &model.AerospikeCluster{},
 	}
 
 	// Incremental backup has FromTime != nil
@@ -221,6 +223,7 @@ func TestMakeBackupConfigWithPartitionList(t *testing.T) {
 		BackupPolicy:  &model.BackupPolicy{},
 		PartitionList: "0-100",
 		IntervalCron:  "@daily",
+		SourceCluster: &model.AerospikeCluster{},
 	}
 
 	config, err := makeBackupConfig(namespace, routine, model.TimeBounds{})
@@ -239,7 +242,8 @@ func TestMakeBackupConfig_DefaultParallelWrite(t *testing.T) {
 		BackupPolicy: &model.BackupPolicy{
 			Parallel: ptr.Of(4),
 		},
-		IntervalCron: "@daily",
+		IntervalCron:  "@daily",
+		SourceCluster: &model.AerospikeCluster{},
 	}
 
 	config, err := makeBackupConfig(namespace, routine, model.TimeBounds{})


### PR DESCRIPTION
1. `prefer-racks` configuration field is moved routine -> cluster
2. routine has new field, `rack-list`, that selects racks to scan exclusively.