### PR TITLE
BRKS-118 Rename all var names Cancelled -> Canceled

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Use these queries in Grafana panels or the Prometheus expression browser to moni
 
   `sum( aerospike_backup_service_backup_events_total{outcome="failure"} )`
 
-- 🚫 Total number of cancelled backups:
+- 🚫 Total number of Canceled backups:
   `sum(aerospike_backup_service_backup_events_total{outcome="cancel"})`
 
 - ⏰ Time since last backup for routine
@@ -757,8 +757,8 @@ Provides a list of all restore jobs, with optional filtering by time range and s
 
 - `from` (optional): Lower bound timestamp filter in milliseconds since epoch.
 - `to` (optional): Upper bound timestamp filter in milliseconds since epoch.
-- `status` (optional): Comma-separated status filter (e.g., `Running,Done,Failed,Cancelled`). Use `!` prefix to exclude
-  statuses (e.g., `!Failed,Cancelled`).
+- `status` (optional): Comma-separated status filter (e.g., `Running,Done,Failed,Canceled`). Use `!` prefix to exclude
+  statuses (e.g., `!Failed,Canceled`).
 
 <details>
     <summary>Response example</summary>

--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -799,7 +799,7 @@
           "JobStatusRunning",
           "JobStatusDone",
           "JobStatusFailed",
