### PR TITLE
APPS-1830 Simplify restore by timestamp request

### DIFF
--- a/build/readme/readme_generator.go
+++ b/build/readme/readme_generator.go
@@ -116,7 +116,9 @@ var jsonExamples = map[string]any{
 			Cluster: &cluster,
 		},
 		Policy: &dto.RestorePolicy{
-			NoGeneration: ptr.Of(true),
+			BaseRestorePolicy: dto.BaseRestorePolicy{
+				NoGeneration: ptr.Of(true),
+			},
 		},
 		StorageConfig: dto.StorageConfig{
 			Storage: &dto.Storage{

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -541,7 +541,7 @@
         "type": "object",
         "properties": {
           "level": {
-            "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).",
+            "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
             "type": "integer",
             "default": 0,
             "maximum": 22,
@@ -1048,7 +1048,7 @@
             "nullable": true
           },
           "compression": {
-            "description": "Compression details (algorithm). Default is no compression.",
+            "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/dto.CompressionPolicy"

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -907,6 +907,21 @@
           }
         }
       },
+      "dto.RestoreCompressionPolicy": {
+        "description": "RestoreCompressionPolicy contains restore compression information.",
+        "type": "object",
+        "properties": {
+          "mode": {
+            "description": "The compression mode to be used (default is NONE).",
+            "type": "string",
+            "default": "NONE",
+            "enum": [
+              "NONE",
+              "ZSTD"
+            ]
+          }
+        }
+      },
       "dto.RestoreJobStatus": {
         "description": "RestoreJobStatus represents restore job status.",
         "type": "object",
@@ -1048,10 +1063,10 @@
             "nullable": true
           },
           "compression": {
-            "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
+            "description": "Compression details (algorithm). Default is no compression.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/dto.CompressionPolicy"
+                "$ref": "#/components/schemas/dto.RestoreCompressionPolicy"
               }
             ]
           },
@@ -1254,7 +1269,7 @@
             "description": "Restore policy to use in the operation.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/dto.RestorePolicy"
+                "$ref": "#/components/schemas/dto.TimestampRestorePolicy"
               }
             ]
           },
@@ -1732,6 +1747,143 @@
             "description": "TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.",
             "type": "string",
             "default": "TLSv1.2"
+          }
+        }
+      },
+      "dto.TimestampRestorePolicy": {
+        "description": "TimestampRestorePolicy represents a policy for the point-in-time restore operation.",
+        "type": "object",
+        "properties": {
+          "bandwidth": {
+            "description": "Throttles read operations from the backup file(s) to not exceed the given I/O bandwidth in MiB/s.\nDefault: no limit.",
+            "type": "integer",
+            "example": 50000,
+            "nullable": true
+          },
+          "batch-size": {
+            "description": "The max allowed number of records per an async batch write call.\nOnly applicable when using batch writes.",
+            "type": "integer",
+            "default": 128,
+            "example": 32
+          },
+          "bin-list": {
+            "description": "The bins to restore (optional, an empty list implies restoring all bins).",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "bin1",
+              "bin2"
+            ],
+            "nullable": true
+          },
+          "disable-batch-writes": {
+            "description": "Disables the use of batch writes when restoring records to the Aerospike cluster.\nBy default, the cluster is checked for batch write support.",
+            "type": "boolean",
+            "default": false
+          },
+          "encryption": {
+            "description": "Encryption details (algorithm and key). Default is no encryption.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/dto.EncryptionPolicy"
+              }
+            ]
+          },
+          "extra-ttl": {
+            "description": "Amount of extra time-to-live to add to records that have expirable void-times.\nMust be set in seconds.",
+            "type": "integer",
+            "default": 0,
+            "example": 86400
+          },
+          "max-async-batches": {
+            "description": "The max number of outstanding async record batch write calls at a time.",
+            "type": "integer",
+            "default": 128,
+            "example": 32
+          },
+          "namespace": {
+            "description": "Namespace optionally specifies an alternative namespace name for the restore operation.\nBy default, the data is restored to the namespace from which it was taken.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/dto.RestoreNamespace"
+              }
+            ]
+          },
+          "no-generation": {
+            "description": "Records from backups take precedence. This option disables the generation check.\nWith this option, records from the backup always overwrite records that already exist in\nthe namespace, regardless of generation numbers.",
+            "type": "boolean",
+            "default": false
+          },
+          "no-indexes": {
+            "description": "Do not restore any secondary index definitions.",
+            "type": "boolean",
+            "default": false
+          },
+          "no-records": {
+            "description": "Do not restore any record data (metadata or bin data).\nBy default, record data, secondary index definitions, and UDF modules will be restored.",
+            "type": "boolean",
+            "default": false
+          },
+          "no-udfs": {
+            "description": "Do not restore any UDF modules.",
+            "type": "boolean",
+            "default": false
+          },
+          "parallel": {
+            "description": "The number of concurrent record readers from backup files.\nThis value controls the level of parallelism used by the backup service when\nreading backup files.\nThe optimal value depends on hardware and network configuration.",
+            "type": "integer",
+            "default": 8,
+            "example": 8
+          },
+          "replace": {
+            "description": "Replace records. This controls how records from the backup overwrite existing records in\nthe namespace. By default, restoring a record from a backup only replaces the bins\ncontained in the backup; all other bins of an existing record remain untouched.",
+            "type": "boolean",
+            "default": false
+          },
+          "retry-policy": {
+            "description": "Configuration of retries for each restore write operation.\nIf nil, the default policy is used (5 retries with a one-minute delay between attempts).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/dto.RetryPolicy"
+              }
+            ]
+          },
+          "set-list": {
+            "description": "The sets to restore (optional, an empty list implies restoring all sets).",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "set1",
+              "set2"
+            ],
+            "nullable": true
+          },
+          "socket-timeout": {
+            "description": "Timeout (ms) for Aerospike commands to write records, create indexes and create UDFs.\nSocket timeout in milliseconds. Default is 10 minutes. If this value is 0, it is set to total-timeout.\nIf both are 0, there is no socket idle time limit.",
+            "type": "integer",
+            "default": 60000,
+            "example": 1000
+          },
+          "total-timeout": {
+            "description": "Total socket timeout in milliseconds. Default is 0, that is, no timeout.",
+            "type": "integer",
+            "default": 0,
+            "example": 2000
+          },
+          "tps": {
+            "description": "Throttles read operations from the backup file(s) to not exceed the given number of transactions per second.\nDefault: no limit.",
+            "type": "integer",
+            "example": 4000,
+            "nullable": true
+          },
+          "unique": {
+            "description": "Existing records take precedence. With this option, only records that do not exist in\nthe namespace are restored, regardless of generation numbers. If a record exists in\nthe namespace, the record from the backup is ignored.",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -541,7 +541,7 @@
         "type": "object",
         "properties": {
           "level": {
-            "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
+            "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.",
             "type": "integer",
             "default": 0,
             "maximum": 22,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2147,7 +2147,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "level": {
-                    "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
+                    "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.",
                     "type": "integer",
                     "default": 0,
                     "maximum": 22,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2147,7 +2147,7 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "level": {
-                    "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).",
+                    "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
                     "type": "integer",
                     "default": 0,
                     "maximum": 22,
@@ -2703,7 +2703,7 @@ const docTemplate = `{
                     ]
                 },
                 "compression": {
-                    "description": "Compression details (algorithm). Default is no compression.",
+                    "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
                     "allOf": [
                         {
                             "$ref": "#/definitions/dto.CompressionPolicy"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2562,6 +2562,21 @@ const docTemplate = `{
                 }
             }
         },
+        "dto.RestoreCompressionPolicy": {
+            "description": "RestoreCompressionPolicy contains restore compression information.",
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "description": "The compression mode to be used (default is NONE).",
+                    "type": "string",
+                    "default": "NONE",
+                    "enum": [
+                        "NONE",
+                        "ZSTD"
+                    ]
+                }
+            }
+        },
         "dto.RestoreJobStatus": {
             "description": "RestoreJobStatus represents restore job status.",
             "type": "object",
@@ -2703,10 +2718,10 @@ const docTemplate = `{
                     ]
                 },
                 "compression": {
-                    "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
+                    "description": "Compression details (algorithm). Default is no compression.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.CompressionPolicy"
+                            "$ref": "#/definitions/dto.RestoreCompressionPolicy"
                         }
                     ]
                 },
@@ -2909,7 +2924,7 @@ const docTemplate = `{
                     "description": "Restore policy to use in the operation.",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/dto.RestorePolicy"
+                            "$ref": "#/definitions/dto.TimestampRestorePolicy"
                         }
                     ]
                 },
