### PR TITLE
Fix race condition for backups registry

### DIFF
--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -158,8 +158,8 @@ func (r *RunningBackupsRegistryImpl) register(routineName string, job jobType, h
 // unregister removes a backup from the registry and updates the last success timestamp.
 // Should be called after successful backup completion.
 func (r *RunningBackupsRegistryImpl) unregister(routineName string, job jobType, timestamp time.Time) {
-	r.setLastTime(routineName, job, timestamp)
-	r.remove(routineName, job)
+	r.remove(routineName, job)                 // first remove finished job from registry
+	r.setLastTime(routineName, job, timestamp) // then update last successful backup time
 }
 
 func (r *RunningBackupsRegistryImpl) setLastTime(routineName string, job jobType, timestamp time.Time) {


### PR DESCRIPTION
setLastTime() might take few seconds because of locks in test environment, when I have many tests running