-          "JobStatusCancelled"
+          "JobStatusCanceled"
         ]
       },
       "dto.LocalStorage": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2432,7 +2432,7 @@ const docTemplate = `{
                 "JobStatusRunning",
                 "JobStatusDone",
                 "JobStatusFailed",
-                "JobStatusCancelled"
+                "JobStatusCanceled"
             ]
         },
         "dto.LocalStorage": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2720,7 +2720,7 @@
                     "JobStatusRunning",
                     "JobStatusDone",
                     "JobStatusFailed",
-                    "JobStatusCancelled"
+                    "JobStatusCanceled"
                 ]
             },
             "dto.LocalStorage": {

--- a/pkg/dto/restore_result.go
+++ b/pkg/dto/restore_result.go
@@ -11,17 +11,17 @@ import (
 type JobStatus string
 
 const (
-	JobStatusRunning   JobStatus = "Running"
-	JobStatusDone      JobStatus = "Done"
-	JobStatusFailed    JobStatus = "Failed"
-	JobStatusCancelled JobStatus = "Canceled"
+	JobStatusRunning  JobStatus = "Running"
+	JobStatusDone     JobStatus = "Done"
+	JobStatusFailed   JobStatus = "Failed"
+	JobStatusCanceled JobStatus = "Canceled"
 )
 
 var allJobStatuses = []JobStatus{
 	JobStatusRunning,
 	JobStatusDone,
 	JobStatusFailed,
-	JobStatusCancelled,
+	JobStatusCanceled,
 }
 
 // restoreStatusFromString returns the corresponding JobStatus enum for string representation.

--- a/pkg/model/restore_result.go
+++ b/pkg/model/restore_result.go
@@ -5,10 +5,10 @@ import "github.com/aerospike/backup-go/models"
 type JobStatus string
 
 const (
-	JobStatusRunning   JobStatus = "Running"
-	JobStatusDone      JobStatus = "Done"
-	JobStatusFailed    JobStatus = "Failed"
-	JobStatusCancelled JobStatus = "Canceled"
+	JobStatusRunning  JobStatus = "Running"
+	JobStatusDone     JobStatus = "Done"
+	JobStatusFailed   JobStatus = "Failed"
+	JobStatusCanceled JobStatus = "Canceled"
 )
 
 // RestoreJobStatus represents a restore job status.

--- a/pkg/service/backup_routine_orchestrator.go
+++ b/pkg/service/backup_routine_orchestrator.go
@@ -210,7 +210,7 @@ func (h *BackupRoutineOrchestrator) processBackupError(backupType jobType, durat
 
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		h.logger.Info(operation + " context canceled")
-		observeBackupEvent(h.routine.Name, backupType, BackupOutcomeCancelled, duration)
+		observeBackupEvent(h.routine.Name, backupType, BackupOutcomeCanceled, duration)
 		return
 	}
 

--- a/pkg/service/backup_routine_orchestrator_test.go
+++ b/pkg/service/backup_routine_orchestrator_test.go
@@ -200,7 +200,7 @@ func TestRunFullBackupInternal_ClientConnectionFailure(t *testing.T) {
 	assert.Equal(t, 1, prometheusCounter(jobTypeFull, BackupOutcomeFailure))
 }
 
-func TestRunFullBackupInternal_ContextCancelled(t *testing.T) {
+func TestRunFullBackupInternal_ContextCanceled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -229,7 +229,7 @@ func TestRunFullBackupInternal_ContextCancelled(t *testing.T) {
 	assert.Zero(t, prometheusCounter(jobTypeFull, BackupOutcomeSuccess))
 	assert.Zero(t, prometheusCounter(jobTypeFull, BackupOutcomeSkip))
 	assert.Zero(t, prometheusCounter(jobTypeFull, BackupOutcomeFailure))
-	assert.Equal(t, 1, prometheusCounter(jobTypeFull, BackupOutcomeCancelled))
+	assert.Equal(t, 1, prometheusCounter(jobTypeFull, BackupOutcomeCanceled))
 }
 
 func TestSkipIncrementalBackup(t *testing.T) {
@@ -356,7 +356,7 @@ func TestRunIncrementalBackup_Skip(t *testing.T) {
 	assert.Zero(t, prometheusCounter(jobTypeIncremental, BackupOutcomeFailure))
 }
 
-func TestRunIncrementalBackup_ContextCancelled(t *testing.T) {
+func TestRunIncrementalBackup_ContextCanceled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -389,7 +389,7 @@ func TestRunIncrementalBackup_ContextCancelled(t *testing.T) {
 	assert.Zero(t, prometheusCounter(jobTypeIncremental, BackupOutcomeSuccess))
 	assert.Zero(t, prometheusCounter(jobTypeIncremental, BackupOutcomeSkip))
 	assert.Zero(t, prometheusCounter(jobTypeIncremental, BackupOutcomeFailure))
-	assert.Equal(t, 1, prometheusCounter(jobTypeIncremental, BackupOutcomeCancelled))
+	assert.Equal(t, 1, prometheusCounter(jobTypeIncremental, BackupOutcomeCanceled))
 }
 
 func TestRunIncrementalBackup_AllowConcurrentFull(t *testing.T) {

--- a/pkg/service/jobs_holder.go
+++ b/pkg/service/jobs_holder.go
@@ -92,7 +92,7 @@ func (j *restoreJob) finish(err error, logger *slog.Logger) {
 		j.status = model.JobStatusDone
 		logger.Info("restore finished")
 	case errors.Is(err, context.Canceled):
-		j.status = model.JobStatusCancelled
+		j.status = model.JobStatusCanceled
 		logger.Info("restore canceled")
 	case errors.Is(err, ErrRestorePrerequisitesFailed):
 		j.status = model.JobStatusFailed

--- a/pkg/service/jobs_holder_test.go
+++ b/pkg/service/jobs_holder_test.go
@@ -130,7 +130,7 @@ func TestRestoreJobsHolder_ConcurrentModification(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, status)
 
-		assert.Equal(t, model.JobStatusCancelled, status.Status)
+		assert.Equal(t, model.JobStatusCanceled, status.Status)
 		job, err = holder.getJob(jobID)
 		require.NoError(t, err)
 		require.ErrorIs(t, job.err, context.Canceled)

--- a/pkg/service/prometheus.go
+++ b/pkg/service/prometheus.go
@@ -216,11 +216,11 @@ func (mc *MetricsCollector) collectRestoreMetrics() {
 type BackupOutcome string
 
 const (
-	BackupOutcomeSuccess   BackupOutcome = "success"
-	BackupOutcomeFailure   BackupOutcome = "failure"
-	BackupOutcomeCancelled BackupOutcome = "canceled"
-	BackupOutcomeRetry     BackupOutcome = "retry"
-	BackupOutcomeSkip      BackupOutcome = "skip"
+	BackupOutcomeSuccess  BackupOutcome = "success"
+	BackupOutcomeFailure  BackupOutcome = "failure"
+	BackupOutcomeCanceled BackupOutcome = "canceled"
+	BackupOutcomeRetry    BackupOutcome = "retry"
+	BackupOutcomeSkip     BackupOutcome = "skip"
 )
 
 // observeBackupEvent updates Prometheus backup counters/histograms.
@@ -262,7 +262,7 @@ func observeBackupEvent(routineName string, backupType jobType, outcome BackupOu
 		}
 	case BackupOutcomeRetry:
 		// No deprecated counter for retry.
-	case BackupOutcomeCancelled:
+	case BackupOutcomeCanceled:
 		// No deprecated counter for canceled.
 	}
 }

--- a/pkg/service/restore_data_test.go
+++ b/pkg/service/restore_data_test.go
@@ -128,7 +128,7 @@ func TestCancelRestoreOK(t *testing.T) {
 
 	require.NoError(t, waitErr)
 	require.NotNil(t, jobStatus)
-	assert.Equal(t, model.JobStatusCancelled, jobStatus.Status)
+	assert.Equal(t, model.JobStatusCanceled, jobStatus.Status)
 }
 
 func TestRestoreFailsWithClientError(t *testing.T) {
@@ -345,7 +345,7 @@ func TestCancelRestore_RaceCondition(t *testing.T) {
 	jobStatus, err := waitForRestore(t, env.restoreManager, jobID)
 
 	require.NoError(t, err)
-	assert.Equal(t, model.JobStatusCancelled, jobStatus.Status)
+	assert.Equal(t, model.JobStatusCanceled, jobStatus.Status)
 	require.ErrorIs(t, jobStatus.Error, context.Canceled)
 }
 


### PR DESCRIPTION
Turns out, linter only checks comments and strings;
Var names are important because they are used to build openAPI spec