### PR TITLE
Remove explicit request body closures in handlers

### DIFF
--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -32,17 +32,15 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		cluster, err := newCluster.ToModel(config)
 		if err != nil {
 			return fmt.Errorf("invalid cluster %q: %w", name, err)
 		}
 
 		return config.AddCluster(name, cluster)
-	})
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -118,14 +116,14 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
+
 	cluster, err := updatedCluster.ToModel(s.config)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		err := config.UpdateCluster(clusterName, cluster)
 		if err != nil {
 			return err
@@ -134,9 +132,7 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		// validate that new cluster has all required NSs (under the lock)
 		s.nsValidator.Validate(r.Context(), config)
 		return nil
-	})
-
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -24,16 +24,16 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
+
 	name := r.PathValue("name")
 	if name == "" {
 		httpError(w, errMissingPolicyName)
 		return
 	}
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		return config.AddPolicy(name, newPolicy.ToModel())
-	})
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -96,17 +96,16 @@ func (s *Service) UpdatePolicy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
+
 	name := r.PathValue("name")
 	if name == "" {
 		httpError(w, errMissingPolicyName)
 		return
 	}
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		return config.UpdatePolicy(name, updatedPolicy.ToModel())
-	})
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -31,14 +31,14 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
+
 	toModel, err := newRoutine.ToModel(s.config.BackupConfigCopy())
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		err := config.AddRoutine(name, toModel)
 		if err != nil {
 			return err
@@ -47,9 +47,7 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 		// validate that new routine has all required NSs (under the lock)
 		s.nsValidator.Validate(r.Context(), config)
 		return nil
-	})
-
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -122,7 +120,6 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
 
 	toModel, err := updatedRoutine.ToModel(s.config.BackupConfigCopy())
 	if err != nil {
@@ -130,7 +127,7 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		err := config.UpdateRoutine(name, toModel)
 		if err != nil {
 			return err
@@ -139,8 +136,7 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		// validate that updated routine has all required NSs (under the lock)
 		s.nsValidator.Validate(r.Context(), config)
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -31,17 +31,14 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	r.Body.Close()
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		storage, err := newStorage.ToModel(config)
 		if err != nil {
 			return fmt.Errorf("failed to convert storage: %w", err)
 		}
 		return config.AddStorage(name, storage)
-	})
-
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -111,16 +108,14 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errInvalidJSONPayload(err))
 		return
 	}
-	defer r.Body.Close()
 
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
+	if err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		storage, err := updatedStorage.ToModel(config)
 		if err != nil {
 			return fmt.Errorf("failed to convert storage: %w", err)
 		}
 		return config.UpdateStorage(storageName, storage)
-	})
-	if err != nil {
+	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}

--- a/internal/server/middleware/logger.go
+++ b/internal/server/middleware/logger.go
@@ -83,8 +83,12 @@ func readRequestBody(r *http.Request) ([]byte, error) {
 		return nil, err
 	}
 
-	r.Body.Close()
+	if err = r.Body.Close(); err != nil {
+		return nil, err
+	}
+
 	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
 	return bodyBytes, nil
 }
 


### PR DESCRIPTION
For server requests, the HTTP server handles this automatically. See the [doc](https://pkg.go.dev/net/http#Request).