@@ -3387,6 +3402,143 @@ const docTemplate = `{
                     "description": "TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.",
                     "type": "string",
                     "default": "TLSv1.2"
+                }
+            }
+        },
+        "dto.TimestampRestorePolicy": {
+            "description": "TimestampRestorePolicy represents a policy for the point-in-time restore operation.",
+            "type": "object",
+            "properties": {
+                "bandwidth": {
+                    "description": "Throttles read operations from the backup file(s) to not exceed the given I/O bandwidth in MiB/s.\nDefault: no limit.",
+                    "type": "integer",
+                    "x-nullable": true,
+                    "example": 50000
+                },
+                "batch-size": {
+                    "description": "The max allowed number of records per an async batch write call.\nOnly applicable when using batch writes.",
+                    "type": "integer",
+                    "default": 128,
+                    "example": 32
+                },
+                "bin-list": {
+                    "description": "The bins to restore (optional, an empty list implies restoring all bins).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "x-nullable": true,
+                    "example": [
+                        "bin1",
+                        "bin2"
+                    ]
+                },
+                "disable-batch-writes": {
+                    "description": "Disables the use of batch writes when restoring records to the Aerospike cluster.\nBy default, the cluster is checked for batch write support.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "encryption": {
+                    "description": "Encryption details (algorithm and key). Default is no encryption.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.EncryptionPolicy"
+                        }
+                    ]
+                },
+                "extra-ttl": {
+                    "description": "Amount of extra time-to-live to add to records that have expirable void-times.\nMust be set in seconds.",
+                    "type": "integer",
+                    "default": 0,
+                    "example": 86400
+                },
+                "max-async-batches": {
+                    "description": "The max number of outstanding async record batch write calls at a time.",
+                    "type": "integer",
+                    "default": 128,
+                    "example": 32
+                },
+                "namespace": {
+                    "description": "Namespace optionally specifies an alternative namespace name for the restore operation.\nBy default, the data is restored to the namespace from which it was taken.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.RestoreNamespace"
+                        }
+                    ]
+                },
+                "no-generation": {
+                    "description": "Records from backups take precedence. This option disables the generation check.\nWith this option, records from the backup always overwrite records that already exist in\nthe namespace, regardless of generation numbers.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "no-indexes": {
+                    "description": "Do not restore any secondary index definitions.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "no-records": {
+                    "description": "Do not restore any record data (metadata or bin data).\nBy default, record data, secondary index definitions, and UDF modules will be restored.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "no-udfs": {
+                    "description": "Do not restore any UDF modules.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "parallel": {
+                    "description": "The number of concurrent record readers from backup files.\nThis value controls the level of parallelism used by the backup service when\nreading backup files.\nThe optimal value depends on hardware and network configuration.",
+                    "type": "integer",
+                    "default": 8,
+                    "example": 8
+                },
+                "replace": {
+                    "description": "Replace records. This controls how records from the backup overwrite existing records in\nthe namespace. By default, restoring a record from a backup only replaces the bins\ncontained in the backup; all other bins of an existing record remain untouched.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "retry-policy": {
+                    "description": "Configuration of retries for each restore write operation.\nIf nil, the default policy is used (5 retries with a one-minute delay between attempts).",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/dto.RetryPolicy"
+                        }
+                    ]
+                },
+                "set-list": {
+                    "description": "The sets to restore (optional, an empty list implies restoring all sets).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "x-nullable": true,
+                    "example": [
+                        "set1",
+                        "set2"
+                    ]
+                },
+                "socket-timeout": {
+                    "description": "Timeout (ms) for Aerospike commands to write records, create indexes and create UDFs.\nSocket timeout in milliseconds. Default is 10 minutes. If this value is 0, it is set to total-timeout.\nIf both are 0, there is no socket idle time limit.",
+                    "type": "integer",
+                    "default": 60000,
+                    "example": 1000
+                },
+                "total-timeout": {
+                    "description": "Total socket timeout in milliseconds. Default is 0, that is, no timeout.",
+                    "type": "integer",
+                    "default": 0,
+                    "example": 2000
+                },
+                "tps": {
+                    "description": "Throttles read operations from the backup file(s) to not exceed the given number of transactions per second.\nDefault: no limit.",
+                    "type": "integer",
+                    "x-nullable": true,
+                    "example": 4000
+                },
+                "unique": {
+                    "description": "Existing records take precedence. With this option, only records that do not exist in\nthe namespace are restored, regardless of generation numbers. If a record exists in\nthe namespace, the record from the backup is ignored.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2479,7 +2479,7 @@
                 "type": "object",
                 "properties": {
                     "level": {
-                        "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).",
+                        "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
                         "type": "integer",
                         "default": 0,
                         "maximum": 22,
@@ -3035,7 +3035,7 @@
                         "nullable": true
                     },
                     "compression": {
-                        "description": "Compression details (algorithm). Default is no compression.",
+                        "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
                         "allOf": [
                             {
                                 "$ref": "#/components/schemas/dto.CompressionPolicy"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2894,6 +2894,21 @@
                     }
                 }
             },
+            "dto.RestoreCompressionPolicy": {
+                "description": "RestoreCompressionPolicy contains restore compression information.",
+                "type": "object",
+                "properties": {
+                    "mode": {
+                        "description": "The compression mode to be used (default is NONE).",
+                        "type": "string",
+                        "default": "NONE",
+                        "enum": [
+                            "NONE",
+                            "ZSTD"
+                        ]
+                    }
+                }
+            },
             "dto.RestoreJobStatus": {
                 "description": "RestoreJobStatus represents restore job status.",
                 "type": "object",
@@ -3035,10 +3050,10 @@
                         "nullable": true
                     },
                     "compression": {
-                        "description": "Compression details (algorithm). Default is no compression.\nThis field is ignored during point-in-time restores as the system automatically detects compression.",
+                        "description": "Compression details (algorithm). Default is no compression.",
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/dto.CompressionPolicy"
+                                "$ref": "#/components/schemas/dto.RestoreCompressionPolicy"
                             }
                         ]
                     },
@@ -3241,7 +3256,7 @@
                         "description": "Restore policy to use in the operation.",
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/dto.RestorePolicy"
+                                "$ref": "#/components/schemas/dto.TimestampRestorePolicy"
                             }
                         ]
                     },
@@ -3719,6 +3734,143 @@
                         "description": "TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.",
                         "type": "string",
                         "default": "TLSv1.2"
+                    }
+                }
+            },
+            "dto.TimestampRestorePolicy": {
+                "description": "TimestampRestorePolicy represents a policy for the point-in-time restore operation.",
+                "type": "object",
+                "properties": {
+                    "bandwidth": {
+                        "description": "Throttles read operations from the backup file(s) to not exceed the given I/O bandwidth in MiB/s.\nDefault: no limit.",
+                        "type": "integer",
+                        "example": 50000,
+                        "nullable": true
+                    },
+                    "batch-size": {
+                        "description": "The max allowed number of records per an async batch write call.\nOnly applicable when using batch writes.",
+                        "type": "integer",
+                        "default": 128,
+                        "example": 32
+                    },
+                    "bin-list": {
+                        "description": "The bins to restore (optional, an empty list implies restoring all bins).",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "bin1",
+                            "bin2"
+                        ],
+                        "nullable": true
+                    },
+                    "disable-batch-writes": {
+                        "description": "Disables the use of batch writes when restoring records to the Aerospike cluster.\nBy default, the cluster is checked for batch write support.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "encryption": {
+                        "description": "Encryption details (algorithm and key). Default is no encryption.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/dto.EncryptionPolicy"
+                            }
+                        ]
+                    },
+                    "extra-ttl": {
+                        "description": "Amount of extra time-to-live to add to records that have expirable void-times.\nMust be set in seconds.",
+                        "type": "integer",
+                        "default": 0,
+                        "example": 86400
+                    },
+                    "max-async-batches": {
+                        "description": "The max number of outstanding async record batch write calls at a time.",
+                        "type": "integer",
+                        "default": 128,
+                        "example": 32
+                    },
+                    "namespace": {
+                        "description": "Namespace optionally specifies an alternative namespace name for the restore operation.\nBy default, the data is restored to the namespace from which it was taken.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/dto.RestoreNamespace"
+                            }
+                        ]
+                    },
+                    "no-generation": {
+                        "description": "Records from backups take precedence. This option disables the generation check.\nWith this option, records from the backup always overwrite records that already exist in\nthe namespace, regardless of generation numbers.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "no-indexes": {
+                        "description": "Do not restore any secondary index definitions.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "no-records": {
+                        "description": "Do not restore any record data (metadata or bin data).\nBy default, record data, secondary index definitions, and UDF modules will be restored.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "no-udfs": {
+                        "description": "Do not restore any UDF modules.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "parallel": {
+                        "description": "The number of concurrent record readers from backup files.\nThis value controls the level of parallelism used by the backup service when\nreading backup files.\nThe optimal value depends on hardware and network configuration.",
+                        "type": "integer",
+                        "default": 8,
+                        "example": 8
+                    },
+                    "replace": {
+                        "description": "Replace records. This controls how records from the backup overwrite existing records in\nthe namespace. By default, restoring a record from a backup only replaces the bins\ncontained in the backup; all other bins of an existing record remain untouched.",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "retry-policy": {
+                        "description": "Configuration of retries for each restore write operation.\nIf nil, the default policy is used (5 retries with a one-minute delay between attempts).",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/dto.RetryPolicy"
+                            }
+                        ]
+                    },
+                    "set-list": {
+                        "description": "The sets to restore (optional, an empty list implies restoring all sets).",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "set1",
+                            "set2"
+                        ],
+                        "nullable": true
+                    },
+                    "socket-timeout": {
+                        "description": "Timeout (ms) for Aerospike commands to write records, create indexes and create UDFs.\nSocket timeout in milliseconds. Default is 10 minutes. If this value is 0, it is set to total-timeout.\nIf both are 0, there is no socket idle time limit.",
+                        "type": "integer",
+                        "default": 60000,
+                        "example": 1000
+                    },
+                    "total-timeout": {
+                        "description": "Total socket timeout in milliseconds. Default is 0, that is, no timeout.",
+                        "type": "integer",
+                        "default": 0,
+                        "example": 2000
+                    },
+                    "tps": {
+                        "description": "Throttles read operations from the backup file(s) to not exceed the given number of transactions per second.\nDefault: no limit.",
+                        "type": "integer",
+                        "example": 4000,
+                        "nullable": true
+                    },
+                    "unique": {
+                        "description": "Existing records take precedence. With this option, only records that do not exist in\nthe namespace are restored, regardless of generation numbers. If a record exists in\nthe namespace, the record from the backup is ignored.",
+                        "type": "boolean",
+                        "default": false
                     }
                 }
             }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2479,7 +2479,7 @@
                 "type": "object",
                 "properties": {
                     "level": {
-                        "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.\nThis field is ignored during restoration.",
+                        "description": "The compression level to use.\nAlgorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).\nThis field is ignored if the compression mode is NONE.",
                         "type": "integer",
                         "default": 0,
                         "maximum": 22,

--- a/docs/readme/dto/dto.compressionpolicy.md
+++ b/docs/readme/dto/dto.compressionpolicy.md
@@ -1,7 +1,7 @@
 ## dto.CompressionPolicy
 CompressionPolicy contains backup compression information.
 
-| Field   | Description                                                                                                | Default Value | Possible Values |
-|---------|------------------------------------------------------------------------------------------------------------|---------------|-----------------|
-| `level` | The compression level to use.<br>Algorithm-specific; for zstd: from -1 (fastest) to 22 (best compression). | `0`           |                 |
-| `mode`  | The compression mode to be used (default is NONE).                                                         | `NONE`        | `NONE`, `ZSTD`  |
+| Field   | Description                                                                                                                                                          | Default Value | Possible Values |
+|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|-----------------|
+| `level` | The compression level to use.<br>Algorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).<br>This field is ignored if the compression mode is NONE. | `0`           |                 |
+| `mode`  | The compression mode to be used (default is NONE).                                                                                                                   | `NONE`        | `NONE`, `ZSTD`  |

--- a/docs/readme/dto/dto.localstorage.md
+++ b/docs/readme/dto/dto.localstorage.md
@@ -1,8 +1,9 @@
 ## dto.LocalStorage
 LocalStorage represents the configuration for local storage.
 
-| Field       | Description                              |
-|-------------|------------------------------------------|
-| 📍 `path`    | The root path for the backup repository. |
+| Field           | Description                                             |
+|-----------------|---------------------------------------------------------|
+| 📍 `path`        | The root path for the backup repository.                |
+| `min-part-size` | The minimum size in bytes of individual storage chunks. |
 
 📍 = Required field

--- a/docs/readme/dto/dto.restorecompressionpolicy.md
+++ b/docs/readme/dto/dto.restorecompressionpolicy.md
@@ -1,0 +1,6 @@
+## dto.RestoreCompressionPolicy
+RestoreCompressionPolicy contains restore compression information.
+
+| Field  | Description                                        | Default Value | Possible Values |
+|--------|----------------------------------------------------|---------------|-----------------|
+| `mode` | The compression mode to be used (default is NONE). | `NONE`        | `NONE`, `ZSTD`  |

--- a/docs/readme/dto/dto.restoretimestamprequest.md
+++ b/docs/readme/dto/dto.restoretimestamprequest.md
@@ -8,7 +8,7 @@ RestoreTimestampRequest represents a restore by timestamp operation request.
 | `destination`        | The details of the Aerospike destination cluster.<br>Mutually exclusive with 'destination-name'.<br>See: [dto.AerospikeCluster](dto.aerospikecluster.md) |               |
 | `destination-name`   | Link to one of preconfigured clusters.<br>Mutually exclusive with 'destination'.                                                                         |               |
 | `disable-reordering` | Disable reverse order of incremental backups optimisation.                                                                                               | `false`       |
-| `policy`             | Restore policy to use in the operation.<br>See: [dto.RestorePolicy](dto.restorepolicy.md)                                                                |               |
+| `policy`             | Restore policy to use in the operation.<br>See: [dto.TimestampRestorePolicy](dto.timestamprestorepolicy.md)                                              |               |
 | `secret-agent`       | Secret Agent configuration (optional).<br>Mutually exclusive with 'secret-agent-name'.<br>See: [dto.SecretAgent](dto.secretagent.md)                     |               |
 | `secret-agent-name`  | Secret Agent configuration (optional). Link to one of preconfigured agents.<br>Mutually exclusive with 'secret-agent'.                                   |               |
 

--- a/docs/readme/dto/dto.timestamprestorepolicy.md
+++ b/docs/readme/dto/dto.timestamprestorepolicy.md
@@ -1,12 +1,11 @@
-## dto.RestorePolicy
-RestorePolicy represents a policy for the restore operation.
+## dto.TimestampRestorePolicy
+TimestampRestorePolicy represents a policy for the point-in-time restore operation.
 
 | Field                  | Description                                                                                                                                                                                                                                                       | Default Value |
 |------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | `bandwidth`            | Throttles read operations from the backup file(s) to not exceed the given I/O bandwidth in MiB/s.<br>Default: no limit.                                                                                                                                           |               |
 | `batch-size`           | The max allowed number of records per an async batch write call.<br>Only applicable when using batch writes.                                                                                                                                                      | `128`         |
 | `bin-list`             | The bins to restore (optional, an empty list implies restoring all bins).                                                                                                                                                                                         |               |
-| `compression`          | Compression details (algorithm). Default is no compression.<br>See: [dto.RestoreCompressionPolicy](dto.restorecompressionpolicy.md)                                                                                                                               |               |
 | `disable-batch-writes` | Disables the use of batch writes when restoring records to the Aerospike cluster.<br>By default, the cluster is checked for batch write support.                                                                                                                  | `false`       |
 | `encryption`           | Encryption details (algorithm and key). Default is no encryption.<br>See: [dto.EncryptionPolicy](dto.encryptionpolicy.md)                                                                                                                                         |               |
 | `extra-ttl`            | Amount of extra time-to-live to add to records that have expirable void-times.<br>Must be set in seconds.                                                                                                                                                         | `0`           |

--- a/pkg/dto/compression_policy.go
+++ b/pkg/dto/compression_policy.go
@@ -18,7 +18,6 @@ type CompressionPolicy struct {
 	// The compression level to use.
 	// Algorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).
 	// This field is ignored if the compression mode is NONE.
-	// This field is ignored during restoration.
 	Level int32 `yaml:"level,omitempty" json:"level,omitempty" default:"0" minimum:"-1" maximum:"22"`
 }
 

--- a/pkg/dto/compression_policy.go
+++ b/pkg/dto/compression_policy.go
@@ -63,3 +63,31 @@ func (p *CompressionPolicy) fromModel(m *model.CompressionPolicy) {
 	p.Mode = m.Mode
 	p.Level = m.Level
 }
+
+// RestoreCompressionPolicy contains restore compression information.
+// @Description RestoreCompressionPolicy contains restore compression information.
+type RestoreCompressionPolicy struct {
+	// The compression mode to be used (default is NONE).
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty" default:"NONE" enums:"NONE,ZSTD"`
+}
+
+// Validate validates the restore compression policy.
+func (p *RestoreCompressionPolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if p.Mode != CompressNone && p.Mode != CompressZSTD {
+		return errValidationInvalidValue("compression mode", p.Mode, []string{CompressNone, CompressZSTD})
+	}
+	return nil
+}
+
+func (p *RestoreCompressionPolicy) ToModel() *model.CompressionPolicy {
+	if p == nil {
+		return nil
+	}
+
+	return &model.CompressionPolicy{
+		Mode: p.Mode,
+	}
+}

