### PR TITLE
BKRS-77 Truncate timestamp to millis

### DIFF
--- a/pkg/model/backup_details.go
+++ b/pkg/model/backup_details.go
@@ -87,7 +87,7 @@ func NewBackupMetadata(
 	return BackupMetadata{
 		From:                from,
 		Created:             startTime,
-		Finished:            time.Now(),
+		Finished:            time.Now().Truncate(time.Millisecond), // ABS supports only millisecond accuracy
 		Namespace:           namespace,
 		RecordCount:         stats.GetReadRecords(),
 		FileCount:           stats.GetFileCount(),

--- a/pkg/model/backup_details.go
+++ b/pkg/model/backup_details.go
@@ -87,7 +87,7 @@ func NewBackupMetadata(
 	return BackupMetadata{
 		From:                from,
 		Created:             startTime,
-		Finished:            time.Now().Truncate(time.Millisecond), // ABS supports only millisecond accuracy
+		Finished:            time.Now().Truncate(time.Millisecond), // ABS supports only millisecond accuracy.
 		Namespace:           namespace,
 		RecordCount:         stats.GetReadRecords(),
 		FileCount:           stats.GetFileCount(),

--- a/pkg/service/backup_job.go
+++ b/pkg/service/backup_job.go
@@ -38,7 +38,7 @@ func (j *backupJob) Execute(ctx context.Context) error {
 		return errors.New("failed to retrieve job metadata from context. " +
 			"Use quartz.WithJobMetadata() option when initializing the scheduler")
 	}
-	now := time.Unix(0, jobMetadata.RunTime).Truncate(time.Millisecond) // ABS supports only millisecond accuracy.
+	now := time.Unix(0, jobMetadata.RunTime).Truncate(time.Millisecond)
 
 	if j.isRunning.CompareAndSwap(false, true) {
 		defer j.isRunning.Store(false)

--- a/pkg/service/backup_job.go
+++ b/pkg/service/backup_job.go
@@ -38,7 +38,7 @@ func (j *backupJob) Execute(ctx context.Context) error {
 		return errors.New("failed to retrieve job metadata from context. " +
 			"Use quartz.WithJobMetadata() option when initializing the scheduler")
 	}
-	now := time.Unix(0, jobMetadata.RunTime).Truncate(time.Millisecond)
+	now := time.Unix(0, jobMetadata.RunTime).Truncate(time.Millisecond) // ABS supports only millisecond accuracy.
 
 	if j.isRunning.CompareAndSwap(false, true) {
 		defer j.isRunning.Store(false)

--- a/pkg/service/jobs_holder.go
+++ b/pkg/service/jobs_holder.go
@@ -55,7 +55,7 @@ type restoreJob struct {
 func newRestoreJob(label string, cancel context.CancelFunc) *restoreJob {
 	return &restoreJob{
 		status:  model.JobStatusRunning,
-		started: time.Now(),
+		started: time.Now().Truncate(time.Millisecond),
 		label:   label,
 		cancel:  cancel,
 	}
@@ -82,7 +82,7 @@ func (j *restoreJob) finish(err error) {
 	j.Lock()
 	defer j.Unlock()
 
-	j.finished = ptr.Of(time.Now())
+	j.finished = ptr.Of(time.Now().Truncate(time.Millisecond))
 	j.err = err
 
 	switch {


### PR DESCRIPTION
Backup job .start was already truncated (pkg/service/backup_job.go:41)
This PR adds truncation to backup finish and restore start/finish.