### PR TITLE
BKRS-101 Align log messages

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -55,7 +55,7 @@ func run() int {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		slog.Error("Error in rootCmd.Execute", attr.Error(err))
+		slog.Error("Command execution failed", attr.Error(err))
 	}
 
 	return log.ToExitVal(err)
@@ -108,7 +108,7 @@ func runHTTPServer(ctx context.Context, service *handlers.Service) error {
 		return err
 	}
 
-	slog.Info("HTTP server shutdown gracefully")
+	slog.Info("HTTP server shut down gracefully")
 
 	return nil
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -684,13 +684,13 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified cluster could not be found",
+                        "description": "The specified cluster was not found",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "500": {
-                        "description": "The specified cluster could not be found",
+                        "description": "The specified cluster was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -871,13 +871,13 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified policy could not be found",
+                        "description": "The specified policy was not found",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "500": {
-                        "description": "The specified policy could not be found",
+                        "description": "The specified policy was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -1052,7 +1052,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified routine could not be found",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -1291,7 +1291,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified storage could not be found",
+                        "description": "The specified storage was not found",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -117,13 +117,7 @@ const docTemplate = `{
                         "description": "Accepted"
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -164,13 +158,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -219,12 +207,6 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -280,12 +262,6 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             },
@@ -321,13 +297,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -376,12 +346,6 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -437,12 +401,6 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             },
@@ -478,13 +436,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -527,13 +479,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -556,12 +502,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/dto.Config"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
                         }
                     }
                 }
@@ -641,12 +581,6 @@ const docTemplate = `{
                                 "$ref": "#/definitions/dto.AerospikeCluster"
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             }
@@ -684,12 +618,6 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified cluster was not found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
                         "description": "The specified cluster was not found",
                         "schema": {
                             "type": "string"
@@ -772,12 +700,6 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             },
@@ -828,12 +750,6 @@ const docTemplate = `{
                                 "$ref": "#/definitions/dto.BackupPolicy"
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             }
@@ -871,12 +787,6 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "The specified policy was not found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
                         "description": "The specified policy was not found",
                         "schema": {
                             "type": "string"
@@ -1186,13 +1096,7 @@ const docTemplate = `{
                         "description": "Routine successfully disabled."
                     },
                     "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Unexpected error occurred.",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -1221,7 +1125,7 @@ const docTemplate = `{
                         "description": "Routine successfully enabled."
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "The specified routine was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -1247,12 +1151,6 @@ const docTemplate = `{
                             "additionalProperties": {
                                 "$ref": "#/definitions/dto.Storage"
                             }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
                         }
                     }
                 }
@@ -1292,12 +1190,6 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "The specified storage was not found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -1441,13 +1333,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Job not found",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
+                        "description": "The specified restore job was not found",
                         "schema": {
                             "type": "string"
                         }
@@ -1588,12 +1474,6 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "string"
-                        }
                     }
                 }
             }
@@ -1627,6 +1507,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "The specified restore job was not found",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -825,7 +825,7 @@
                         }
                     },
                     "404": {
-                        "description": "The specified cluster could not be found",
+                        "description": "The specified cluster was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -835,7 +835,7 @@
                         }
                     },
                     "500": {
-                        "description": "The specified cluster could not be found",
+                        "description": "The specified cluster was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1036,7 +1036,7 @@
                         }
                     },
                     "404": {
-                        "description": "The specified policy could not be found",
+                        "description": "The specified policy was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1046,7 +1046,7 @@
                         }
                     },
                     "500": {
-                        "description": "The specified policy could not be found",
+                        "description": "The specified policy was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1237,7 +1237,7 @@
                         }
                     },
                     "404": {
-                        "description": "The specified routine could not be found",
+                        "description": "The specified routine was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1508,7 +1508,7 @@
                         }
                     },
                     "404": {
-                        "description": "The specified storage could not be found",
+                        "description": "The specified storage was not found",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -112,17 +112,7 @@
                         "description": "Accepted"
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -174,17 +164,7 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -242,16 +222,6 @@
                     },
                     "400": {
                         "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -322,16 +292,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             },
@@ -375,17 +335,7 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -443,16 +393,6 @@
                     },
                     "400": {
                         "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -523,16 +463,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             },
@@ -576,17 +506,7 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -641,17 +561,7 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -677,16 +587,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/dto.Config"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
                                 }
                             }
                         }
@@ -771,16 +671,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -825,16 +715,6 @@
                         }
                     },
                     "404": {
-                        "description": "The specified cluster was not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
                         "description": "The specified cluster was not found",
                         "content": {
                             "application/json": {
@@ -915,16 +795,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             },
@@ -982,16 +852,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -1036,16 +896,6 @@
                         }
                     },
                     "404": {
-                        "description": "The specified policy was not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
                         "description": "The specified policy was not found",
                         "content": {
                             "application/json": {
@@ -1377,17 +1227,7 @@
                         "description": "Routine successfully disabled."
                     },
                     "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Unexpected error occurred.",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -1422,7 +1262,7 @@
                         "description": "Routine successfully enabled."
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "The specified routine was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -1451,16 +1291,6 @@
                                     "additionalProperties": {
                                         "$ref": "#/components/schemas/dto.Storage"
                                     }
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
                                 }
                             }
                         }
@@ -1509,16 +1339,6 @@
                     },
                     "404": {
                         "description": "The specified storage was not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1676,17 +1496,7 @@
                         }
                     },
                     "404": {
-                        "description": "Job not found",
-                        "content": {
-                            "*/*": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error",
+                        "description": "The specified restore job was not found",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -1846,16 +1656,6 @@
                                 }
                             }
                         }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        }
                     }
                 }
             }