--- a/pkg/dto/compression_policy.go
+++ b/pkg/dto/compression_policy.go
@@ -17,6 +17,8 @@ type CompressionPolicy struct {
 	Mode string `yaml:"mode,omitempty" json:"mode,omitempty" default:"NONE" enums:"NONE,ZSTD"`
 	// The compression level to use.
 	// Algorithm-specific; for zstd: from -1 (fastest) to 22 (best compression).
+	// This field is ignored if the compression mode is NONE.
+	// This field is ignored during restoration.
 	Level int32 `yaml:"level,omitempty" json:"level,omitempty" default:"0" minimum:"-1" maximum:"22"`
 }
 

--- a/pkg/dto/restore_policy.go
+++ b/pkg/dto/restore_policy.go
@@ -7,9 +7,8 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 )
 
-// RestorePolicy represents a policy for the restore operation.
-// @Description RestorePolicy represents a policy for the restore operation.
-type RestorePolicy struct {
+// BaseRestorePolicy represents the common policy for restore operations.
+type BaseRestorePolicy struct {
 	// The number of concurrent record readers from backup files.
 	// This value controls the level of parallelism used by the backup service when
 	// reading backup files.
@@ -63,9 +62,6 @@ type RestorePolicy struct {
 	Tps *int `json:"tps,omitempty" example:"4000" extensions:"x-nullable"`
 	// Encryption details (algorithm and key). Default is no encryption.
 	EncryptionPolicy *EncryptionPolicy `yaml:"encryption,omitempty" json:"encryption,omitempty"`
-	// Compression details (algorithm). Default is no compression.
-	// This field is ignored during point-in-time restores as the system automatically detects compression.
-	CompressionPolicy *CompressionPolicy `yaml:"compression,omitempty" json:"compression,omitempty"`
 	// Configuration of retries for each restore write operation.
 	// If nil, the default policy is used (5 retries with a one-minute delay between attempts).
 	RetryPolicy *RetryPolicy `yaml:"retry-policy,omitempty" json:"retry-policy,omitempty"`
@@ -74,8 +70,22 @@ type RestorePolicy struct {
 	ExtraTTL *int64 `yaml:"extra-ttl" json:"extra-ttl,omitempty" example:"86400" default:"0"`
 }
 
-// Validate validates the restore policy.
-func (p *RestorePolicy) Validate() error {
+// RestorePolicy represents a policy for the restore operation.
+// @Description RestorePolicy represents a policy for the restore operation.
+type RestorePolicy struct {
+	BaseRestorePolicy
+	// Compression details (algorithm). Default is no compression.
+	CompressionPolicy *RestoreCompressionPolicy `yaml:"compression,omitempty" json:"compression,omitempty"`
+}
+
+// TimestampRestorePolicy represents a policy for the point-in-time restore operation.
+// @Description TimestampRestorePolicy represents a policy for the point-in-time restore operation.
+type TimestampRestorePolicy struct {
+	BaseRestorePolicy
+}
+
+// Validate validates the base restore policy.
+func (p *BaseRestorePolicy) Validate() error {
 	if p == nil {
 		return nil
 	}
@@ -121,9 +131,6 @@ func (p *RestorePolicy) Validate() error {
 	if err := p.EncryptionPolicy.Validate(); err != nil {
 		return err
 	}
-	if err := p.CompressionPolicy.Validate(); err != nil {
-		return err
-	}
 	if err := p.RetryPolicy.Validate(); err != nil {
 		return fmt.Errorf("retry policy invalid: %w", err)
 	}
@@ -134,7 +141,29 @@ func (p *RestorePolicy) Validate() error {
 	return nil
 }
 
-func (p *RestorePolicy) validateExistingRecordPolicy() error {
+// Validate validates the restore policy.
+func (p *RestorePolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if err := p.BaseRestorePolicy.Validate(); err != nil {
+		return err
+	}
+	if err := p.CompressionPolicy.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Validate validates the timestamp restore policy.
+func (p *TimestampRestorePolicy) Validate() error {
+	if p == nil {
+		return nil
+	}
+	return p.BaseRestorePolicy.Validate()
+}
+
+func (p *BaseRestorePolicy) validateExistingRecordPolicy() error {
 	if p.Replace != nil && *p.Replace && p.Unique != nil && *p.Unique {
 		return errValidationMutuallyExclusive("replace", "unique")
 	}
@@ -145,7 +174,7 @@ func (p *RestorePolicy) validateExistingRecordPolicy() error {
 	return nil
 }
 
-func (p *RestorePolicy) ToModel() *model.RestorePolicy {
+func (p *BaseRestorePolicy) ToModel() *model.RestorePolicy {
 	if p == nil {
 		return &model.RestorePolicy{}
 	}
@@ -169,8 +198,24 @@ func (p *RestorePolicy) ToModel() *model.RestorePolicy {
 		Bandwidth:          p.Bandwidth,
 		Tps:                p.Tps,
 		EncryptionPolicy:   p.EncryptionPolicy.ToModel(),
-		CompressionPolicy:  p.CompressionPolicy.ToModel(),
 		RetryPolicy:        p.RetryPolicy.ToModel(),
 		ExtraTTL:           p.ExtraTTL,
 	}
+}
+
+func (p *RestorePolicy) ToModel() *model.RestorePolicy {
+	if p == nil {
+		return nil
+	}
+
+	m := p.BaseRestorePolicy.ToModel()
+	m.CompressionPolicy = p.CompressionPolicy.ToModel()
+	return m
+}
+
+func (p *TimestampRestorePolicy) ToModel() *model.RestorePolicy {
+	if p == nil {
+		return nil
+	}
+	return p.BaseRestorePolicy.ToModel()
 }

--- a/pkg/dto/restore_policy.go
+++ b/pkg/dto/restore_policy.go
@@ -64,6 +64,7 @@ type RestorePolicy struct {
 	// Encryption details (algorithm and key). Default is no encryption.
 	EncryptionPolicy *EncryptionPolicy `yaml:"encryption,omitempty" json:"encryption,omitempty"`
 	// Compression details (algorithm). Default is no compression.
+	// This field is ignored during point-in-time restores as the system automatically detects compression.
 	CompressionPolicy *CompressionPolicy `yaml:"compression,omitempty" json:"compression,omitempty"`
 	// Configuration of retries for each restore write operation.
 	// If nil, the default policy is used (5 retries with a one-minute delay between attempts).

--- a/pkg/dto/restore_policy_test.go
+++ b/pkg/dto/restore_policy_test.go
@@ -9,22 +9,24 @@ import (
 
 func TestRestorePolicy_ValidPolicy(t *testing.T) {
 	policy := &RestorePolicy{
-		Parallel:           ptr.Of(8),
-		TotalTimeout:       ptr.Of(int64(2000)),
-		SocketTimeout:      ptr.Of(int64(1000)),
-		MaxAsyncBatches:    ptr.Of(32),
-		BatchSize:          ptr.Of(128),
-		Bandwidth:          ptr.Of(int64(50000)),
-		Tps:                ptr.Of(4000),
-		Replace:            ptr.Of(true),
-		NoGeneration:       ptr.Of(false),
-		ExtraTTL:           ptr.Of(int64(86400)),
-		DisableBatchWrites: ptr.Of(false),
-		NoRecords:          ptr.Of(false),
-		NoIndexes:          ptr.Of(false),
-		NoUdfs:             ptr.Of(false),
-		SetList:            []string{"set1", "set2"},
-		BinList:            []string{"bin1", "bin2"},
+		BaseRestorePolicy: BaseRestorePolicy{
+			Parallel:           ptr.Of(8),
+			TotalTimeout:       ptr.Of(int64(2000)),
+			SocketTimeout:      ptr.Of(int64(1000)),
+			MaxAsyncBatches:    ptr.Of(32),
+			BatchSize:          ptr.Of(128),
+			Bandwidth:          ptr.Of(int64(50000)),
+			Tps:                ptr.Of(4000),
+			Replace:            ptr.Of(true),
+			NoGeneration:       ptr.Of(false),
+			ExtraTTL:           ptr.Of(int64(86400)),
+			DisableBatchWrites: ptr.Of(false),
+			NoRecords:          ptr.Of(false),
+			NoIndexes:          ptr.Of(false),
+			NoUdfs:             ptr.Of(false),
+			SetList:            []string{"set1", "set2"},
+			BinList:            []string{"bin1", "bin2"},
+		},
 	}
 	err := policy.Validate()
 	assert.NoError(t, err)
@@ -38,7 +40,9 @@ func TestRestorePolicy_NilPolicy(t *testing.T) {
 
 func TestRestorePolicy_InvalidTotalTimeout(t *testing.T) {
 	policy := &RestorePolicy{
-		TotalTimeout: ptr.Of(int64(-1)),
+		BaseRestorePolicy: BaseRestorePolicy{
+			TotalTimeout: ptr.Of(int64(-1)),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -48,7 +52,9 @@ func TestRestorePolicy_InvalidTotalTimeout(t *testing.T) {
 
 func TestRestorePolicy_InvalidSocketTimeout(t *testing.T) {
 	policy := &RestorePolicy{
-		SocketTimeout: ptr.Of(int64(-1)),
+		BaseRestorePolicy: BaseRestorePolicy{
+			SocketTimeout: ptr.Of(int64(-1)),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -58,7 +64,9 @@ func TestRestorePolicy_InvalidSocketTimeout(t *testing.T) {
 
 func TestRestorePolicy_SocketTimeoutZero(t *testing.T) {
 	policy := &RestorePolicy{
-		SocketTimeout: ptr.Of(int64(0)),
+		BaseRestorePolicy: BaseRestorePolicy{
+			SocketTimeout: ptr.Of(int64(0)),
+		},
 	}
 	err := policy.Validate()
 	assert.NoError(t, err)
@@ -66,7 +74,9 @@ func TestRestorePolicy_SocketTimeoutZero(t *testing.T) {
 
 func TestRestorePolicy_InvalidParallel(t *testing.T) {
 	policy := &RestorePolicy{
-		Parallel: ptr.Of(0),
+		BaseRestorePolicy: BaseRestorePolicy{
+			Parallel: ptr.Of(0),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -76,7 +86,9 @@ func TestRestorePolicy_InvalidParallel(t *testing.T) {
 
 func TestRestorePolicy_InvalidMaxAsyncBatches(t *testing.T) {
 	policy := &RestorePolicy{
-		MaxAsyncBatches: ptr.Of(0),
+		BaseRestorePolicy: BaseRestorePolicy{
+			MaxAsyncBatches: ptr.Of(0),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -86,7 +98,9 @@ func TestRestorePolicy_InvalidMaxAsyncBatches(t *testing.T) {
 
 func TestRestorePolicy_InvalidBatchSize(t *testing.T) {
 	policy := &RestorePolicy{
-		BatchSize: ptr.Of(0),
+		BaseRestorePolicy: BaseRestorePolicy{
+			BatchSize: ptr.Of(0),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -96,7 +110,9 @@ func TestRestorePolicy_InvalidBatchSize(t *testing.T) {
 
 func TestRestorePolicy_InvalidBandwidth(t *testing.T) {
 	policy := &RestorePolicy{
-		Bandwidth: ptr.Of(int64(-1)),
+		BaseRestorePolicy: BaseRestorePolicy{
+			Bandwidth: ptr.Of(int64(-1)),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -106,7 +122,9 @@ func TestRestorePolicy_InvalidBandwidth(t *testing.T) {
 
 func TestRestorePolicy_InvalidTps(t *testing.T) {
 	policy := &RestorePolicy{
-		Tps: ptr.Of(0),
+		BaseRestorePolicy: BaseRestorePolicy{
+			Tps: ptr.Of(0),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -116,8 +134,10 @@ func TestRestorePolicy_InvalidTps(t *testing.T) {
 
 func TestRestorePolicy_MutuallyExclusiveReplaceUnique(t *testing.T) {
 	policy := &RestorePolicy{
-		Replace: ptr.Of(true),
-		Unique:  ptr.Of(true),
+		BaseRestorePolicy: BaseRestorePolicy{
+			Replace: ptr.Of(true),
+			Unique:  ptr.Of(true),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)
@@ -128,7 +148,9 @@ func TestRestorePolicy_MutuallyExclusiveReplaceUnique(t *testing.T) {
 
 func TestRestorePolicy_InvalidExtraTTL(t *testing.T) {
 	policy := &RestorePolicy{
-		ExtraTTL: ptr.Of(int64(-1)),
+		BaseRestorePolicy: BaseRestorePolicy{
+			ExtraTTL: ptr.Of(int64(-1)),
+		},
 	}
 	err := policy.Validate()
 	assert.Error(t, err)

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -105,13 +105,18 @@ func (r *RestoreTimestampRequest) Validate(opts ...ValidationOption) error {
 }
 
 func (r *RestoreTimestampRequest) ToModel(config *model.Config) (*model.RestoreTimestampRequest, error) {
+	routine, found := config.Routine(r.Routine)
+	if !found {
+		return nil, errValidationNotFound("routine", r.Routine)
+	}
+
 	cluster, err := r.DestinationClusterConfig.ToModel(config)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cluster: %w", err)
 	}
-	routine, found := config.Routine(r.Routine)
-	if !found {
-		return nil, errValidationNotFound("routine", r.Routine)
+
+	if cluster == nil { // if cluster is not specified, use routine's cluster.
+		cluster = routine.SourceCluster
 	}
 
 	secretAgent, err := r.SecretAgentConfig.ToModel(config)
@@ -165,6 +170,10 @@ type DestinationClusterConfig struct {
 	Name string `json:"destination-name,omitempty" extensions:"x-nullable"`
 }
 
+func (c *DestinationClusterConfig) IsEmpty() bool {
+	return c.Name == "" && c.Cluster == nil
+}
+
 func (c *DestinationClusterConfig) Validate(opts ...ValidationOption) error {
 	if c.Cluster == nil && c.Name == "" && !slices.Contains(opts, ValidationAllowEmpty) {
 		return errValidationRequiredEither("destination", "destination-name")
@@ -182,6 +191,10 @@ func (c *DestinationClusterConfig) Validate(opts ...ValidationOption) error {
 }
 
 func (c *DestinationClusterConfig) ToModel(config *model.Config) (*model.AerospikeCluster, error) {
+	if c.IsEmpty() {
+		return nil, nil
+	}
+
 	if c.Cluster != nil {
 		return c.Cluster.ToModel(config)
 	}

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -42,7 +42,7 @@ type RestoreTimestampRequest struct {
 	DestinationClusterConfig
 	*SecretAgentConfig
 	// Restore policy to use in the operation.
-	Policy *RestorePolicy `json:"policy,omitempty"`
+	Policy *TimestampRestorePolicy `json:"policy,omitempty"`
 	// Required epoch time (in millis) for recovery. The closest backup before the timestamp will be applied.
 	Time int64 `json:"time" format:"int64" example:"1739538000000" validate:"required" minimum:"1000000000000"`
 	// The backup routine name.

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
@@ -80,7 +81,8 @@ func (r *RestoreRequest) Validate(opts ...ValidationOption) error {
 
 // Validate validates the restore operation request.
 func (r *RestoreTimestampRequest) Validate(opts ...ValidationOption) error {
-	if err := r.DestinationClusterConfig.Validate(opts...); err != nil {
+	// If no cluster is specified, routine's cluster will be used.
+	if err := r.DestinationClusterConfig.Validate(append(opts, ValidationAllowEmpty)...); err != nil {
 		return err
 	}
 	if err := r.Policy.Validate(); err != nil {
@@ -164,7 +166,7 @@ type DestinationClusterConfig struct {
 }
 
 func (c *DestinationClusterConfig) Validate(opts ...ValidationOption) error {
-	if c.Cluster == nil && c.Name == "" {
+	if c.Cluster == nil && c.Name == "" && !slices.Contains(opts, ValidationAllowEmpty) {
 		return errValidationRequiredEither("destination", "destination-name")
 	}
 	if c.Cluster != nil && c.Name != "" {

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -123,6 +123,9 @@ func (r *RestoreTimestampRequest) ToModel(config *model.Config) (*model.RestoreT
 	if err != nil {
 		return nil, fmt.Errorf("invalid secret agent: %w", err)
 	}
+	if secretAgent == nil {
+		secretAgent = routine.SecretAgent // use routine's secret agent if not specified.
+	}
 
 	return &model.RestoreTimestampRequest{
 		DestinationCluster: cluster,

--- a/pkg/dto/restore_request_test.go
+++ b/pkg/dto/restore_request_test.go
@@ -259,7 +259,7 @@ func TestRestoreTimestampRequest_Validate(t *testing.T) {
 	validCluster := &AerospikeCluster{
 		SeedNodes: []SeedNode{{HostName: "host", Port: 80}},
 	}
-	validPolicy := &RestorePolicy{}
+	validPolicy := &TimestampRestorePolicy{}
 
 	tests := []struct {
 		name    string
@@ -476,7 +476,7 @@ func TestRestoreTimestampRequest_ToModel(t *testing.T) {
 				},
 				Time:    1739538000000,
 				Routine: "daily",
-				Policy:  &RestorePolicy{},
+				Policy:  &TimestampRestorePolicy{},
 			},
 			want: &model.RestoreTimestampRequest{
 				DestinationCluster: cluster,

--- a/pkg/dto/restore_request_test.go
+++ b/pkg/dto/restore_request_test.go
@@ -57,6 +57,12 @@ func TestDestinationClusterConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestDestinationClusterConfig_Validate_AllowEmpty(t *testing.T) {
+	config := DestinationClusterConfig{}
+	err := config.Validate(ValidationAllowEmpty)
+	require.NoError(t, err)
+}
+
 func TestStorageConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -313,7 +319,6 @@ func TestRestoreTimestampRequest_Validate(t *testing.T) {
 				Policy:  validPolicy,
 				Routine: "daily",
 			},
-			err: errRequiredEither,
 		},
 		{
 			name: "valid request",

--- a/pkg/dto/validate_options.go
+++ b/pkg/dto/validate_options.go
@@ -5,4 +5,5 @@ type ValidationOption int
 
 const (
 	ValidationSkipTLSFiles ValidationOption = iota
+	ValidationAllowEmpty
 )

--- a/pkg/dto/validation_duplicate_test.go
+++ b/pkg/dto/validation_duplicate_test.go
@@ -76,14 +76,18 @@ func TestRestorePolicy_Validate_Duplicates(t *testing.T) {
 		{
 			name: "duplicate set-list",
 			policy: &RestorePolicy{
-				SetList: []string{"set1", "set1"},
+				BaseRestorePolicy: BaseRestorePolicy{
+					SetList: []string{"set1", "set1"},
+				},
 			},
 			wantErr: "set-list contains duplicate value",
 		},
 		{
 			name: "duplicate bin-list",
 			policy: &RestorePolicy{
-				BinList: []string{"bin1", "bin1"},
+				BaseRestorePolicy: BaseRestorePolicy{
+					BinList: []string{"bin1", "bin1"},
+				},
 			},
 			wantErr: "bin-list contains duplicate value",
 		},

--- a/pkg/model/compression_policy.go
+++ b/pkg/model/compression_policy.go
@@ -5,5 +5,7 @@ type CompressionPolicy struct {
 	// The compression mode to be used (default is NONE).
 	Mode string
 	// The compression level to use (or -1 if unspecified).
+	// This field is ignored if the compression mode is NONE.
+	// This field is ignored during restoration.
 	Level int32
 }

--- a/pkg/model/restore_policy.go
+++ b/pkg/model/restore_policy.go
@@ -55,6 +55,7 @@ type RestorePolicy struct {
 	// Encryption details.
 	EncryptionPolicy *EncryptionPolicy
 	// Compression details.
+	// This field is ignored during point-in-time restores as the system automatically detects compression.
 	CompressionPolicy *CompressionPolicy
 	// Configuration of retries for each restore write operation.
 	RetryPolicy *RetryPolicy

--- a/pkg/service/restore_data.go
+++ b/pkg/service/restore_data.go
@@ -260,6 +260,10 @@ func (r *dataRestorer) restoreByTimeSync(
 		return err
 	}
 
+	if err := validateEncryption(backupsByNamespace, request); err != nil {
+		return err
+	}
+
 	client, err := r.clientManager.GetClient(ctx, request.DestinationCluster, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get client for cluster %s: %w",
@@ -294,6 +298,41 @@ func (r *dataRestorer) restoreByTimeSync(
 	wg.Wait()
 
 	return multiError
+}
+
+func validateEncryption(
+	backupsByNamespace map[string][]model.BackupDetails,
+	request *model.RestoreTimestampRequest,
+) error {
+	for _, backups := range backupsByNamespace {
+		for _, b := range backups {
+			if b.Encryption != "" && b.Encryption != model.EncryptNone { // Backup is encrypted
+				// Check if user provided an encryption policy in the request
+				if request.Policy == nil || request.Policy.EncryptionPolicy == nil {
+					return fmt.Errorf("backup is encrypted with mode '%s', "+
+						"but no encryption policy was provided in the restore request", b.Encryption)
+				}
+
+				userEncryptionPolicy := request.Policy.EncryptionPolicy
+
+				// Check if the provided encryption mode matches the backup's encryption mode
+				if userEncryptionPolicy.Mode != b.Encryption {
+					return fmt.Errorf("backup is encrypted with mode '%s', "+
+						"but the provided encryption policy specifies mode '%s'", b.Encryption, userEncryptionPolicy.Mode)
+				}
+
+				// Check if an encryption key is provided
+				if userEncryptionPolicy.KeyFile == nil &&
+					userEncryptionPolicy.KeyEnv == nil &&
+					userEncryptionPolicy.KeySecret == nil {
+					return fmt.Errorf("backup is encrypted, " +
+						"but no encryption key (KeyFile, KeyEnv, or KeySecret) was provided in the encryption policy")
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (r *dataRestorer) restoreNamespace(
@@ -336,6 +375,11 @@ func (r *dataRestorer) restoreNamespace(
 			slog.Any("backup", b))
 		if b.FileCount == 0 { // skip empty namespaces
 			continue
+		}
+
+		// for restore by time we can extract compression from metadata
+		effectivePolicy.CompressionPolicy = &model.CompressionPolicy{
+			Mode: b.Compression,
 		}
 
 		handler, err := r.restoreFromPath(ctx, client, request, b.Key, b.Storage, &effectivePolicy)

--- a/pkg/service/restore_data.go
+++ b/pkg/service/restore_data.go
@@ -264,10 +264,15 @@ func (r *dataRestorer) restoreByTimeSync(
 		return err
 	}
 
-	client, err := r.clientManager.GetClient(ctx, request.DestinationCluster, logger)
+	var effectiveCluster = request.DestinationCluster
+	if effectiveCluster == nil {
+		effectiveCluster = request.Routine.SourceCluster
+	}
+
+	client, err := r.clientManager.GetClient(ctx, effectiveCluster, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get client for cluster %s: %w",
-			ptr.ValueOrZero(request.DestinationCluster.ClusterLabel), err)
+			ptr.ValueOrZero(effectiveCluster.ClusterLabel), err)
 	}
 	defer r.clientManager.Close(client)
 

--- a/pkg/service/restore_data.go
+++ b/pkg/service/restore_data.go
@@ -264,15 +264,10 @@ func (r *dataRestorer) restoreByTimeSync(
 		return err
 	}
 
-	var effectiveCluster = request.DestinationCluster
-	if effectiveCluster == nil {
-		effectiveCluster = request.Routine.SourceCluster
-	}
-
-	client, err := r.clientManager.GetClient(ctx, effectiveCluster, logger)
+	client, err := r.clientManager.GetClient(ctx, request.DestinationCluster, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get client for cluster %s: %w",
-			ptr.ValueOrZero(effectiveCluster.ClusterLabel), err)
+			ptr.ValueOrZero(request.DestinationCluster.ClusterLabel), err)
 	}
 	defer r.clientManager.Close(client)
 

--- a/pkg/service/restore_data_test.go
+++ b/pkg/service/restore_data_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/restoreexecutor"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/aerospike/backup-go/mocks"
 	"github.com/aerospike/backup-go/models"
 	"github.com/stretchr/testify/assert"
@@ -366,4 +367,111 @@ func (env *testRestoreEnv) expectSuccessfulClientInteraction(
 		Times(1)
 
 	return client
+}
+
+func TestRestoreByTime_CompressionAndEncryptionHandling(t *testing.T) {
+	tests := []struct {
+		name              string
+		policy            *model.RestorePolicy
+		backupEncryption  string
+		backupCompression string
+		shouldSucceed     bool
+	}{
+		{
+			name:              "sets compression policy from backup",
+			policy:            &model.RestorePolicy{},
+			backupCompression: "ZSTD",
+			shouldSucceed:     true,
+		},
+		{
+			name:             "fails when encrypted backup has no policy",
+			policy:           nil,
+			backupEncryption: "AES128",
+			shouldSucceed:    false,
+		},
+		{
+			name: "fails when encryption mode mismatches",
+			policy: &model.RestorePolicy{
+				EncryptionPolicy: &model.EncryptionPolicy{Mode: "AES256"},
+			},
+			backupEncryption: "AES128",
+			shouldSucceed:    false,
+		},
+		{
+			name: "fails when encryption key is missing",
+			policy: &model.RestorePolicy{
+				EncryptionPolicy: &model.EncryptionPolicy{Mode: "AES128"},
+			},
+			backupEncryption: "AES128",
+			shouldSucceed:    false,
+		},
+		{
+			name: "succeeds with valid encryption policy",
+			policy: &model.RestorePolicy{
+				EncryptionPolicy: &model.EncryptionPolicy{
+					Mode:   "AES128",
+					KeyEnv: ptr.Of("AES_KEY"),
+				},
+			},
+			backupEncryption: "AES128",
+			shouldSucceed:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := setupTestRestoreEnv(t)
+			defer env.ctrl.Finish()
+
+			request := &model.RestoreTimestampRequest{
+				DestinationCluster: &model.AerospikeCluster{},
+				Policy:             tt.policy,
+				Routine:            &model.BackupRoutine{Name: "test-routine"},
+				Time:               time.Now(),
+				DisableReordering:  true,
+			}
+
+			backup := model.BackupDetails{
+				BackupMetadata: model.BackupMetadata{
+					Created:     time.Now().Add(-1 * time.Hour),
+					Namespace:   "ns1",
+					Encryption:  tt.backupEncryption,
+					Compression: tt.backupCompression,
+					FileCount:   1,
+				},
+				Key:     "backup/path/test",
+				Storage: &model.LocalStorage{},
+			}
+
+			env.mockBackupReader.EXPECT().
+				GetBackups(gomock.Any(), gomock.Any()).
+				Return([]model.BackupDetails{backup}, nil).
+				Times(2)
+
+			if tt.shouldSucceed {
+				client := env.expectSuccessfulClientInteraction(t, request.DestinationCluster)
+				mockRestoreHandler := restoreexecutor.NewMockRestoreHandler(env.ctrl)
+				mockRestoreHandler.EXPECT().Wait(gomock.Any()).Return(nil).AnyTimes()
+				mockRestoreHandler.EXPECT().GetStats().Return(models.NewRestoreStats()).AnyTimes()
+				mockRestoreHandler.EXPECT().GetMetrics().Return(&models.Metrics{}).AnyTimes()
+
+				env.mockRestore.EXPECT().
+					Run(gomock.Any(), client, gomock.Any()).
+					Return(mockRestoreHandler, nil).AnyTimes()
+			}
+
+			jobID, err := env.restoreManager.RestoreByTime(context.Background(), request)
+			require.NoError(t, err)
+
+			jobStatus, err := waitForRestore(t, env.restoreManager, jobID)
+			require.NoError(t, err)
+
+			if tt.shouldSucceed {
+				assert.Equal(t, model.JobStatusDone, jobStatus.Status)
+			} else {
+				assert.Equal(t, model.JobStatusFailed, jobStatus.Status)
+				assert.NotNil(t, jobStatus.Error)
+			}
+		})
+	}
 }


### PR DESCRIPTION
1.   Users are no longer presented with ignored fields (CompressionPolicy in timestamp restores, Level in restore compression).
2. Optional Destination Cluster: DestinationCluster/Secret Agent in RestoreTimestampRequest is now optional. If omitted, the operation defaults to restoring to the routine's.
3. Synchronously validate that Encryption is set for encrypted backups before start restore