### PR TITLE
Improve HTTP server lifecycle handling

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -191,11 +191,22 @@ func runHTTPServer(
 	ctx context.Context, serverConfig *model.HTTPServerConfig, service *handlers.Service, logger *slog.Logger,
 ) error {
 	httpServer := server.NewHTTPServer(serverConfig, service, logger)
+
+	// Channel to capture server startup errors
+	errCh := make(chan error, 1)
 	go func() {
-		httpServer.Start()
+		if err := httpServer.Start(); err != nil {
+			errCh <- err
+		}
 	}()
 
-	<-ctx.Done()
+	// Wait for either context cancellation or server error
+	select {
+	case err := <-errCh:
+		return fmt.Errorf("HTTP server failed: %w", err)
+	case <-ctx.Done():
+	}
+
 	time.Sleep(time.Millisecond * 100) // wait for other goroutines to exit
 	// shutdown the HTTP server gracefully
 	if err := httpServer.Shutdown(); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,10 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
+	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/middleware"
@@ -13,7 +14,8 @@ import (
 )
 
 const (
-	restAPIVersion = "v1"
+	restAPIVersion  = "v1"
+	shutdownTimeout = 30 * time.Second
 )
 
 // HTTPServer is the backup service HTTP server wrapper.
@@ -46,17 +48,19 @@ func NewHTTPServer(serverConfig *model.HTTPServerConfig, service *handlers.Servi
 	}
 }
 
-// Start starts the HTTP server.
-func (s *HTTPServer) Start() {
+// Start starts the HTTP server. Returns an error if the server fails to start.
+func (s *HTTPServer) Start() error {
 	err := s.server.ListenAndServe()
-	if err != nil && strings.Contains(err.Error(), "Server closed") {
+	if errors.Is(err, http.ErrServerClosed) {
 		slog.Info(err.Error())
-	} else {
-		panic(err)
+		return nil
 	}
+	return err
 }
 
-// Shutdown shutdowns the HTTP server.
+// Shutdown shuts down the HTTP server gracefully with a timeout.
 func (s *HTTPServer) Shutdown() error {
-	return s.server.Shutdown(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	return s.server.Shutdown(ctx)
 }


### PR DESCRIPTION
* Change `Start()` to return `error` instead of panicking
* Use `errors.Is(err, http.ErrServerClosed)` instead of string matching
* Update `Shutdown()` to use `context.WithTimeout`
* Capture startup errors in `runHTTPServer()`