@@ -1892,6 +1692,16 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified restore job was not found",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/internal/log/slog_level_logger.go
+++ b/internal/log/slog_level_logger.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+)
+
+// NewMinLevelLogger returns a logger that forwards records at or above minLevel.
+// It reuses the same underlying handler chain as the base logger.
+func NewMinLevelLogger(base *slog.Logger, minLevel slog.Level) *slog.Logger {
+	return slog.New(&minLevelHandler{
+		minLevel: minLevel,
+		base:     base.Handler(),
+	})
+}
+
+type minLevelHandler struct {
+	minLevel slog.Level
+	base     slog.Handler
+}
+
+func (h *minLevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if level < h.minLevel {
+		return false
+	}
+
+	return h.base.Enabled(ctx, level)
+}
+
+func (h *minLevelHandler) Handle(ctx context.Context, record slog.Record) error {
+	return h.base.Handle(ctx, record)
+}
+
+func (h *minLevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &minLevelHandler{
+		minLevel: h.minLevel,
+		base:     h.base.WithAttrs(attrs),
+	}
+}
+
+func (h *minLevelHandler) WithGroup(name string) slog.Handler {
+	return &minLevelHandler{
+		minLevel: h.minLevel,
+		base:     h.base.WithGroup(name),
+	}
+}

--- a/internal/server/handlers/backup.go
+++ b/internal/server/handlers/backup.go
@@ -218,7 +218,6 @@ func (s *Service) TriggerFullBackup(w http.ResponseWriter, r *http.Request) {
 // @Success     202
 // @Failure     400 {string} string
 // @Failure     404 {string} string
-// @Failure     500 {string} string
 func (s *Service) ScheduleFullBackup(w http.ResponseWriter, r *http.Request) {
 	s.scheduleBackup(w, r, service.NewAdHocFullBackupJobForRoutine)
 }
@@ -233,7 +232,6 @@ func (s *Service) ScheduleFullBackup(w http.ResponseWriter, r *http.Request) {
 // @Success  202
 // @Failure  400 {string} string
 // @Failure  404 {string} string
-// @Failure  500 {string} string
 func (s *Service) TriggerIncrementalBackup(w http.ResponseWriter, r *http.Request) {
 	s.scheduleBackup(w, r, service.NewAdHocIncrementalBackupJobForRoutine)
 }
@@ -294,7 +292,6 @@ func parseDelay(delayParameter string) (int, error) {
 // @Success  200 {object} dto.RoutineState "Current backup statistics"
 // @Failure  404 {string} string
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 func (s *Service) GetCurrentBackupInfo(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")
 	if routineName == "" {

--- a/internal/server/handlers/backup.go
+++ b/internal/server/handlers/backup.go
@@ -27,7 +27,6 @@ const minAdHocBackupDelay = 50 * time.Millisecond
 // @Router   /v1/backups/full [get]
 // @Success  200 {object} map[string][]dto.BackupDetails "Full backups by routine"
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 func (s *Service) GetAllFullBackups(w http.ResponseWriter, r *http.Request) {
 	timeBounds, err := dto.NewTimeBoundsFromString(r.URL.Query().Get("from"), r.URL.Query().Get("to"))
 	if err != nil {
@@ -57,7 +56,6 @@ func (s *Service) GetAllFullBackups(w http.ResponseWriter, r *http.Request) {
 // @Router   /v1/backups/full/{name} [get]
 // @Success  200 {object} []dto.BackupDetails "Full backups for routine"
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 func (s *Service) GetFullBackupsForRoutine(w http.ResponseWriter, r *http.Request) {
 	timeBounds, err := dto.NewTimeBoundsFromString(r.URL.Query().Get("from"), r.URL.Query().Get("to"))
 	if err != nil {
@@ -97,7 +95,6 @@ func (s *Service) GetFullBackupsForRoutine(w http.ResponseWriter, r *http.Reques
 // @Router   /v1/backups/incremental [get]
 // @Success  200 {object} map[string][]dto.BackupDetails "Incremental backups by routine"
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 func (s *Service) GetAllIncrementalBackups(w http.ResponseWriter, r *http.Request) {
 	timeBounds, err := dto.NewTimeBoundsFromString(r.URL.Query().Get("from"), r.URL.Query().Get("to"))
 	if err != nil {
@@ -127,7 +124,6 @@ func (s *Service) GetAllIncrementalBackups(w http.ResponseWriter, r *http.Reques
 // @Router   /v1/backups/incremental/{name} [get]
 // @Success  200 {object} []dto.BackupDetails "Incremental backups for routine"
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 func (s *Service) GetIncrementalBackupsForRoutine(w http.ResponseWriter, r *http.Request) {
 	timeBounds, err := dto.NewTimeBoundsFromString(r.URL.Query().Get("from"), r.URL.Query().Get("to"))
 	if err != nil {
@@ -200,8 +196,7 @@ func (s *Service) readBackupsForRoutine(
 // @Router   /v1/backups/full/{name} [post]
 // @Success  202
 // @Failure  400 {string} string
-// @Failure  404 {string} string
-// @Failure  500 {string} string
+// @Failure  404 {string} string "The specified routine was not found"
 func (s *Service) TriggerFullBackup(w http.ResponseWriter, r *http.Request) {
 	s.scheduleBackup(w, r, service.NewAdHocFullBackupJobForRoutine)
 }
@@ -217,7 +212,7 @@ func (s *Service) TriggerFullBackup(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/backups/schedule/{name} [post]
 // @Success     202
 // @Failure     400 {string} string
-// @Failure     404 {string} string
+// @Failure     404 {string} string "The specified routine was not found"
 func (s *Service) ScheduleFullBackup(w http.ResponseWriter, r *http.Request) {
 	s.scheduleBackup(w, r, service.NewAdHocFullBackupJobForRoutine)
 }
@@ -231,7 +226,7 @@ func (s *Service) ScheduleFullBackup(w http.ResponseWriter, r *http.Request) {
 // @Router   /v1/backups/incremental/{name} [post]
 // @Success  202
 // @Failure  400 {string} string
-// @Failure  404 {string} string
+// @Failure  404 {string} string "The specified routine was not found"
 func (s *Service) TriggerIncrementalBackup(w http.ResponseWriter, r *http.Request) {
 	s.scheduleBackup(w, r, service.NewAdHocIncrementalBackupJobForRoutine)
 }
@@ -290,7 +285,7 @@ func parseDelay(delayParameter string) (int, error) {
 // @Param    name path string true "Backup routine name"
 // @Router   /v1/backups/currentBackup/{name} [get]
 // @Success  200 {object} dto.RoutineState "Current backup statistics"
-// @Failure  404 {string} string
+// @Failure  404 {string} string "The specified routine was not found"
 // @Failure  400 {string} string
 func (s *Service) GetCurrentBackupInfo(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")
@@ -316,8 +311,7 @@ func (s *Service) GetCurrentBackupInfo(w http.ResponseWriter, r *http.Request) {
 // @Param    name path string true "Backup routine name"
 // @Router   /v1/backups/cancel/{name} [post]
 // @Success  202
-// @Failure  404 {string} string
-// @Failure  500 {string} string
+// @Failure  404 {string} string "The specified routine was not found"
 func (s *Service) CancelCurrentBackup(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")
 	if routineName == "" {

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -115,7 +115,7 @@ func (s *Service) changeConfig(ctx context.Context, updateFunc func(*model.Confi
 
 	err := updateFunc(s.config)
 	if err != nil {
-		return fmt.Errorf("cannot update configuration: %w", err)
+		return fmt.Errorf("failed to update configuration: %w", err)
 	}
 
 	err = s.configurationManager.Write(ctx, s.config)

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -22,7 +22,6 @@ func (s *Service) ConfigActionHandler(_ http.ResponseWriter, _ *http.Request) {
 // @Router      /v1/config [get]
 // @Produce     json
 // @Success     200 {object} dto.Config
-// @Failure     500 {string} string
 func (s *Service) ReadConfig(w http.ResponseWriter, _ *http.Request) {
 	httpOK(w, dto.NewConfigFromModel(s.config))
 }

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -19,7 +19,6 @@ import (
 // @Param       cluster body dto.AerospikeCluster true "Aerospike cluster details"
 // @Success     201
 // @Failure     400 {string} string
-// @Failure     500 {string} string
 func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {
@@ -76,8 +75,7 @@ func (s *Service) ReadAerospikeClusters(w http.ResponseWriter, _ *http.Request) 
 // @Produce     json
 // @Success  	200 {object} dto.AerospikeCluster
 // @Failure     400 {string} string
-// @Failure     404 {string} string "The specified cluster could not be found"
-// @Failure     500 {string} string "The specified cluster could not be found"
+// @Failure     404 {string} string "The specified cluster was not found"
 func (s *Service) ReadAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 	clusterName := r.PathValue("name")
 	if clusterName == "" {

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -54,7 +54,6 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/clusters [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.AerospikeCluster
-// @Failure     500 {string} string
 func (s *Service) ReadAerospikeClusters(w http.ResponseWriter, _ *http.Request) {
 	backupConfig := s.config.BackupConfigCopy()
 	clusters := dto.ConvertModelMapToDTO(

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -48,7 +48,6 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/policies [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.BackupPolicy
-// @Failure     500 {string} string
 func (s *Service) ReadPolicies(w http.ResponseWriter, _ *http.Request) {
 	policies := dto.ConvertModelMapToDTO(s.config.BackupConfigCopy().BackupPolicies, dto.NewBackupPolicyFromModel)
 	httpOK(w, policies)
@@ -63,8 +62,7 @@ func (s *Service) ReadPolicies(w http.ResponseWriter, _ *http.Request) {
 // @Produce     json
 // @Success  	200 {object} dto.BackupPolicy
 // @Response    400 {string} string
-// @Failure     404 {string} string "The specified policy could not be found"
-// @Failure     500 {string} string "The specified policy could not be found"
+// @Failure     404 {string} string "The specified policy was not found"
 func (s *Service) ReadPolicy(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if name == "" {

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -173,7 +173,7 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 // @ID          enableRoutine
 // @Param       name path string true "Backup routine name"
 // @Success     204 "Routine successfully enabled."
-// @Failure     404 {string} string
+// @Failure     404 {string} string "The specified routine was not found"
 // @Router      /v1/config/routines/{name}/enable [put]
 func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")
@@ -203,7 +203,7 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 // @ID          disableRoutine
 // @Param       name path string true "The name of the backup routine."
 // @Success     204 "Routine successfully disabled."
-// @Failure     404 {string} string
+// @Failure     404 {string} string "The specified routine was not found"
 // @Router      /v1/config/routines/{name}/disable [put]
 func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -79,7 +79,7 @@ func (s *Service) ReadRoutines(w http.ResponseWriter, _ *http.Request) {
 // @Produce     json
 // @Success  	200 {object} dto.BackupRoutine
 // @Response    400 {string} string
-// @Failure     404 {string} string "The specified routine could not be found"
+// @Failure     404 {string} string "The specified routine was not found"
 func (s *Service) ReadRoutine(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")
 	if routineName == "" {
@@ -204,7 +204,6 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 // @Param       name path string true "The name of the backup routine."
 // @Success     204 "Routine successfully disabled."
 // @Failure     404 {string} string
-// @Failure     500 {string} string "Unexpected error occurred."
 // @Router      /v1/config/routines/{name}/disable [put]
 func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 	routineName := r.PathValue("name")

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -53,7 +53,6 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/storage [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.Storage
-// @Failure     500 {string} string
 func (s *Service) ReadAllStorage(w http.ResponseWriter, _ *http.Request) {
 	backupConfig := s.config.BackupConfigCopy()
 	httpOK(w, dto.ConvertStorageMapToDTO(backupConfig.Storage, backupConfig))
@@ -68,8 +67,7 @@ func (s *Service) ReadAllStorage(w http.ResponseWriter, _ *http.Request) {
 // @Produce     json
 // @Success  	200 {object} dto.Storage
 // @Response    400 {string} string
-// @Failure     404 {string} string "The specified storage could not be found"
-// @Failure     500 {string} string
+// @Failure     404 {string} string "The specified storage was not found"
 func (s *Service) ReadStorage(w http.ResponseWriter, r *http.Request) {
 	storageName := r.PathValue("name")
 	if storageName == "" {

--- a/internal/server/handlers/errors.go
+++ b/internal/server/handlers/errors.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"mime"
 	"net/http"
 	"path/filepath"
 	"strconv"
 
-	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
@@ -73,19 +71,14 @@ func httpOK(w http.ResponseWriter, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		slog.Error("Error encoding JSON response", attr.Error(err))
-	}
+	_ = json.NewEncoder(w).Encode(data)
 }
 
 // httpAcceptedWithJobID responds with a job ID and 202 status.
 func httpAcceptedWithJobID(w http.ResponseWriter, jobID model.RestoreJobID) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
-	_, err := fmt.Fprintf(w, "%d", jobID)
-	if err != nil {
-		slog.Error("Error encoding job id response", attr.Error(err))
-	}
+	_, _ = fmt.Fprintf(w, "%d", jobID)
 }
 
 // httpAccepted responds with an empty 202 Accepted.
@@ -108,8 +101,5 @@ func httpContent(w http.ResponseWriter, buf []byte, filename string) {
 
 	w.WriteHeader(http.StatusOK)
 
-	if _, err := w.Write(buf); err != nil {
-		slog.Error("Error encoding writing response", attr.Error(err))
-		http.Error(w, "Failed to send file", http.StatusInternalServerError)
-	}
+	_, _ = w.Write(buf)
 }

--- a/internal/server/handlers/restore.go
+++ b/internal/server/handlers/restore.go
@@ -114,6 +114,7 @@ func (s *Service) RestoreByTimeHandler(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/restore/status/{jobId} [get]
 // @Success     200 {object} dto.RestoreJobStatus "Restore job status details"
 // @Failure     400 {string} string
+// @Failure     404 {string} string "The specified restore job was not found"
 func (s *Service) RestoreStatusHandler(w http.ResponseWriter, r *http.Request) {
 	jobID, err := extractJobID(r)
 	if err != nil {
@@ -158,7 +159,6 @@ func extractJobID(r *http.Request) (model.RestoreJobID, error) {
 // @Router   /v1/restore/jobs [get]
 // @Success  200 {object} map[string]dto.RestoreJobStatus "Restore jobs"
 // @Failure  400 {string} string
-// @Failure  500 {string} string
 //
 //nolint:lll
 func (s *Service) RetrieveRestoreJobs(w http.ResponseWriter, r *http.Request) {
@@ -235,7 +235,7 @@ func (s *Service) RetrieveConfig(w http.ResponseWriter, r *http.Request) {
 // @Param       jobId path int true "Restore job ID" format(int64)
 // @Success     202 {string} string "Restore job canceled successfully"
 // @Failure     400 {string} string "Invalid job ID"
-// @Failure     404 {string} string "Job not found"
+// @Failure     404 {string} string "The specified restore job was not found"
 func (s *Service) CancelRestoreHandler(w http.ResponseWriter, r *http.Request) {
 	jobID, err := extractJobID(r)
 	if err != nil {

--- a/internal/server/handlers/restore.go
+++ b/internal/server/handlers/restore.go
@@ -236,7 +236,6 @@ func (s *Service) RetrieveConfig(w http.ResponseWriter, r *http.Request) {
 // @Success     202 {string} string "Restore job canceled successfully"
 // @Failure     400 {string} string "Invalid job ID"
 // @Failure     404 {string} string "Job not found"
-// @Failure     500 {string} string "Internal server error"
 func (s *Service) CancelRestoreHandler(w http.ResponseWriter, r *http.Request) {
 	jobID, err := extractJobID(r)
 	if err != nil {

--- a/internal/server/handlers/system.go
+++ b/internal/server/handlers/system.go
@@ -3,13 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
 
 	backup "github.com/aerospike/aerospike-backup-service/v3"
 	_ "github.com/aerospike/aerospike-backup-service/v3/docs" // auto-generated Swagger spec
-	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
@@ -25,10 +23,7 @@ func RootActionHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
 		w.WriteHeader(http.StatusNotFound)
 	}
-	_, err := fmt.Fprintf(w, "")
-	if err != nil {
-		slog.Error("failed to write response", attr.Error(err))
-	}
+	_, _ = fmt.Fprintf(w, "")
 }
 
 // HealthActionHandler
@@ -38,10 +33,7 @@ func RootActionHandler(w http.ResponseWriter, r *http.Request) {
 // @Router      /health [get]
 // @Success 	200
 func HealthActionHandler(w http.ResponseWriter, _ *http.Request) {
-	_, err := fmt.Fprintf(w, "Ok")
-	if err != nil {
-		slog.Error("failed to write response", attr.Error(err))
-	}
+	_, _ = fmt.Fprintf(w, "Ok")
 }
 
 // ReadyActionHandler
@@ -51,10 +43,7 @@ func HealthActionHandler(w http.ResponseWriter, _ *http.Request) {
 // @Router      /ready [get]
 // @Success 	200
 func ReadyActionHandler(w http.ResponseWriter, _ *http.Request) {
-	_, err := fmt.Fprintf(w, "Ok")
-	if err != nil {
-		slog.Error("failed to write response", attr.Error(err))
-	}
+	_, _ = fmt.Fprintf(w, "Ok")
 }
 
 // VersionActionHandler
@@ -71,9 +60,7 @@ func VersionActionHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		slog.Error("failed to write response", attr.Error(err))
-	}
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 // MetricsActionHandler

--- a/internal/server/middleware/logger.go
+++ b/internal/server/middleware/logger.go
@@ -28,7 +28,7 @@ func RequestLogger(logger *slog.Logger, skipPaths []string) Middleware {
 
 			body, err := readRequestBody(r)
 			if err != nil {
-				logger.Error("failed to read request body", attr.Error(err))
+				logger.Error("Failed to read request body", attr.Error(err))
 				http.Error(w, "Failed to read request body: "+err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/internal/server/middleware/logger_test.go
+++ b/internal/server/middleware/logger_test.go
@@ -88,7 +88,7 @@ func TestRequestLogger(t *testing.T) {
 			handler:      func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
 			body:         &errorReader{},
 			wantLevel:    slog.LevelError,
-			wantMsg:      "failed to read request body",
+			wantMsg:      "Failed to read request body",
 			wantErrorMsg: "unexpected EOF",
 		},
 	}

--- a/internal/server/middleware/rate_limiter.go
+++ b/internal/server/middleware/rate_limiter.go
@@ -84,7 +84,7 @@ func (wl *IPWhiteList) isAllowed(ip string) bool {
 	}
 	ipAddr, err := netip.ParseAddr(ip)
 	if err != nil {
-		slog.Warn("Invalid client ip", slog.String("ip", ip))
+		slog.Warn("Invalid client IP", slog.String("ip", ip))
 		return false
 	}
 	_, ok := wl.addresses[ip]

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/middleware"
 )
@@ -52,7 +53,7 @@ func NewHTTPServer(service *handlers.Service) *HTTPServer {
 func (s *HTTPServer) Start() error {
 	err := s.server.ListenAndServe()
 	if errors.Is(err, http.ErrServerClosed) {
-		slog.Info(err.Error())
+		slog.Info("HTTP server closed", attr.Error(err))
 		return nil
 	}
 	return err

--- a/pkg/dto/decoder/field_info.go
+++ b/pkg/dto/decoder/field_info.go
@@ -18,12 +18,12 @@ var (
 func init() {
 	swaggerDoc, err := swag.ReadDoc("swagger")
 	if err != nil {
-		slog.Warn("Failed to read swagger doc", attr.Error(err))
+		slog.Warn("Failed to read Swagger doc", attr.Error(err))
 		return
 	}
 	fieldsByStruct, err = parseOpenAPISpec(swaggerDoc)
 	if err != nil {
-		slog.Warn("Failed to parse swagger doc", attr.Error(err))
+		slog.Warn("Failed to parse Swagger doc", attr.Error(err))
 		return
 	}
 

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -150,7 +150,7 @@ func (r *RestoreRequest) ToModel(config *model.Config) (*model.RestoreRequest, e
 
 	secretAgent, err := r.SecretAgentConfig.ToModel(config)
 	if err != nil {
-		return nil, fmt.Errorf("invalid secret-agent: %w", err)
+		return nil, fmt.Errorf("invalid secret agent: %w", err)
 	}
 
 	return &model.RestoreRequest{

--- a/pkg/model/backup_details.go
+++ b/pkg/model/backup_details.go
@@ -65,7 +65,7 @@ func NewMetadataFromBytes(data []byte) (*BackupMetadata, error) {
 	var metadata BackupMetadata
 	err := yaml.Unmarshal(data, &metadata)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling YAML: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal YAML: %w", err)
 	}
 	return &metadata, nil
 }

--- a/pkg/model/time_bounds.go
+++ b/pkg/model/time_bounds.go
@@ -15,7 +15,7 @@ type TimeBounds struct {
 // NewTimeBounds creates a new TimeBounds using provided fromTime and toTime values.
 func NewTimeBounds(fromTime, toTime *time.Time) (TimeBounds, error) {
 	if fromTime != nil && toTime != nil && fromTime.After(*toTime) {
-		return TimeBounds{}, errors.New("fromTime should be less than or equal to toTime")
+		return TimeBounds{}, errors.New("fromTime must be less than or equal to toTime")
 	}
 	return TimeBounds{FromTime: fromTime, ToTime: toTime}, nil
 }

--- a/pkg/service/aerospike/client_factory.go
+++ b/pkg/service/aerospike/client_factory.go
@@ -125,7 +125,7 @@ func setTLSConfig(c *model.AerospikeCluster, policy *as.ClientPolicy) {
 	var err error
 	policy.TlsConfig, err = NewTLSConfig(tlsToApply)
 	if err != nil {
-		slog.Error("Failed to initialize tls.Config",
+		slog.Error("Failed to initialize TLS config",
 			slog.String("cluster", ptr.ValueOrZero(c.ClusterLabel)),
 			attr.Error(err))
 	}

--- a/pkg/service/aerospike/namespace_validator.go
+++ b/pkg/service/aerospike/namespace_validator.go
@@ -38,7 +38,7 @@ func (nv *NamespaceValidatorImpl) Validate(ctx context.Context, cfg *model.Confi
 	missing := nv.findMissingNamespaces(ctx, cfg.Routines())
 
 	for routine, namespaces := range missing {
-		slog.Warn("namespaces referenced by routine are missing in the cluster",
+		slog.Warn("Namespaces referenced by routine are missing in the cluster",
 			attr.Routine(routine),
 			slog.Any("missingNamespaces", namespaces),
 		)
@@ -77,7 +77,7 @@ func (nv *NamespaceValidatorImpl) fetchNamespacesByCluster(
 	for cluster := range clusters {
 		namespaces, err := nv.fetchClusterNamespaces(ctx, cluster)
 		if err != nil {
-			slog.Error("failed to fetch namespaces for cluster", attr.Error(err))
+			slog.Error("Failed to fetch namespaces for cluster", attr.Error(err))
 			continue
 		}
 		namespacesByCluster[cluster] = namespaces

--- a/pkg/service/aerospike/namespace_validator.go
+++ b/pkg/service/aerospike/namespace_validator.go
@@ -93,13 +93,13 @@ func (nv *NamespaceValidatorImpl) fetchClusterNamespaces(
 ) ([]string, error) {
 	client, err := nv.clientManager.GetClient(ctx, cluster, nil)
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to cluster: %w", err)
+		return nil, fmt.Errorf("failed to connect to cluster: %w", err)
 	}
 	defer nv.clientManager.Close(client)
 
 	namespaces, err := client.InfoClient().GetNamespacesList(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve namespaces: %w", err)
+		return nil, fmt.Errorf("failed to retrieve namespaces: %w", err)
 	}
 
 	return namespaces, nil

--- a/pkg/service/backend_reader.go
+++ b/pkg/service/backend_reader.go
@@ -101,7 +101,7 @@ func (r *backupReader) readBackupDetails(
 		}
 		metadata, err := model.NewMetadataFromBytes(file)
 		if err != nil {
-			return nil, fmt.Errorf("error decoding backup metadata YAML: %w", err)
+			return nil, fmt.Errorf("failed to decode backup metadata YAML: %w", err)
 		}
 		key := keyFromStoragePath(path)
 		details := model.NewBackupDetails(*metadata, key, storage)

--- a/pkg/service/backup_completion.go
+++ b/pkg/service/backup_completion.go
@@ -58,7 +58,7 @@ func (h *backupCompletionHandler) OnSuccess(
 	go func() {
 		if err := h.retentionManager.deleteOldBackups(ctx, routine); err != nil {
 			if errors.Is(err, context.Canceled) {
-				logger.Info("Old backups clean up context cancelled")
+				logger.Info("Old backups cleanup context canceled")
 				return
 			}
 			logger.Error("Failed to clean up old backups", attr.Error(err))
@@ -69,7 +69,7 @@ func (h *backupCompletionHandler) OnSuccess(
 		if routine.BackupPolicy.WithClusterConfig != nil && *routine.BackupPolicy.WithClusterConfig {
 			if err := h.clusterConfigWriter.Write(ctx, routine, timestamp); err != nil {
 				if errors.Is(err, context.Canceled) {
-					logger.Info("Cluster configuration backup context cancelled")
+					logger.Info("Cluster configuration backup context canceled")
 					return
 				}
 

--- a/pkg/service/backup_namespace_runner.go
+++ b/pkg/service/backup_namespace_runner.go
@@ -96,11 +96,11 @@ func (op *BackupNamespaceRunner) deleteFolder(ctx context.Context, path string) 
 	err := op.backendService.Delete(ctx, op.routine, path)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			op.logger.Info("Delete folder context cancelled")
+			op.logger.Info("Delete folder context canceled")
 			return
 		}
 
-		op.logger.Error("Could not delete folder", attr.Error(err))
+		op.logger.Error("Failed to delete folder", attr.Error(err))
 		return
 	}
 }

--- a/pkg/service/backup_namespace_runner.go
+++ b/pkg/service/backup_namespace_runner.go
@@ -109,7 +109,7 @@ func (op *BackupNamespaceRunner) writeBackupMetadata(
 	ctx context.Context, metadata model.BackupMetadata, backupFolder string,
 ) error {
 	if err := op.backendService.WriteBackupMetadata(ctx, op.routine, backupFolder, metadata); err != nil {
-		return fmt.Errorf("could not write backup metadata to %q: %w", backupFolder, err)
+		return fmt.Errorf("failed to write backup metadata to %q: %w", backupFolder, err)
 	}
 
 	op.logger.Info("Wrote backup metadata",

--- a/pkg/service/backup_namespace_runner_test.go
+++ b/pkg/service/backup_namespace_runner_test.go
@@ -264,7 +264,7 @@ func TestMetadataWriteError(t *testing.T) {
 		GetStats().
 		Return(backupStats)
 
-	mocks.backendService.EXPECT(). // backup succeeded, but could not write metadata => delete all
+	mocks.backendService.EXPECT(). // backup succeeded, but failed to write metadata => delete all
 					WriteBackupMetadata(gomock.Any(), routine, backupFolder, gomock.Any()).
 					Return(metadataError)
 
@@ -277,7 +277,7 @@ func TestMetadataWriteError(t *testing.T) {
 	require.NotNil(t, handler)
 	err := handler.Wait(t.Context())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not write backup metadata")
+	require.Contains(t, err.Error(), "failed to write backup metadata")
 }
 
 func TestRetryableBackupHandler_Cancel(t *testing.T) {

--- a/pkg/service/backup_routine_orchestrator.go
+++ b/pkg/service/backup_routine_orchestrator.go
@@ -91,6 +91,8 @@ func (h *BackupRoutineOrchestrator) runFullBackup(ctx context.Context, now time.
 
 func (h *BackupRoutineOrchestrator) runFullBackupInternal(ctx context.Context, now time.Time) error {
 	h.fullBackupLock.Lock()
+	h.logger.Info("Full backup started", slog.Time("now", now))
+
 	if h.skipFullBackup() {
 		h.fullBackupLock.Unlock()
 		return errBackupSkipped
@@ -177,8 +179,9 @@ func (h *BackupRoutineOrchestrator) createTimeBounds(jobType jobType, now time.T
 }
 
 func (h *BackupRoutineOrchestrator) runIncrementalBackup(ctx context.Context, now time.Time) {
+	h.logger.Info("Incremental backup started", slog.Time("now", now))
+
 	if h.skipIncrementalBackup(now) {
-		h.logger.Debug("Incremental backup skipped")
 		observeBackupEvent(h.routine.Name, jobTypeIncremental, BackupOutcomeSkip, 0)
 		return
 	}

--- a/pkg/service/backup_routine_orchestrator.go
+++ b/pkg/service/backup_routine_orchestrator.go
@@ -209,7 +209,7 @@ func (h *BackupRoutineOrchestrator) processBackupError(backupType jobType, durat
 	}
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		h.logger.Info(operation + " context cancelled")
+		h.logger.Info(operation + " context canceled")
 		observeBackupEvent(h.routine.Name, backupType, BackupOutcomeCancelled, duration)
 		return
 	}

--- a/pkg/service/backup_routine_orchestrator.go
+++ b/pkg/service/backup_routine_orchestrator.go
@@ -135,13 +135,13 @@ func (h *BackupRoutineOrchestrator) skipFullBackup() bool {
 func (h *BackupRoutineOrchestrator) prepareCluster(ctx context.Context) (aerospike.Client, []string, error) {
 	client, err := h.clientManager.GetClient(ctx, h.routine.SourceCluster, h.logger)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot get backup client: %w", err)
+		return nil, nil, fmt.Errorf("failed to get backup client: %w", err)
 	}
 
 	namespaces, err := h.resolveNamespaces(ctx, h.routine.Namespaces, client.InfoClient())
 	if err != nil {
 		h.clientManager.Close(client)
-		return nil, nil, fmt.Errorf("cannot retrieve namespaces from source cluster: %w", err)
+		return nil, nil, fmt.Errorf("failed to retrieve namespaces from source cluster: %w", err)
 	}
 
 	return client, namespaces, nil

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
+	"github.com/aerospike/aerospike-backup-service/v3/internal/log"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 	"github.com/reugn/go-quartz/logger"
@@ -70,9 +71,10 @@ func NewAdHocIncrementalBackupJobForRoutine(routineName string) *quartz.JobDetai
 
 // NewScheduler creates a new quartz.Scheduler.
 func NewScheduler(ctx context.Context, appLogger *slog.Logger) (quartz.Scheduler, error) {
+	warnOnlyLogger := log.NewMinLevelLogger(appLogger, slog.LevelWarn)
 	scheduler, err := quartz.NewStdScheduler(
 		quartz.WithOutdatedThreshold(time.Second),
-		quartz.WithLogger(logger.NewSlogLogger(ctx, appLogger)),
+		quartz.WithLogger(logger.NewSlogLogger(ctx, warnOnlyLogger)),
 		quartz.WithJobMetadata(),
 	)
 	return scheduler, err

--- a/pkg/service/cluster_config_writer.go
+++ b/pkg/service/cluster_config_writer.go
@@ -53,7 +53,7 @@ func (w *DefaultClusterConfigWriter) Write(
 
 	client, err := w.clientManager.GetClient(ctx, routine.SourceCluster, logger)
 	if err != nil {
-		return fmt.Errorf("cannot get backup client: %w", err)
+		return fmt.Errorf("failed to get backup client: %w", err)
 	}
 
 	defer w.clientManager.Close(client)

--- a/pkg/service/cluster_config_writer.go
+++ b/pkg/service/cluster_config_writer.go
@@ -60,7 +60,7 @@ func (w *DefaultClusterConfigWriter) Write(
 
 	infos := cluster.ReadConfiguration(client.AerospikeClient(), logger)
 	if len(infos) == 0 {
-		return errors.New("could not read Aerospike configuration")
+		return errors.New("failed to read Aerospike configuration")
 	}
 
 	var errs error

--- a/pkg/service/config_applier.go
+++ b/pkg/service/config_applier.go
@@ -66,14 +66,14 @@ func (a *DefaultConfigApplier) ApplyNewConfig(ctx context.Context) error {
 func (a *DefaultConfigApplier) clearPeriodicSchedulerJobs() error {
 	keys, err := a.scheduler.GetJobKeys(matcher.JobGroupEquals(string(quartzGroupScheduled)))
 	if err != nil {
-		return fmt.Errorf("cannot fetch jobs: %w", err)
+		return fmt.Errorf("failed to fetch jobs: %w", err)
 	}
 
 	slog.Info("Delete scheduled jobs", slog.Any("keys", keys))
 	for _, key := range keys {
 		err = a.scheduler.DeleteJob(key)
 		if err != nil {
-			return fmt.Errorf("cannot delete job %q: %w", key, err)
+			return fmt.Errorf("failed to delete job %q: %w", key, err)
 		}
 	}
 

--- a/pkg/service/path_service.go
+++ b/pkg/service/path_service.go
@@ -102,7 +102,7 @@ func (s *PathServiceImpl) ExtractTimestampFromPath(path string) string {
 		return matches[2] // The timestamp is in the second capturing group
 	}
 
-	slog.Warn("Could not extract timestamp", slog.String("path", path))
+	slog.Warn("Failed to extract timestamp", slog.String("path", path))
 	return ""
 }
 

--- a/pkg/service/path_service.go
+++ b/pkg/service/path_service.go
@@ -102,7 +102,7 @@ func (s *PathServiceImpl) ExtractTimestampFromPath(path string) string {
 		return matches[2] // The timestamp is in the second capturing group
 	}
 
-	slog.Warn("could not extract timestamp", slog.String("path", path))
+	slog.Warn("Could not extract timestamp", slog.String("path", path))
 	return ""
 }
 

--- a/pkg/service/restore_time_runner.go
+++ b/pkg/service/restore_time_runner.go
@@ -80,7 +80,7 @@ func (r *timeRestoreRunner) findBackupsToRestore(
 			WithFromTime(backups[0].Created).
 			WithToTime(request.Time))
 	if err != nil {
-		return nil, fmt.Errorf("could not find incremental backups: %w", err)
+		return nil, fmt.Errorf("failed to find incremental backups: %w", err)
 	}
 
 	backupsByNs := make(map[string][]model.BackupDetails)
@@ -206,7 +206,7 @@ func (r *timeRestoreRunner) restoreNamespace(
 	if !request.DisableReordering {
 		counter, err := client.InfoClient().GetRecordCount(ctx, namespace, effectivePolicy.SetList)
 		if err != nil {
-			return fmt.Errorf("could not determine if namespace %s is empty: %w", namespace, err)
+			return fmt.Errorf("failed to determine if namespace %s is empty: %w", namespace, err)
 		}
 
 		if counter == 0 {
@@ -271,7 +271,7 @@ func (r *timeRestoreRunner) restoreFromPath(
 	)
 	handler, err := r.restoreService.Run(ctx, client, restoreRequest)
 	if err != nil {
-		return nil, fmt.Errorf("could not start restore from backup at %s: %w", backupPath, err)
+		return nil, fmt.Errorf("failed to start restore from backup at %s: %w", backupPath, err)
 	}
 
 	return handler, nil

--- a/pkg/service/restoreexecutor/scan.go
+++ b/pkg/service/restoreexecutor/scan.go
@@ -25,13 +25,13 @@ func runScanRestore(
 	reader, err := operations.CreateDirReader(ctx,
 		request.SourceStorage, request.BackupDataPath, options.WithValidator(asb.NewValidator()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create backup reader, %w", err)
+		return nil, fmt.Errorf("failed to create backup reader: %w", err)
 	}
 
 	config := makeRestoreConfig(request)
 	handler, err := client.Restore(ctx, config, reader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start restore, %w", err)
+		return nil, fmt.Errorf("failed to start restore: %w", err)
 	}
 
 	return handler, nil

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -90,7 +90,7 @@ func (t *routineTracker) recordSuccessfulBackup(routineName string, job jobType,
 	defer t.mu.Unlock()
 
 	logger := slog.Default().With(attr.Routine(routineName))
-	logger.Info("set last backup time",
+	logger.Info("Set last backup time",
 		slog.String("time", timestamp.String()),
 		slog.String("job", string(job)),
 	)

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -107,7 +107,7 @@ func (r *RunningBackupsRegistryImpl) SynchroniseBackupHistory(ctx context.Contex
 	}
 
 	if errors.Is(err, context.Canceled) {
-		slog.Info("History synchronization context cancelled")
+		slog.Info("History synchronization context canceled")
 		return
 	}
 

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -202,7 +202,7 @@ func (r *RunningBackupsRegistryImpl) GetRoutineState(routine *model.BackupRoutin
 	nextRunTime, err := nextBackup(routine)
 	if err != nil {
 		slog.Default().With(attr.Routine(routine.Name)).
-			Warn("Could not calculate next fire time", attr.Error(err))
+			Warn("Failed to calculate next fire time", attr.Error(err))
 		nextRunTime = model.NewNoBackupTime()
 	}
 


### PR DESCRIPTION
Reformatted log and errors.
Fixed misprints, capitaliaztions, moved from many different synonims to "failed to ..." everywhere.

go-quartz is using logger with WARN and ERROR only! 
I got tired of

time=2026-02-23T12:49:22.198Z level=INFO source=github.com/reugn/go-quartz@v0.15.2/quartz/scheduler.go:747 msg="Job exited the execution loop" key=ad-hoc_localStorageIncremental1-adhoc-1771850962148 error="trigger has expired"

messages. I don't want customers to ask "what does this error means??"