### PR TITLE
Rescan storage after backup 

### DIFF
--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -57,7 +57,6 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 
 	err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		config.SetBackupConfig(newConfigModel.BackupConfigCopy())
-		config.InvalidateAllRoutines()
 		s.nsValidator.Validate(r.Context(), config) // validate under the lock
 		return nil
 	})
@@ -99,7 +98,6 @@ func (s *Service) ApplyConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.config.SetBackupConfig(config.BackupConfigCopy())
-	s.config.InvalidateAllRoutines()
 	err = s.configApplier.ApplyNewConfig(s.sysCtx)
 
 	if err != nil {

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -57,6 +57,7 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 
 	err = s.changeConfig(r.Context(), func(config *model.Config) error {
 		config.SetBackupConfig(newConfigModel.BackupConfigCopy())
+		config.InvalidateAllRoutines()
 		s.nsValidator.Validate(r.Context(), config) // validate under the lock
 		return nil
 	})
@@ -98,6 +99,7 @@ func (s *Service) ApplyConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.config.SetBackupConfig(config.BackupConfigCopy())
+	s.config.InvalidateAllRoutines()
 	err = s.configApplier.ApplyNewConfig(s.sysCtx)
 
 	if err != nil {

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -14,9 +14,10 @@ type backupConfigChangeOptions struct {
 
 // changeBackupConfig applies a mutation to the backup configuration DTO, validates the
 // full configuration via ToModel, and persists the result.
+// The mutate function returns routine names that should be rescheduled and rescanned.
 func (s *Service) changeBackupConfig(
 	ctx context.Context,
-	mutate func(*dto.Config) error,
+	mutate func(*dto.Config) ([]string, error),
 	opts ...func(*backupConfigChangeOptions),
 ) error {
 	options := backupConfigChangeOptions{}
@@ -28,7 +29,8 @@ func (s *Service) changeBackupConfig(
 	defer s.changeConfigLock.Unlock()
 
 	dtoConfig := dto.NewConfigFromModel(s.config)
-	if err := mutate(dtoConfig); err != nil {
+	routinesToInvalidate, err := mutate(dtoConfig)
+	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
 	}
 
@@ -38,6 +40,7 @@ func (s *Service) changeBackupConfig(
 	}
 
 	s.config.SetBackupConfig(modelConfig.BackupConfigCopy())
+	s.config.InvalidateRoutines(routinesToInvalidate)
 
 	if options.validateNamespaces {
 		s.nsValidator.Validate(ctx, s.config)
@@ -56,6 +59,16 @@ func (s *Service) changeBackupConfig(
 
 func withNamespaceValidation(opts *backupConfigChangeOptions) {
 	opts.validateNamespaces = true
+}
+
+func routinesUsingStorage(config *dto.Config, storageName string) []string {
+	var names []string
+	for name, routine := range config.BackupRoutines {
+		if routine != nil && routine.Storage == storageName {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func ensurePolicyNotInUse(config *dto.Config, policyName string) error {

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -32,12 +32,12 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.AerospikeClusters[name]; exists {
-			return fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
+			return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
 		}
 		config.AerospikeClusters[name] = newCluster
-		return nil
+		return nil, nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -113,12 +113,12 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.AerospikeClusters[clusterName]; !exists {
-			return fmt.Errorf("update Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
+			return nil, fmt.Errorf("update Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
 		}
 		config.AerospikeClusters[clusterName] = updatedCluster
-		return nil
+		return nil, nil
 	}, withNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -142,15 +142,15 @@ func (s *Service) DeleteAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.AerospikeClusters[clusterName]; !exists {
-			return fmt.Errorf("delete Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
+			return nil, fmt.Errorf("delete Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
 		}
 		if err := ensureClusterNotInUse(config, clusterName); err != nil {
-			return err
+			return nil, err
 		}
 		delete(config.AerospikeClusters, clusterName)
-		return nil
+		return nil, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -75,15 +75,15 @@ func (s *Service) ReadAerospikeClusters(w http.ResponseWriter, _ *http.Request) 
 // @Failure     400 {string} string
 // @Failure     404 {string} string "The specified cluster was not found"
 func (s *Service) ReadAerospikeCluster(w http.ResponseWriter, r *http.Request) {
-	clusterName := r.PathValue("name")
-	if clusterName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingClusterName)
 		return
 	}
 	backupConfig := s.config.BackupConfigCopy()
-	cluster, ok := backupConfig.AerospikeClusters[clusterName]
+	cluster, ok := backupConfig.AerospikeClusters[name]
 	if !ok {
-		httpError(w, errNotFound("cluster", clusterName))
+		httpError(w, errNotFound("cluster", name))
 		return
 	}
 
@@ -101,8 +101,8 @@ func (s *Service) ReadAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 // @Success     200
 // @Failure     400 {string} string
 func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request) {
-	clusterName := r.PathValue("name")
-	if clusterName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingClusterName)
 		return
 	}
@@ -114,10 +114,10 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.AerospikeClusters[clusterName]; !exists {
-			return nil, fmt.Errorf("update Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
+		if _, exists := config.AerospikeClusters[name]; !exists {
+			return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)
 		}
-		config.AerospikeClusters[clusterName] = updatedCluster
+		config.AerospikeClusters[name] = updatedCluster
 		return nil, nil
 	}, withNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
@@ -136,20 +136,20 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 // @Success     204
 // @Failure     400 {string} string
 func (s *Service) DeleteAerospikeCluster(w http.ResponseWriter, r *http.Request) {
-	clusterName := r.PathValue("name")
-	if clusterName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingClusterName)
 		return
 	}
 
 	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.AerospikeClusters[clusterName]; !exists {
-			return nil, fmt.Errorf("delete Aerospike cluster %q: %w", clusterName, model.ErrNotFound)
+		if _, exists := config.AerospikeClusters[name]; !exists {
+			return nil, fmt.Errorf("delete Aerospike cluster %q: %w", name, model.ErrNotFound)
 		}
-		if err := ensureClusterNotInUse(config, clusterName); err != nil {
+		if err := ensureClusterNotInUse(config, name); err != nil {
 			return nil, err
 		}
-		delete(config.AerospikeClusters, clusterName)
+		delete(config.AerospikeClusters, name)
 		return nil, nil
 	})
 	if err != nil {

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -32,12 +32,12 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupPolicies[name]; exists {
-			return fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
+			return nil, fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
 		}
 		config.BackupPolicies[name] = newPolicy
-		return nil
+		return nil, nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -106,12 +106,12 @@ func (s *Service) UpdatePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupPolicies[name]; !exists {
-			return fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
+			return nil, fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
 		}
 		config.BackupPolicies[name] = updatedPolicy
-		return nil
+		return nil, nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -135,15 +135,15 @@ func (s *Service) DeletePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupPolicies[name]; !exists {
-			return fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
+			return nil, fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
 		}
 		if err := ensurePolicyNotInUse(config, name); err != nil {
-			return err
+			return nil, err
 		}
 		delete(config.BackupPolicies, name)
-		return nil
+		return nil, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -144,7 +144,7 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 			return nil, fmt.Errorf("delete backup routine %q: %w", routineName, model.ErrNotFound)
 		}
 		delete(config.BackupRoutines, routineName)
-		return []string{routineName}, nil
+		return nil, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))
@@ -210,8 +210,8 @@ func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
 		}
 		routine.Disabled = true
-		return []string{routineName}, nil
-	})
+		return nil, nil
+	}) // name -> routineName
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(routineName))

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -73,14 +73,14 @@ func (s *Service) ReadRoutines(w http.ResponseWriter, _ *http.Request) {
 // @Response    400 {string} string
 // @Failure     404 {string} string "The specified routine was not found"
 func (s *Service) ReadRoutine(w http.ResponseWriter, r *http.Request) {
-	routineName := r.PathValue("name")
-	if routineName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingRoutineName)
 		return
 	}
-	routine, found := s.config.Routine(routineName)
+	routine, found := s.config.Routine(name)
 	if !found {
-		httpError(w, errRoutineNotFound(routineName))
+		httpError(w, errRoutineNotFound(name))
 		return
 	}
 
@@ -133,17 +133,17 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 // @Success     204
 // @Failure     400 {string} string
 func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
-	routineName := r.PathValue("name")
-	if routineName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingRoutineName)
 		return
 	}
 
 	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupRoutines[routineName]; !exists {
-			return nil, fmt.Errorf("delete backup routine %q: %w", routineName, model.ErrNotFound)
+		if _, exists := config.BackupRoutines[name]; !exists {
+			return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
 		}
-		delete(config.BackupRoutines, routineName)
+		delete(config.BackupRoutines, name)
 		return nil, nil
 	})
 	if err != nil {
@@ -163,23 +163,23 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 // @Failure     404 {string} string "The specified routine was not found"
 // @Router      /v1/config/routines/{name}/enable [put]
 func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
-	routineName := r.PathValue("name")
-	if routineName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingRoutineName)
 		return
 	}
 
 	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		routine, exists := config.BackupRoutines[routineName]
+		routine, exists := config.BackupRoutines[name]
 		if !exists {
-			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
 		}
 		routine.Disabled = false
-		return []string{routineName}, nil
+		return []string{name}, nil
 	})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
-			httpError(w, errRoutineNotFound(routineName))
+			httpError(w, errRoutineNotFound(name))
 			return
 		}
 		httpError(w, errBadRequest(err))
@@ -198,30 +198,30 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 // @Failure     404 {string} string "The specified routine was not found"
 // @Router      /v1/config/routines/{name}/disable [put]
 func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
-	routineName := r.PathValue("name")
-	if routineName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingRoutineName)
 		return
 	}
 
 	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		routine, exists := config.BackupRoutines[routineName]
+		routine, exists := config.BackupRoutines[name]
 		if !exists {
-			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
 		}
 		routine.Disabled = true
 		return nil, nil
 	}) // name -> routineName
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
-			httpError(w, errRoutineNotFound(routineName))
+			httpError(w, errRoutineNotFound(name))
 			return
 		}
 		httpError(w, errBadRequest(err))
 		return
 	}
 
-	s.registry.Cancel(routineName) // cancel any running job for this routine after disabling it.
+	s.registry.Cancel(name) // cancel any running job for this routine after disabling it.
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -32,12 +32,12 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupRoutines[name]; exists {
-			return fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
+			return nil, fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
 		}
 		config.BackupRoutines[name] = newRoutine
-		return nil
+		return []string{name}, nil
 	}, withNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -110,12 +110,12 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupRoutines[name]; !exists {
-			return fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
+			return nil, fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
 		}
 		config.BackupRoutines[name] = updatedRoutine
-		return nil
+		return []string{name}, nil
 	}, withNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -139,12 +139,12 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.BackupRoutines[routineName]; !exists {
-			return fmt.Errorf("delete backup routine %q: %w", routineName, model.ErrNotFound)
+			return nil, fmt.Errorf("delete backup routine %q: %w", routineName, model.ErrNotFound)
 		}
 		delete(config.BackupRoutines, routineName)
-		return nil
+		return []string{routineName}, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))
@@ -169,13 +169,13 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		routine, exists := config.BackupRoutines[routineName]
 		if !exists {
-			return fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
 		}
 		routine.Disabled = false
-		return nil
+		return []string{routineName}, nil
 	})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
@@ -204,13 +204,13 @@ func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		routine, exists := config.BackupRoutines[routineName]
 		if !exists {
-			return fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", routineName, model.ErrNotFound)
 		}
 		routine.Disabled = true
-		return nil
+		return []string{routineName}, nil
 	})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -144,7 +144,7 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 			return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
 		}
 		delete(config.BackupRoutines, name)
-		return nil, nil
+		return []string{name}, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))
@@ -210,8 +210,8 @@ func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
 		}
 		routine.Disabled = true
-		return nil, nil
-	}) // name -> routineName
+		return []string{name}, nil
+	})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(name))

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -32,12 +32,12 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.Storage[name]; exists {
-			return fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
+			return nil, fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
 		}
 		config.Storage[name] = newStorage
-		return nil
+		return nil, nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -107,12 +107,12 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.Storage[storageName]; !exists {
-			return fmt.Errorf("update storage %q: %w", storageName, model.ErrNotFound)
+			return nil, fmt.Errorf("update storage %q: %w", storageName, model.ErrNotFound)
 		}
 		config.Storage[storageName] = updatedStorage
-		return nil
+		return routinesUsingStorage(config, storageName), nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -136,15 +136,15 @@ func (s *Service) DeleteStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) error {
+	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
 		if _, exists := config.Storage[storageName]; !exists {
-			return fmt.Errorf("delete storage %q: %w", storageName, model.ErrNotFound)
+			return nil, fmt.Errorf("delete storage %q: %w", storageName, model.ErrNotFound)
 		}
 		if err := ensureStorageNotInUse(config, storageName); err != nil {
-			return err
+			return nil, err
 		}
 		delete(config.Storage, storageName)
-		return nil
+		return nil, nil
 	})
 	if err != nil {
 		httpError(w, errBadRequest(err))

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -69,15 +69,15 @@ func (s *Service) ReadAllStorage(w http.ResponseWriter, _ *http.Request) {
 // @Response    400 {string} string
 // @Failure     404 {string} string "The specified storage was not found"
 func (s *Service) ReadStorage(w http.ResponseWriter, r *http.Request) {
-	storageName := r.PathValue("name")
-	if storageName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingStorageName)
 		return
 	}
 	backupConfig := s.config.BackupConfigCopy()
-	storage, ok := backupConfig.Storage[storageName]
+	storage, ok := backupConfig.Storage[name]
 	if !ok {
-		httpError(w, errNotFound("storage", storageName))
+		httpError(w, errNotFound("storage", name))
 		return
 	}
 
@@ -95,8 +95,8 @@ func (s *Service) ReadStorage(w http.ResponseWriter, r *http.Request) {
 // @Success     200
 // @Failure     400 {string} string
 func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
-	storageName := r.PathValue("name")
-	if storageName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingStorageName)
 		return
 	}
@@ -108,11 +108,11 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.Storage[storageName]; !exists {
-			return nil, fmt.Errorf("update storage %q: %w", storageName, model.ErrNotFound)
+		if _, exists := config.Storage[name]; !exists {
+			return nil, fmt.Errorf("update storage %q: %w", name, model.ErrNotFound)
 		}
-		config.Storage[storageName] = updatedStorage
-		return routinesUsingStorage(config, storageName), nil
+		config.Storage[name] = updatedStorage
+		return routinesUsingStorage(config, name), nil
 	}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -130,20 +130,20 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 // @Success     204
 // @Failure     400 {string} string
 func (s *Service) DeleteStorage(w http.ResponseWriter, r *http.Request) {
-	storageName := r.PathValue("name")
-	if storageName == "" {
+	name := r.PathValue("name")
+	if name == "" {
 		httpError(w, errMissingStorageName)
 		return
 	}
 
 	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.Storage[storageName]; !exists {
-			return nil, fmt.Errorf("delete storage %q: %w", storageName, model.ErrNotFound)
+		if _, exists := config.Storage[name]; !exists {
+			return nil, fmt.Errorf("delete storage %q: %w", name, model.ErrNotFound)
 		}
-		if err := ensureStorageNotInUse(config, storageName); err != nil {
+		if err := ensureStorageNotInUse(config, name); err != nil {
 			return nil, err
 		}
-		delete(config.Storage, storageName)
+		delete(config.Storage, name)
 		return nil, nil
 	})
 	if err != nil {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -233,6 +233,10 @@ func (c *Config) SetBackupConfig(other *BackupConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.backupConfig = *other
+
+	for _, r := range c.backupConfig.BackupRoutines {
+		c.invalidateRoutine(r.Name)
+	}
 }
 
 // InvalidateRoutines marks the given routines as needing reschedule and history rescan.
@@ -250,14 +254,6 @@ func (c *Config) InvalidateRoutines(names []string) {
 }
 
 // InvalidateAllRoutines marks every configured routine as invalidated.
-func (c *Config) InvalidateAllRoutines() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	for _, r := range c.backupConfig.BackupRoutines {
-		c.invalidateRoutine(r.Name)
-	}
-}
 
 // ToggleRoutineDisabled sets the Disabled field of the BackupRoutine based on the provided state.
 func (c *Config) ToggleRoutineDisabled(name string, isDisabled bool) error {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -233,6 +233,27 @@ func (c *Config) SetBackupConfig(other *BackupConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.backupConfig = *other
+}
+
+// InvalidateRoutines marks the given routines as needing reschedule and history rescan.
+func (c *Config) InvalidateRoutines(names []string) {
+	if len(names) == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, name := range names {
+		c.invalidateRoutine(name)
+	}
+}
+
+// InvalidateAllRoutines marks every configured routine as invalidated.
+func (c *Config) InvalidateAllRoutines() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	for _, r := range c.backupConfig.BackupRoutines {
 		c.invalidateRoutine(r.Name)
 	}

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -233,10 +233,6 @@ func (c *Config) SetBackupConfig(other *BackupConfig) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.backupConfig = *other
-
-	for _, r := range c.backupConfig.BackupRoutines {
-		c.invalidateRoutine(r.Name)
-	}
 }
 
 // InvalidateRoutines marks the given routines as needing reschedule and history rescan.
@@ -254,6 +250,14 @@ func (c *Config) InvalidateRoutines(names []string) {
 }
 
 // InvalidateAllRoutines marks every configured routine as invalidated.
+func (c *Config) InvalidateAllRoutines() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, r := range c.backupConfig.BackupRoutines {
+		c.invalidateRoutine(r.Name)
+	}
+}
 
 // ToggleRoutineDisabled sets the Disabled field of the BackupRoutine based on the provided state.
 func (c *Config) ToggleRoutineDisabled(name string, isDisabled bool) error {

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -55,18 +55,6 @@ func TestInvalidateRoutines(t *testing.T) {
 	assert.Equal(t, []string{"r1"}, invalidated)
 }
 
-func TestInvalidateAllRoutines(t *testing.T) {
-	cfg := NewConfig()
-	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))
-	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r2"}))
-	cfg.PopInvalidatedRoutineNames()
-
-	cfg.InvalidateAllRoutines()
-
-	invalidated := cfg.PopInvalidatedRoutineNames()
-	assert.Equal(t, []string{"r1", "r2"}, invalidated)
-}
-
 func TestSetBackupConfig_DoesNotInvalidate(t *testing.T) {
 	cfg := NewConfig()
 	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -55,6 +55,18 @@ func TestInvalidateRoutines(t *testing.T) {
 	assert.Equal(t, []string{"r1"}, invalidated)
 }
 
+func TestInvalidateAllRoutines(t *testing.T) {
+	cfg := NewConfig()
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r2"}))
+	cfg.PopInvalidatedRoutineNames()
+
+	cfg.InvalidateAllRoutines()
+
+	invalidated := cfg.PopInvalidatedRoutineNames()
+	assert.Equal(t, []string{"r1", "r2"}, invalidated)
+}
+
 func TestSetBackupConfig_DoesNotInvalidate(t *testing.T) {
 	cfg := NewConfig()
 	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -42,3 +42,38 @@ func TestToggleRoutineDisabled_InvalidatesOnDisableAndEnable(t *testing.T) {
 	invalidated := cfg.PopInvalidatedRoutineNames()
 	assert.Equal(t, []string{"r1"}, invalidated)
 }
+
+func TestInvalidateRoutines(t *testing.T) {
+	cfg := NewConfig()
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r2"}))
+	cfg.PopInvalidatedRoutineNames()
+
+	cfg.InvalidateRoutines([]string{"r1"})
+
+	invalidated := cfg.PopInvalidatedRoutineNames()
+	assert.Equal(t, []string{"r1"}, invalidated)
+}
+
+func TestInvalidateAllRoutines(t *testing.T) {
+	cfg := NewConfig()
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r2"}))
+	cfg.PopInvalidatedRoutineNames()
+
+	cfg.InvalidateAllRoutines()
+
+	invalidated := cfg.PopInvalidatedRoutineNames()
+	assert.Equal(t, []string{"r1", "r2"}, invalidated)
+}
+
+func TestSetBackupConfig_DoesNotInvalidate(t *testing.T) {
+	cfg := NewConfig()
+	require.NoError(t, cfg.AddRoutine(&BackupRoutine{Name: "r1"}))
+	cfg.PopInvalidatedRoutineNames()
+
+	other := cfg.BackupConfigCopy()
+	cfg.SetBackupConfig(other)
+
+	assert.Empty(t, cfg.PopInvalidatedRoutineNames())
+}

--- a/pkg/service/backend_reader.go
+++ b/pkg/service/backend_reader.go
@@ -4,13 +4,10 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
-	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
@@ -30,61 +27,26 @@ func newBackupReader(pathService PathService, operations storageOperations) *bac
 func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFilter) ([]model.BackupDetails, error) {
 	backupStorage := filter.storage
 
-	start := time.Now()
-	listStart := time.Now()
 	files, err := r.operations.ReadFileNames(ctx, backupStorage, filter.getPath(), metadataFile, filter.FromTime)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata files in %s: %w", filter.getPath(), err)
 	}
-	listDuration := time.Since(listStart)
 
 	storagePrefix := filepath.Clean(backupStorage.GetPath())
 	files = pathsRelativeToStorage(files, storagePrefix)
 	maxPath := filter.getUpperBoundary(r.pathService)
 	eligibleFiles := r.filterEligibleFiles(files, maxPath)
-	slog.Info("Listed routine backup metadata files",
-		attr.Routine(filter.routineName),
-		slog.String("backupType", string(filter.backupType)),
-		slog.Bool("onlyLast", filter.onlyLast),
-		slog.String("path", filter.getPath()),
-		slog.Int("files", len(files)),
-		slog.Int("eligibleFiles", len(eligibleFiles)),
-		slog.Duration("duration", listDuration),
-	)
 
 	if filter.onlyLast {
-		backups, err := r.readLatestBackupDetails(ctx, backupStorage, filter, eligibleFiles)
-		if err != nil {
-			return nil, err
-		}
-		slog.Info("Completed routine backup metadata request",
-			attr.Routine(filter.routineName),
-			slog.String("backupType", string(filter.backupType)),
-			slog.Bool("onlyLast", filter.onlyLast),
-			slog.Int("backups", len(backups)),
-			slog.Duration("duration", time.Since(start)),
-		)
-
-		return backups, nil
+		return r.readLatestBackupDetails(ctx, backupStorage, filter, eligibleFiles)
 	}
 
-	readStart := time.Now()
 	backups, err := r.readBackupDetails(ctx, backupStorage, eligibleFiles)
 	if err != nil {
 		return nil, err
 	}
-	readDuration := time.Since(readStart)
 
 	backups = r.filterAndSortBackups(backups, filter.timeBounds())
-	slog.Info("Completed routine backup metadata request",
-		attr.Routine(filter.routineName),
-		slog.String("backupType", string(filter.backupType)),
-		slog.Bool("onlyLast", filter.onlyLast),
-		slog.Int("metadataFilesRead", len(eligibleFiles)),
-		slog.Int("backups", len(backups)),
-		slog.Duration("readDuration", readDuration),
-		slog.Duration("duration", time.Since(start)),
-	)
 
 	return backups, nil
 }
@@ -97,12 +59,6 @@ func (r *backupReader) readLatestBackupDetails(
 ) ([]model.BackupDetails, error) {
 	bounds := filter.timeBounds()
 	pathsByTimestamp := r.groupMetadataPathsByTimestamp(files)
-	slog.Info("Grouped routine backup metadata files by timestamp",
-		attr.Routine(filter.routineName),
-		slog.String("backupType", string(filter.backupType)),
-		slog.Int("timestamps", len(pathsByTimestamp)),
-		slog.Int("metadataFiles", len(files)),
-	)
 
 	for len(pathsByTimestamp) > 0 {
 		// The storage layout is routine/backup/<timestamp>/data/<namespace>/metadata.yaml,
@@ -111,25 +67,15 @@ func (r *backupReader) readLatestBackupDetails(
 		paths := pathsByTimestamp[timestamp]
 		slices.Sort(paths)
 
-		readStart := time.Now()
 		backups, err := r.readBackupDetails(ctx, storage, paths)
 		if err != nil {
 			return nil, err
 		}
-		readDuration := time.Since(readStart)
 
 		// Created is represented by the timestamp path, but Finished only exists
 		// in metadata. If this timestamp does not match the full bounds, try the
 		// next newest timestamp.
 		backups = r.filterAndSortBackups(backups, bounds)
-		slog.Info("Read latest routine backup timestamp metadata",
-			attr.Routine(filter.routineName),
-			slog.String("backupType", string(filter.backupType)),
-			slog.String("timestamp", timestamp),
-			slog.Int("metadataFilesRead", len(paths)),
-			slog.Int("backups", len(backups)),
-			slog.Duration("duration", readDuration),
-		)
 		if len(backups) > 0 {
 			return backups, nil
 		}
@@ -141,30 +87,16 @@ func (r *backupReader) readLatestBackupDetails(
 }
 
 func (r *backupReader) getPathBackups(ctx context.Context, filter *PathFilter) ([]model.BackupDetails, error) {
-	start := time.Now()
-	listStart := time.Now()
 	files, err := r.operations.ReadFileNames(ctx, filter.storage, filter.path, metadataFile, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata files in %s: %w", filter.String(), err)
 	}
-	listDuration := time.Since(listStart)
 	files = pathsRelativeToStorage(files, filepath.Clean(filter.storage.GetPath()))
-	readStart := time.Now()
 	backups, err := r.readBackupDetails(ctx, filter.storage, files)
 	if err != nil {
 		return nil, err
 	}
-	readDuration := time.Since(readStart)
-	backups = r.filterAndSortBackups(backups, filter.timeBounds())
-	slog.Info("Completed path backup metadata request",
-		slog.String("path", filter.path),
-		slog.Int("metadataFiles", len(files)),
-		slog.Int("backups", len(backups)),
-		slog.Duration("listDuration", listDuration),
-		slog.Duration("readDuration", readDuration),
-		slog.Duration("duration", time.Since(start)),
-	)
-	return backups, nil
+	return r.filterAndSortBackups(backups, filter.timeBounds()), nil
 }
 
 // pathsRelativeToStorage normalizes paths from ReadFileNames to be relative to storage root.

--- a/pkg/service/backend_reader.go
+++ b/pkg/service/backend_reader.go
@@ -42,7 +42,7 @@ func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFil
 	files = pathsRelativeToStorage(files, storagePrefix)
 	maxPath := filter.getUpperBoundary(r.pathService)
 	eligibleFiles := r.filterEligibleFiles(files, maxPath)
-	slog.Debug("Listed routine backup metadata files",
+	slog.Info("Listed routine backup metadata files",
 		attr.Routine(filter.routineName),
 		slog.String("backupType", string(filter.backupType)),
 		slog.Bool("onlyLast", filter.onlyLast),
@@ -57,13 +57,14 @@ func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFil
 		if err != nil {
 			return nil, err
 		}
-		slog.Debug("Completed routine backup metadata request",
+		slog.Info("Completed routine backup metadata request",
 			attr.Routine(filter.routineName),
 			slog.String("backupType", string(filter.backupType)),
 			slog.Bool("onlyLast", filter.onlyLast),
 			slog.Int("backups", len(backups)),
 			slog.Duration("duration", time.Since(start)),
 		)
+
 		return backups, nil
 	}
 
@@ -75,7 +76,7 @@ func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFil
 	readDuration := time.Since(readStart)
 
 	backups = r.filterAndSortBackups(backups, filter.timeBounds())
-	slog.Debug("Completed routine backup metadata request",
+	slog.Info("Completed routine backup metadata request",
 		attr.Routine(filter.routineName),
 		slog.String("backupType", string(filter.backupType)),
 		slog.Bool("onlyLast", filter.onlyLast),
@@ -96,7 +97,7 @@ func (r *backupReader) readLatestBackupDetails(
 ) ([]model.BackupDetails, error) {
 	bounds := filter.timeBounds()
 	pathsByTimestamp := r.groupMetadataPathsByTimestamp(files)
-	slog.Debug("Grouped routine backup metadata files by timestamp",
+	slog.Info("Grouped routine backup metadata files by timestamp",
 		attr.Routine(filter.routineName),
 		slog.String("backupType", string(filter.backupType)),
 		slog.Int("timestamps", len(pathsByTimestamp)),
@@ -121,7 +122,7 @@ func (r *backupReader) readLatestBackupDetails(
 		// in metadata. If this timestamp does not match the full bounds, try the
 		// next newest timestamp.
 		backups = r.filterAndSortBackups(backups, bounds)
-		slog.Debug("Read latest routine backup timestamp metadata",
+		slog.Info("Read latest routine backup timestamp metadata",
 			attr.Routine(filter.routineName),
 			slog.String("backupType", string(filter.backupType)),
 			slog.String("timestamp", timestamp),
@@ -155,7 +156,7 @@ func (r *backupReader) getPathBackups(ctx context.Context, filter *PathFilter) (
 	}
 	readDuration := time.Since(readStart)
 	backups = r.filterAndSortBackups(backups, filter.timeBounds())
-	slog.Debug("Completed path backup metadata request",
+	slog.Info("Completed path backup metadata request",
 		slog.String("path", filter.path),
 		slog.Int("metadataFiles", len(files)),
 		slog.Int("backups", len(backups)),

--- a/pkg/service/backend_reader.go
+++ b/pkg/service/backend_reader.go
@@ -37,17 +37,52 @@ func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFil
 	maxPath := filter.getUpperBoundary(r.pathService)
 	eligibleFiles := r.filterEligibleFiles(files, maxPath)
 
+	if filter.onlyLast {
+		return r.readLatestBackupDetails(ctx, backupStorage, eligibleFiles, filter.timeBounds())
+	}
+
 	backups, err := r.readBackupDetails(ctx, backupStorage, eligibleFiles)
 	if err != nil {
 		return nil, err
 	}
 
 	backups = r.filterAndSortBackups(backups, filter.timeBounds())
-	if filter.onlyLast {
-		backups = r.getLastBackupsByCreated(backups)
-	}
 
 	return backups, nil
+}
+
+func (r *backupReader) readLatestBackupDetails(
+	ctx context.Context,
+	storage model.Storage,
+	files []string,
+	bounds model.TimeBounds,
+) ([]model.BackupDetails, error) {
+	pathsByTimestamp := r.groupMetadataPathsByTimestamp(files)
+
+	for len(pathsByTimestamp) > 0 {
+		// The storage layout is routine/backup/<timestamp>/data/<namespace>/metadata.yaml,
+		// so the newest timestamp directory identifies the last backup run.
+		timestamp := maxTimestamp(pathsByTimestamp)
+		paths := pathsByTimestamp[timestamp]
+		slices.Sort(paths)
+
+		backups, err := r.readBackupDetails(ctx, storage, paths)
+		if err != nil {
+			return nil, err
+		}
+
+		// Created is represented by the timestamp path, but Finished only exists
+		// in metadata. If this timestamp does not match the full bounds, try the
+		// next newest timestamp.
+		backups = r.filterAndSortBackups(backups, bounds)
+		if len(backups) > 0 {
+			return backups, nil
+		}
+
+		delete(pathsByTimestamp, timestamp)
+	}
+
+	return nil, nil
 }
 
 func (r *backupReader) getPathBackups(ctx context.Context, filter *PathFilter) ([]model.BackupDetails, error) {
@@ -84,6 +119,26 @@ func (r *backupReader) filterEligibleFiles(files []string, maxPath string) []str
 		}
 	}
 	return out
+}
+
+func (r *backupReader) groupMetadataPathsByTimestamp(files []string) map[string][]string {
+	pathsByTimestamp := make(map[string][]string)
+	for _, file := range files {
+		timestamp := r.pathService.ExtractTimestampFromPath(file)
+		if timestamp != "" {
+			pathsByTimestamp[timestamp] = append(pathsByTimestamp[timestamp], file)
+		}
+	}
+
+	return pathsByTimestamp
+}
+
+func maxTimestamp(pathsByTimestamp map[string][]string) string {
+	var latestTimestamp string
+	for timestamp := range pathsByTimestamp {
+		latestTimestamp = max(latestTimestamp, timestamp)
+	}
+	return latestTimestamp
 }
 
 // readBackupDetails reads and parses metadata for the given metadata file paths.
@@ -136,29 +191,6 @@ func (r *backupReader) filterAndSortBackups(
 
 		return cmp.Compare(a.Key, b.Key)
 	})
-
-	return out
-}
-
-// getLastBackupsByCreated returns only backups whose Created time equals the latest.
-func (r *backupReader) getLastBackupsByCreated(backups []model.BackupDetails) []model.BackupDetails {
-	if len(backups) == 0 {
-		return nil
-	}
-
-	latest := backups[0].Created
-	for _, b := range backups[1:] {
-		if b.Created.After(latest) {
-			latest = b.Created
-		}
-	}
-
-	out := make([]model.BackupDetails, 0, len(backups))
-	for _, b := range backups {
-		if b.Created.Equal(latest) {
-			out = append(out, b)
-		}
-	}
 
 	return out
 }

--- a/pkg/service/backend_reader.go
+++ b/pkg/service/backend_reader.go
@@ -4,10 +4,13 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
+	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
@@ -27,26 +30,60 @@ func newBackupReader(pathService PathService, operations storageOperations) *bac
 func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFilter) ([]model.BackupDetails, error) {
 	backupStorage := filter.storage
 
+	start := time.Now()
+	listStart := time.Now()
 	files, err := r.operations.ReadFileNames(ctx, backupStorage, filter.getPath(), metadataFile, filter.FromTime)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata files in %s: %w", filter.getPath(), err)
 	}
+	listDuration := time.Since(listStart)
 
 	storagePrefix := filepath.Clean(backupStorage.GetPath())
 	files = pathsRelativeToStorage(files, storagePrefix)
 	maxPath := filter.getUpperBoundary(r.pathService)
 	eligibleFiles := r.filterEligibleFiles(files, maxPath)
+	slog.Debug("Listed routine backup metadata files",
+		attr.Routine(filter.routineName),
+		slog.String("backupType", string(filter.backupType)),
+		slog.Bool("onlyLast", filter.onlyLast),
+		slog.String("path", filter.getPath()),
+		slog.Int("files", len(files)),
+		slog.Int("eligibleFiles", len(eligibleFiles)),
+		slog.Duration("duration", listDuration),
+	)
 
 	if filter.onlyLast {
-		return r.readLatestBackupDetails(ctx, backupStorage, eligibleFiles, filter.timeBounds())
+		backups, err := r.readLatestBackupDetails(ctx, backupStorage, filter, eligibleFiles)
+		if err != nil {
+			return nil, err
+		}
+		slog.Debug("Completed routine backup metadata request",
+			attr.Routine(filter.routineName),
+			slog.String("backupType", string(filter.backupType)),
+			slog.Bool("onlyLast", filter.onlyLast),
+			slog.Int("backups", len(backups)),
+			slog.Duration("duration", time.Since(start)),
+		)
+		return backups, nil
 	}
 
+	readStart := time.Now()
 	backups, err := r.readBackupDetails(ctx, backupStorage, eligibleFiles)
 	if err != nil {
 		return nil, err
 	}
+	readDuration := time.Since(readStart)
 
 	backups = r.filterAndSortBackups(backups, filter.timeBounds())
+	slog.Debug("Completed routine backup metadata request",
+		attr.Routine(filter.routineName),
+		slog.String("backupType", string(filter.backupType)),
+		slog.Bool("onlyLast", filter.onlyLast),
+		slog.Int("metadataFilesRead", len(eligibleFiles)),
+		slog.Int("backups", len(backups)),
+		slog.Duration("readDuration", readDuration),
+		slog.Duration("duration", time.Since(start)),
+	)
 
 	return backups, nil
 }
@@ -54,10 +91,17 @@ func (r *backupReader) getRoutineBackups(ctx context.Context, filter *RoutineFil
 func (r *backupReader) readLatestBackupDetails(
 	ctx context.Context,
 	storage model.Storage,
+	filter *RoutineFilter,
 	files []string,
-	bounds model.TimeBounds,
 ) ([]model.BackupDetails, error) {
+	bounds := filter.timeBounds()
 	pathsByTimestamp := r.groupMetadataPathsByTimestamp(files)
+	slog.Debug("Grouped routine backup metadata files by timestamp",
+		attr.Routine(filter.routineName),
+		slog.String("backupType", string(filter.backupType)),
+		slog.Int("timestamps", len(pathsByTimestamp)),
+		slog.Int("metadataFiles", len(files)),
+	)
 
 	for len(pathsByTimestamp) > 0 {
 		// The storage layout is routine/backup/<timestamp>/data/<namespace>/metadata.yaml,
@@ -66,15 +110,25 @@ func (r *backupReader) readLatestBackupDetails(
 		paths := pathsByTimestamp[timestamp]
 		slices.Sort(paths)
 
+		readStart := time.Now()
 		backups, err := r.readBackupDetails(ctx, storage, paths)
 		if err != nil {
 			return nil, err
 		}
+		readDuration := time.Since(readStart)
 
 		// Created is represented by the timestamp path, but Finished only exists
 		// in metadata. If this timestamp does not match the full bounds, try the
 		// next newest timestamp.
 		backups = r.filterAndSortBackups(backups, bounds)
+		slog.Debug("Read latest routine backup timestamp metadata",
+			attr.Routine(filter.routineName),
+			slog.String("backupType", string(filter.backupType)),
+			slog.String("timestamp", timestamp),
+			slog.Int("metadataFilesRead", len(paths)),
+			slog.Int("backups", len(backups)),
+			slog.Duration("duration", readDuration),
+		)
 		if len(backups) > 0 {
 			return backups, nil
 		}
@@ -86,16 +140,30 @@ func (r *backupReader) readLatestBackupDetails(
 }
 
 func (r *backupReader) getPathBackups(ctx context.Context, filter *PathFilter) ([]model.BackupDetails, error) {
+	start := time.Now()
+	listStart := time.Now()
 	files, err := r.operations.ReadFileNames(ctx, filter.storage, filter.path, metadataFile, nil)
 	if err != nil {
 		return nil, fmt.Errorf("read metadata files in %s: %w", filter.String(), err)
 	}
+	listDuration := time.Since(listStart)
 	files = pathsRelativeToStorage(files, filepath.Clean(filter.storage.GetPath()))
+	readStart := time.Now()
 	backups, err := r.readBackupDetails(ctx, filter.storage, files)
 	if err != nil {
 		return nil, err
 	}
-	return r.filterAndSortBackups(backups, filter.timeBounds()), nil
+	readDuration := time.Since(readStart)
+	backups = r.filterAndSortBackups(backups, filter.timeBounds())
+	slog.Debug("Completed path backup metadata request",
+		slog.String("path", filter.path),
+		slog.Int("metadataFiles", len(files)),
+		slog.Int("backups", len(backups)),
+		slog.Duration("listDuration", listDuration),
+		slog.Duration("readDuration", readDuration),
+		slog.Duration("duration", time.Since(start)),
+	)
+	return backups, nil
 }
 
 // pathsRelativeToStorage normalizes paths from ReadFileNames to be relative to storage root.

--- a/pkg/service/backend_service_test.go
+++ b/pkg/service/backend_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -312,6 +313,78 @@ func TestIncrementalBackup(t *testing.T) {
 	assert.Equal(t, "test-routine/backup/1609459200000/data/test-ns", fullBackups[0].Key)
 }
 
+func TestLastBackupsReadsOnlyLatestTimestampMetadataFiles(t *testing.T) {
+	pathService := NewPathService(nil)
+	operations := &countingStorageOperations{
+		storageOperations: storage.NewOperations(storage.NewLocalStorageAccessor()),
+	}
+	service := NewBackupBackendService(pathService, operations)
+	routine := &model.BackupRoutine{
+		Name: "test-routine",
+		Storage: &model.LocalStorage{
+			Path: t.TempDir(),
+		},
+	}
+
+	fullTimes := []time.Time{
+		time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+	for _, tm := range fullTimes {
+		path := pathService.GetBackupPath(routineName, model.BackupTypeFull, testNamespace, tm)
+		err := service.WriteBackupMetadata(t.Context(), routine, path, model.BackupMetadata{
+			Created:   tm,
+			Finished:  tm,
+			Namespace: testNamespace,
+		})
+		require.NoError(t, err)
+	}
+
+	latestFullTime := fullTimes[1]
+	latestFullOtherNamespacePath := pathService.GetBackupPath(
+		routineName,
+		model.BackupTypeFull,
+		"other-ns",
+		latestFullTime,
+	)
+	err := service.WriteBackupMetadata(t.Context(), routine, latestFullOtherNamespacePath, model.BackupMetadata{
+		Created:   latestFullTime,
+		Finished:  latestFullTime,
+		Namespace: "other-ns",
+	})
+	require.NoError(t, err)
+
+	incrementalTimes := []time.Time{
+		time.Date(2021, 1, 2, 1, 0, 0, 0, time.UTC),
+		time.Date(2021, 1, 3, 0, 0, 0, 0, time.UTC),
+	}
+	for _, tm := range incrementalTimes {
+		path := pathService.GetBackupPath(routineName, model.BackupTypeIncremental, testNamespace, tm)
+		err = service.WriteBackupMetadata(t.Context(), routine, path, model.BackupMetadata{
+			Created:   tm,
+			Finished:  tm,
+			From:      latestFullTime,
+			Namespace: testNamespace,
+		})
+		require.NoError(t, err)
+	}
+
+	backups, err := service.GetBackups(t.Context(), NewFullBackupFilter(routine).Last())
+	require.NoError(t, err)
+	require.Len(t, backups, 2)
+	assert.Equal(t, latestFullTime, backups[0].Created)
+	assert.Equal(t, latestFullTime, backups[1].Created)
+	assert.ElementsMatch(t, []string{testNamespace, "other-ns"}, []string{backups[0].Namespace, backups[1].Namespace})
+	assert.Equal(t, 2, operations.readFileCount)
+
+	backups, err = service.GetBackups(t.Context(),
+		NewIncrementalBackupFilter(routine).WithFromTime(latestFullTime).Last())
+	require.NoError(t, err)
+	require.Len(t, backups, 1)
+	assert.Equal(t, incrementalTimes[1], backups[0].Created)
+	assert.Equal(t, 3, operations.readFileCount)
+}
+
 func TestReadPath(t *testing.T) {
 	service, pathService, routine := setupLocalBackupBackendService(t)
 
@@ -382,4 +455,18 @@ func setupLocalBackupBackendService(t *testing.T) (*BackupBackendServiceImpl, Pa
 	pathService := NewPathService(nil)
 	return NewBackupBackendService(pathService,
 		storage.NewOperations(storage.NewLocalStorageAccessor())), pathService, routine
+}
+
+type countingStorageOperations struct {
+	storageOperations
+	readFileCount int
+}
+
+func (o *countingStorageOperations) ReadFile(
+	ctx context.Context,
+	storage model.Storage,
+	filePath string,
+) ([]byte, error) {
+	o.readFileCount++
+	return o.storageOperations.ReadFile(ctx, storage, filePath)
 }

--- a/pkg/service/backup_completion.go
+++ b/pkg/service/backup_completion.go
@@ -54,7 +54,7 @@ func (h *backupCompletionHandler) OnSuccess(
 	timestamp time.Time,
 	logger *slog.Logger,
 ) {
-	go h.registry.recordSuccessfulBackup(ctx, routine, backupType)
+	go h.registry.recordSuccessfulBackup(routine, backupType)
 
 	if backupType != model.BackupTypeFull {
 		return

--- a/pkg/service/backup_completion.go
+++ b/pkg/service/backup_completion.go
@@ -54,7 +54,7 @@ func (h *backupCompletionHandler) OnSuccess(
 	timestamp time.Time,
 	logger *slog.Logger,
 ) {
-	go h.registry.recordSuccessfulBackup(routine.Name, backupType, timestamp)
+	go h.registry.recordSuccessfulBackup(ctx, routine, backupType)
 
 	if backupType != model.BackupTypeFull {
 		return

--- a/pkg/service/history_manager.go
+++ b/pkg/service/history_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
@@ -34,21 +35,39 @@ func (hm *HistoryManagerImpl) FindLastRun(
 	ctx context.Context,
 	routine *model.BackupRoutine,
 ) (*model.BackupTime, error) {
+	start := time.Now()
+	fullStart := time.Now()
 	lastFullBackup, err := hm.backupReader.GetBackups(ctx, NewFullBackupFilter(routine).Last())
 	if err != nil {
 		return nil, fmt.Errorf("read last full backup failed: %w", err)
 	}
+	slog.Debug("Last full backup scan completed",
+		attr.Routine(routine.Name),
+		slog.Int("backups", len(lastFullBackup)),
+		slog.Duration("duration", time.Since(fullStart)),
+	)
 
 	if len(lastFullBackup) == 0 {
+		slog.Debug("Last backup time scan completed for routine",
+			attr.Routine(routine.Name),
+			slog.String("lastRun", model.NewNoBackupTime().String()),
+			slog.Duration("duration", time.Since(start)),
+		)
 		return model.NewNoBackupTime(), nil
 	}
 	lastFullTime := lastFullBackup[0].Created
 
+	incrementalStart := time.Now()
 	lastIncrBackup, err := hm.backupReader.GetBackups(ctx,
 		NewIncrementalBackupFilter(routine).WithFromTime(lastFullTime).Last())
 	if err != nil {
 		return nil, fmt.Errorf("read last incremental backup failed: %w", err)
 	}
+	slog.Debug("Last incremental backup scan completed",
+		attr.Routine(routine.Name),
+		slog.Int("backups", len(lastIncrBackup)),
+		slog.Duration("duration", time.Since(incrementalStart)),
+	)
 
 	var lastRun *model.BackupTime
 	if len(lastIncrBackup) > 0 {
@@ -59,7 +78,8 @@ func (hm *HistoryManagerImpl) FindLastRun(
 
 	slog.Debug("Last backup time scan completed for routine",
 		attr.Routine(routine.Name),
-		slog.String("lastRun", lastRun.String()))
+		slog.String("lastRun", lastRun.String()),
+		slog.Duration("duration", time.Since(start)))
 
 	return lastRun, nil
 }

--- a/pkg/service/history_manager.go
+++ b/pkg/service/history_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
@@ -35,39 +34,21 @@ func (hm *HistoryManagerImpl) FindLastRun(
 	ctx context.Context,
 	routine *model.BackupRoutine,
 ) (*model.BackupTime, error) {
-	start := time.Now()
-	fullStart := time.Now()
 	lastFullBackup, err := hm.backupReader.GetBackups(ctx, NewFullBackupFilter(routine).Last())
 	if err != nil {
 		return nil, fmt.Errorf("read last full backup failed: %w", err)
 	}
-	slog.Info("Last full backup scan completed",
-		attr.Routine(routine.Name),
-		slog.Int("backups", len(lastFullBackup)),
-		slog.Duration("duration", time.Since(fullStart)),
-	)
 
 	if len(lastFullBackup) == 0 {
-		slog.Info("Last backup time scan completed for routine",
-			attr.Routine(routine.Name),
-			slog.String("lastRun", model.NewNoBackupTime().String()),
-			slog.Duration("duration", time.Since(start)),
-		)
 		return model.NewNoBackupTime(), nil
 	}
 	lastFullTime := lastFullBackup[0].Created
 
-	incrementalStart := time.Now()
 	lastIncrBackup, err := hm.backupReader.GetBackups(ctx,
 		NewIncrementalBackupFilter(routine).WithFromTime(lastFullTime).Last())
 	if err != nil {
 		return nil, fmt.Errorf("read last incremental backup failed: %w", err)
 	}
-	slog.Info("Last incremental backup scan completed",
-		attr.Routine(routine.Name),
-		slog.Int("backups", len(lastIncrBackup)),
-		slog.Duration("duration", time.Since(incrementalStart)),
-	)
 
 	var lastRun *model.BackupTime
 	if len(lastIncrBackup) > 0 {
@@ -76,10 +57,9 @@ func (hm *HistoryManagerImpl) FindLastRun(
 		lastRun = model.NewFullBackupTime(lastFullTime)
 	}
 
-	slog.Info("Last backup time scan completed for routine",
+	slog.Debug("Last backup time scan completed for routine",
 		attr.Routine(routine.Name),
-		slog.String("lastRun", lastRun.String()),
-		slog.Duration("duration", time.Since(start)))
+		slog.String("lastRun", lastRun.String()))
 
 	return lastRun, nil
 }

--- a/pkg/service/history_manager.go
+++ b/pkg/service/history_manager.go
@@ -41,14 +41,14 @@ func (hm *HistoryManagerImpl) FindLastRun(
 	if err != nil {
 		return nil, fmt.Errorf("read last full backup failed: %w", err)
 	}
-	slog.Debug("Last full backup scan completed",
+	slog.Info("Last full backup scan completed",
 		attr.Routine(routine.Name),
 		slog.Int("backups", len(lastFullBackup)),
 		slog.Duration("duration", time.Since(fullStart)),
 	)
 
 	if len(lastFullBackup) == 0 {
-		slog.Debug("Last backup time scan completed for routine",
+		slog.Info("Last backup time scan completed for routine",
 			attr.Routine(routine.Name),
 			slog.String("lastRun", model.NewNoBackupTime().String()),
 			slog.Duration("duration", time.Since(start)),
@@ -63,7 +63,7 @@ func (hm *HistoryManagerImpl) FindLastRun(
 	if err != nil {
 		return nil, fmt.Errorf("read last incremental backup failed: %w", err)
 	}
-	slog.Debug("Last incremental backup scan completed",
+	slog.Info("Last incremental backup scan completed",
 		attr.Routine(routine.Name),
 		slog.Int("backups", len(lastIncrBackup)),
 		slog.Duration("duration", time.Since(incrementalStart)),
@@ -76,7 +76,7 @@ func (hm *HistoryManagerImpl) FindLastRun(
 		lastRun = model.NewFullBackupTime(lastFullTime)
 	}
 
-	slog.Debug("Last backup time scan completed for routine",
+	slog.Info("Last backup time scan completed for routine",
 		attr.Routine(routine.Name),
 		slog.String("lastRun", lastRun.String()),
 		slog.Duration("duration", time.Since(start)))

--- a/pkg/service/mockgen.go
+++ b/pkg/service/mockgen.go
@@ -314,15 +314,15 @@ func (mr *MockRunningBackupsRegistryMockRecorder) clearFailedBackup(routineName,
 }
 
 // recordSuccessfulBackup mocks base method.
-func (m *MockRunningBackupsRegistry) recordSuccessfulBackup(routineName string, jt model.BackupType, timestamp time.Time) {
+func (m *MockRunningBackupsRegistry) recordSuccessfulBackup(ctx context.Context, routine *model.BackupRoutine, jt model.BackupType) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "recordSuccessfulBackup", routineName, jt, timestamp)
+	m.ctrl.Call(m, "recordSuccessfulBackup", ctx, routine, jt)
 }
 
 // recordSuccessfulBackup indicates an expected call of recordSuccessfulBackup.
-func (mr *MockRunningBackupsRegistryMockRecorder) recordSuccessfulBackup(routineName, jt, timestamp any) *gomock.Call {
+func (mr *MockRunningBackupsRegistryMockRecorder) recordSuccessfulBackup(ctx, routine, jt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "recordSuccessfulBackup", reflect.TypeOf((*MockRunningBackupsRegistry)(nil).recordSuccessfulBackup), routineName, jt, timestamp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "recordSuccessfulBackup", reflect.TypeOf((*MockRunningBackupsRegistry)(nil).recordSuccessfulBackup), ctx, routine, jt)
 }
 
 // register mocks base method.

--- a/pkg/service/mockgen.go
+++ b/pkg/service/mockgen.go
@@ -314,15 +314,15 @@ func (mr *MockRunningBackupsRegistryMockRecorder) clearFailedBackup(routineName,
 }
 
 // recordSuccessfulBackup mocks base method.
-func (m *MockRunningBackupsRegistry) recordSuccessfulBackup(ctx context.Context, routine *model.BackupRoutine, jt model.BackupType) {
+func (m *MockRunningBackupsRegistry) recordSuccessfulBackup(routine *model.BackupRoutine, jt model.BackupType) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "recordSuccessfulBackup", ctx, routine, jt)
+	m.ctrl.Call(m, "recordSuccessfulBackup", routine, jt)
 }
 
 // recordSuccessfulBackup indicates an expected call of recordSuccessfulBackup.
-func (mr *MockRunningBackupsRegistryMockRecorder) recordSuccessfulBackup(ctx, routine, jt any) *gomock.Call {
+func (mr *MockRunningBackupsRegistryMockRecorder) recordSuccessfulBackup(routine, jt any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "recordSuccessfulBackup", reflect.TypeOf((*MockRunningBackupsRegistry)(nil).recordSuccessfulBackup), ctx, routine, jt)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "recordSuccessfulBackup", reflect.TypeOf((*MockRunningBackupsRegistry)(nil).recordSuccessfulBackup), routine, jt)
 }
 
 // register mocks base method.

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -140,7 +140,7 @@ func (t *routineTracker) cancelScan() {
 }
 
 // beginScan prepares the tracker for a new storage scan.
-// It unblocks any getState callers waiting on a previous (now-cancelled) scan
+// It unblocks any getState callers waiting on a previous (now-canceled) scan
 // and installs a fresh open channel for the new scan.
 // Returns the channel that the caller must pass to endScan when done.
 func (t *routineTracker) beginScan() chan struct{} {

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -112,12 +112,26 @@ func (t *routineTracker) clearFailedBackup(backupType model.BackupType) {
 
 // setLastRun updates the history state.
 // This is called by the HistoryManagerImpl after a scan.
+// It merges rather than replaces, so that a concurrent recordSuccessfulBackup
+// (fired as a goroutine from backup_completion) cannot have its more recent
+// timestamp silently overwritten by a stale storage-scan result.
 func (t *routineTracker) setLastRun(lastRun *model.BackupTime) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.lastRun = lastRun
-	t.scanCancel = nil // cannot cancel finished scan
+	if full := lastRun.FullBackupTime(); full != nil {
+		if cur := t.lastRun.FullBackupTime(); cur == nil || full.After(*cur) {
+			t.lastRun.SetFullBackupTime(*full)
+		}
+	}
+
+	if incr := lastRun.IncrementalBackupTime(); incr != nil {
+		if cur := t.lastRun.IncrementalBackupTime(); cur == nil || incr.After(*cur) {
+			t.lastRun.SetIncrementalBackupTime(*incr)
+		}
+	}
+
+	t.scanCancel = nil
 }
 
 // cancel stops all ongoing backups for this routine.

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -67,13 +67,14 @@ func (t *routineTracker) getState(timeout time.Duration) (*trackerSnapshot, erro
 		// old channel and installs a new one), loop to wait for the new scan.
 		t.mu.RLock()
 		if t.scanDone == done {
-			defer t.mu.RUnlock()
-
-			return &trackerSnapshot{
+			snapshot := &trackerSnapshot{
 				full:    currentBackupStatus(t.handlers[model.BackupTypeFull]),
 				incr:    currentBackupStatus(t.handlers[model.BackupTypeIncremental]),
 				lastRun: t.lastRun,
-			}, nil
+			}
+			t.mu.RUnlock()
+
+			return snapshot, nil
 		}
 		t.mu.RUnlock()
 	}

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -20,13 +20,12 @@ type routineTracker struct {
 	// --- History State ---
 	lastRun *model.BackupTime
 
-	// --- Sync State ---
-	// initialSyncDone is closed when the *first* history scan is completed.
-	// This ensures getState calls block until history is populated.
-	initialSyncDone chan struct{}
-	syncOnce        sync.Once
-
 	// --- Scan State ---
+	// scanDone is closed when no scan is in progress. getState blocks on it
+	// so that callers always see post-scan data.
+	// Open (blocking) → a scan is pending or in progress.
+	// Closed (non-blocking) → the most recent scan has finished.
+	scanDone chan struct{}
 	// scanCancel is a function to cancel a currently running history scan
 	scanCancel context.CancelFunc
 }
@@ -34,9 +33,9 @@ type routineTracker struct {
 // newRoutineTracker creates a new, initialized tracker.
 func newRoutineTracker() *routineTracker {
 	return &routineTracker{
-		initialSyncDone: make(chan struct{}),
-		handlers:        make(map[model.BackupType]CancelableBackupHandler),
-		lastRun:         model.NewNoBackupTime(), // Start with non-nil empty state
+		scanDone: make(chan struct{}), // open = blocks until first scan completes
+		handlers: make(map[model.BackupType]CancelableBackupHandler),
+		lastRun:  model.NewNoBackupTime(),
 	}
 }
 
@@ -48,24 +47,36 @@ type trackerSnapshot struct {
 }
 
 // getState returns a consistent, point-in-time snapshot of the routine's state.
-// It will block until the initial history synchronization is complete.
+// It blocks until no storage scan is in progress, so that the returned
+// timestamps always reflect completed scan results.
 func (t *routineTracker) getState(timeout time.Duration) (*trackerSnapshot, error) {
-	select {
-	case <-t.initialSyncDone:
-		// Sync is done, proceed
-	case <-time.After(timeout):
-		return nil, context.DeadlineExceeded
+	deadline := time.After(timeout)
+
+	for {
+		t.mu.RLock()
+		done := t.scanDone
+		t.mu.RUnlock()
+
+		select {
+		case <-done:
+		case <-deadline:
+			return nil, context.DeadlineExceeded
+		}
+
+		// If a new scan started while we were waiting (beginScan closes the
+		// old channel and installs a new one), loop to wait for the new scan.
+		t.mu.RLock()
+		if t.scanDone == done {
+			defer t.mu.RUnlock()
+
+			return &trackerSnapshot{
+				full:    currentBackupStatus(t.handlers[model.BackupTypeFull]),
+				incr:    currentBackupStatus(t.handlers[model.BackupTypeIncremental]),
+				lastRun: t.lastRun,
+			}, nil
+		}
+		t.mu.RUnlock()
 	}
-
-	// Now that sync is done, get a consistent snapshot of the state
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	return &trackerSnapshot{
-		full:    currentBackupStatus(t.handlers[model.BackupTypeFull]),
-		incr:    currentBackupStatus(t.handlers[model.BackupTypeIncremental]),
-		lastRun: t.lastRun,
-	}, nil
 }
 
 // register adds a new running backup handler.
@@ -77,22 +88,11 @@ func (t *routineTracker) register(backupType model.BackupType, handler Cancelabl
 	t.handlers[backupType] = handler
 }
 
-// clearCompletedBackup removes a completed backup handler.
-// It does not update timestamps — that is done by a subsequent storage scan,
-// which is the single source of truth for backup history.
-func (t *routineTracker) clearCompletedBackup(backupType model.BackupType) {
+// clearBackup removes a backup handler from the tracker.
+func (t *routineTracker) clearBackup(backupType model.BackupType) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	delete(t.handlers, backupType)
-}
-
-// clearFailedBackup removes a failed backup handler without updating history.
-func (t *routineTracker) clearFailedBackup(backupType model.BackupType) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Remove the handler
 	delete(t.handlers, backupType)
 }
 
@@ -139,9 +139,41 @@ func (t *routineTracker) cancelScan() {
 	}
 }
 
-// signalSyncDone safely closes the initialSyncDone channel.
-func (t *routineTracker) signalSyncDone() {
-	t.syncOnce.Do(func() {
-		close(t.initialSyncDone)
-	})
+// beginScan prepares the tracker for a new storage scan.
+// It unblocks any getState callers waiting on a previous (now-cancelled) scan
+// and installs a fresh open channel for the new scan.
+// Returns the channel that the caller must pass to endScan when done.
+func (t *routineTracker) beginScan() chan struct{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	closeChan(t.scanDone)
+
+	ch := make(chan struct{})
+	t.scanDone = ch
+
+	return ch
+}
+
+// endScan signals that a specific scan has completed.
+// Safe to call if the channel was already closed (e.g. by a subsequent beginScan).
+func (t *routineTracker) endScan(ch chan struct{}) {
+	closeChan(ch)
+}
+
+// markScanDone closes the current scanDone channel without starting a new scan.
+// Used in tests to skip the scan wait.
+func (t *routineTracker) markScanDone() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	closeChan(t.scanDone)
+}
+
+func closeChan(ch chan struct{}) {
+	select {
+	case <-ch:
+	default:
+		close(ch)
+	}
 }

--- a/pkg/service/routine_tracker.go
+++ b/pkg/service/routine_tracker.go
@@ -2,11 +2,9 @@ package service
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
@@ -79,25 +77,13 @@ func (t *routineTracker) register(backupType model.BackupType, handler Cancelabl
 	t.handlers[backupType] = handler
 }
 
-// recordSuccessfulBackup removes a successful backup and updates its last run time.
-func (t *routineTracker) recordSuccessfulBackup(routineName string, backupType model.BackupType, timestamp time.Time) {
+// clearCompletedBackup removes a completed backup handler.
+// It does not update timestamps — that is done by a subsequent storage scan,
+// which is the single source of truth for backup history.
+func (t *routineTracker) clearCompletedBackup(backupType model.BackupType) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	logger := slog.Default().With(attr.Routine(routineName))
-	logger.Info("Set last backup time",
-		slog.String("time", timestamp.String()),
-		slog.String("job", string(backupType)),
-	)
-
-	switch backupType {
-	case model.BackupTypeFull:
-		t.lastRun.SetFullBackupTime(timestamp)
-	case model.BackupTypeIncremental:
-		t.lastRun.SetIncrementalBackupTime(timestamp)
-	}
-
-	// Remove the handler
 	delete(t.handlers, backupType)
 }
 
@@ -110,27 +96,13 @@ func (t *routineTracker) clearFailedBackup(backupType model.BackupType) {
 	delete(t.handlers, backupType)
 }
 
-// setLastRun updates the history state.
-// This is called by the HistoryManagerImpl after a scan.
-// It merges rather than replaces, so that a concurrent recordSuccessfulBackup
-// (fired as a goroutine from backup_completion) cannot have its more recent
-// timestamp silently overwritten by a stale storage-scan result.
+// setLastRun updates the history state from a storage scan result.
+// It replaces the entire lastRun value, making storage the single source of truth.
 func (t *routineTracker) setLastRun(lastRun *model.BackupTime) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if full := lastRun.FullBackupTime(); full != nil {
-		if cur := t.lastRun.FullBackupTime(); cur == nil || full.After(*cur) {
-			t.lastRun.SetFullBackupTime(*full)
-		}
-	}
-
-	if incr := lastRun.IncrementalBackupTime(); incr != nil {
-		if cur := t.lastRun.IncrementalBackupTime(); cur == nil || incr.After(*cur) {
-			t.lastRun.SetIncrementalBackupTime(*incr)
-		}
-	}
-
+	t.lastRun = lastRun
 	t.scanCancel = nil
 }
 

--- a/pkg/service/routine_tracker_test.go
+++ b/pkg/service/routine_tracker_test.go
@@ -83,7 +83,7 @@ func TestRegisterAndGetState(t *testing.T) {
 	assert.Equal(t, uint64(50), snapshot.incr.TotalRecords)
 }
 
-func TestRecordSuccessfulBackup(t *testing.T) {
+func TestClearCompletedBackup(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
 	tracker.signalSyncDone()
@@ -93,26 +93,18 @@ func TestRecordSuccessfulBackup(t *testing.T) {
 	handler := NewMockCancelableBackupHandler(ctrl)
 	tracker.register(model.BackupTypeFull, handler)
 
-	// record a successful full backup
-	now := time.Now()
-	tracker.recordSuccessfulBackup(routineName, model.BackupTypeFull, now)
+	tracker.clearCompletedBackup(model.BackupTypeFull)
 
 	snapshot, err := tracker.getState(1 * time.Second)
 	require.NoError(t, err)
 	assert.Nil(t, snapshot.full) // handler should be removed
-	assert.Equal(t, now, *snapshot.lastRun.FullBackupTime())
-	assert.Nil(t, snapshot.lastRun.IncrementalBackupTime())
 
-	// record a successful incremental backup
 	tracker.register(model.BackupTypeIncremental, handler)
-	nowIncr := time.Now()
-	tracker.recordSuccessfulBackup(routineName, model.BackupTypeIncremental, nowIncr)
+	tracker.clearCompletedBackup(model.BackupTypeIncremental)
 
 	snapshotIncr, err := tracker.getState(1 * time.Second)
 	require.NoError(t, err)
 	assert.Nil(t, snapshotIncr.incr) // handler should be removed
-	assert.Equal(t, now, *snapshotIncr.lastRun.FullBackupTime())
-	assert.Equal(t, nowIncr, *snapshotIncr.lastRun.IncrementalBackupTime())
 }
 
 func TestClearFailedBackup(t *testing.T) {

--- a/pkg/service/routine_tracker_test.go
+++ b/pkg/service/routine_tracker_test.go
@@ -16,11 +16,11 @@ func TestNewRoutineTracker(t *testing.T) {
 	tracker := newRoutineTracker()
 	assert.NotNil(t, tracker)
 	assert.NotNil(t, tracker.lastRun)
-	assert.NotNil(t, tracker.initialSyncDone)
-	// initialSyncDone should be open
+	assert.NotNil(t, tracker.scanDone)
+	// scanDone should be open (blocking until first scan)
 	select {
-	case <-tracker.initialSyncDone:
-		t.Fatal("initialSyncDone should be open")
+	case <-tracker.scanDone:
+		t.Fatal("scanDone should be open")
 	default:
 		// success
 	}
@@ -38,7 +38,7 @@ func TestGetState_BlockingAndTimeout(t *testing.T) {
 	// Test blocking and unblocking
 	go func() {
 		time.Sleep(50 * time.Millisecond)
-		tracker.signalSyncDone()
+		tracker.markScanDone()
 	}()
 
 	start := time.Now()
@@ -53,7 +53,7 @@ func TestGetState_BlockingAndTimeout(t *testing.T) {
 func TestRegisterAndGetState(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
-	tracker.signalSyncDone() // unblock getState
+	tracker.markScanDone() // unblock getState
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -83,24 +83,24 @@ func TestRegisterAndGetState(t *testing.T) {
 	assert.Equal(t, uint64(50), snapshot.incr.TotalRecords)
 }
 
-func TestClearCompletedBackup(t *testing.T) {
+func TestClearBackup(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
-	tracker.signalSyncDone()
+	tracker.markScanDone()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	handler := NewMockCancelableBackupHandler(ctrl)
 	tracker.register(model.BackupTypeFull, handler)
 
-	tracker.clearCompletedBackup(model.BackupTypeFull)
+	tracker.clearBackup(model.BackupTypeFull)
 
 	snapshot, err := tracker.getState(1 * time.Second)
 	require.NoError(t, err)
 	assert.Nil(t, snapshot.full) // handler should be removed
 
 	tracker.register(model.BackupTypeIncremental, handler)
-	tracker.clearCompletedBackup(model.BackupTypeIncremental)
+	tracker.clearBackup(model.BackupTypeIncremental)
 
 	snapshotIncr, err := tracker.getState(1 * time.Second)
 	require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestClearCompletedBackup(t *testing.T) {
 func TestClearFailedBackup(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
-	tracker.signalSyncDone()
+	tracker.markScanDone()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -118,7 +118,7 @@ func TestClearFailedBackup(t *testing.T) {
 	tracker.register(model.BackupTypeFull, handler)
 
 	// clear a failed backup
-	tracker.clearFailedBackup(model.BackupTypeFull)
+	tracker.clearBackup(model.BackupTypeFull)
 
 	snapshot, err := tracker.getState(1 * time.Second)
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func TestClearFailedBackup(t *testing.T) {
 func TestSetLastRun(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
-	tracker.signalSyncDone()
+	tracker.markScanDone()
 
 	backupTime := model.NewFullBackupTime(time.Now())
 	tracker.setLastRun(backupTime)
@@ -171,19 +171,19 @@ func TestScanCancellation(t *testing.T) {
 	assert.False(t, cancel2Called)
 }
 
-func TestSignalSyncDone_Idempotency(t *testing.T) {
+func TestMarkScanDone_Idempotency(t *testing.T) {
 	t.Parallel()
 	tracker := newRoutineTracker()
 
-	// calling signalSyncDone multiple times should not panic
-	tracker.signalSyncDone()
-	tracker.signalSyncDone()
+	// calling markScanDone multiple times should not panic
+	tracker.markScanDone()
+	tracker.markScanDone()
 
-	// channel should be closed
+	// scanDone should be closed
 	select {
-	case <-tracker.initialSyncDone:
+	case <-tracker.scanDone:
 		// success
 	default:
-		t.Fatal("initialSyncDone should be closed")
+		t.Fatal("scanDone should be closed")
 	}
 }

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -151,17 +151,25 @@ func (r *RunningBackupsRegistryImpl) scanSingleRoutineHistory(ctx context.Contex
 	defer cancelFunc()
 	tracker.setScanCancel(cancelFunc)
 
-	lastRun, err := r.history.FindLastRun(ctxWithCancel, routine)
+	lastRun, duration, err := timeutil.MeasureDurationWithResult(func() (*model.BackupTime, error) {
+		return r.history.FindLastRun(ctxWithCancel, routine)
+	})
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {
-			slog.Error("Failed to read last backup time during sync", attr.Error(err), attr.Routine(routine.Name))
+			slog.Error("Failed to read last backup time during sync",
+				attr.Error(err), attr.Routine(routine.Name),
+				slog.Duration("duration", duration),
+			)
 		}
 		tracker.setLastRun(model.NewNoBackupTime())
 		return err
 	}
 
-	// On success, update the tracker's history
-	slog.Info("Last existing backup", attr.Routine(routine.Name), slog.Any("time", lastRun))
+	slog.Info("Last existing backup",
+		attr.Routine(routine.Name),
+		slog.Any("time", lastRun),
+		slog.Duration("duration", duration),
+	)
 	tracker.setLastRun(lastRun)
 	prometheus.SetInitialLastBackup(routine.Name, lastRun)
 

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -24,7 +24,7 @@ type RunningBackupsRegistry interface {
 	clearFailedBackup(routineName string, jt model.BackupType)
 	// recordSuccessfulBackup removes a backup from the registry and triggers a storage scan
 	// to update the last backup timestamp. Storage is the single source of truth for history.
-	recordSuccessfulBackup(ctx context.Context, routine *model.BackupRoutine, jt model.BackupType)
+	recordSuccessfulBackup(routine *model.BackupRoutine, jt model.BackupType)
 
 	// GetRoutineState returns the current backup statistics for a routine.
 	GetRoutineState(routine *model.BackupRoutine) model.RoutineState
@@ -155,12 +155,14 @@ func (r *RunningBackupsRegistryImpl) scanSingleRoutineHistory(ctx context.Contex
 		return r.history.FindLastRun(ctxWithCancel, routine)
 	})
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			slog.Error("Failed to read last backup time during sync",
-				attr.Error(err), attr.Routine(routine.Name),
-				slog.Duration("duration", duration),
-			)
+		if errors.Is(err, context.Canceled) {
+			return err
 		}
+
+		slog.Error("Failed to read last backup time during sync",
+			attr.Error(err), attr.Routine(routine.Name),
+			slog.Duration("duration", duration),
+		)
 		tracker.setLastRun(model.NewNoBackupTime())
 		return err
 	}
@@ -188,12 +190,11 @@ func (r *RunningBackupsRegistryImpl) register(
 // recordSuccessfulBackup removes a backup from the registry and triggers a storage scan
 // to update the last backup timestamp. Storage is the single source of truth for history.
 func (r *RunningBackupsRegistryImpl) recordSuccessfulBackup(
-	ctx context.Context,
 	routine *model.BackupRoutine,
 	backupType model.BackupType,
 ) {
 	r.getTracker(routine.Name).clearBackup(backupType)
-	_ = r.scanSingleRoutineHistory(ctx, routine)
+	_ = r.scanSingleRoutineHistory(context.Background(), routine)
 }
 
 // clearFailedBackup deletes a backup from the registry.

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -22,9 +22,9 @@ type RunningBackupsRegistry interface {
 	// clearFailedBackup deletes a backup from the registry.
 	// Should be called for failed backups.
 	clearFailedBackup(routineName string, jt model.BackupType)
-	// recordSuccessfulBackup removes a backup from the registry and updates the last success timestamp.
-	// Should be called after successful backup completion.
-	recordSuccessfulBackup(routineName string, jt model.BackupType, timestamp time.Time)
+	// recordSuccessfulBackup removes a backup from the registry and triggers a storage scan
+	// to update the last backup timestamp. Storage is the single source of truth for history.
+	recordSuccessfulBackup(ctx context.Context, routine *model.BackupRoutine, jt model.BackupType)
 
 	// GetRoutineState returns the current backup statistics for a routine.
 	GetRoutineState(routine *model.BackupRoutine) model.RoutineState
@@ -174,13 +174,15 @@ func (r *RunningBackupsRegistryImpl) register(
 	r.getTracker(routineName).register(backupType, handler)
 }
 
-// recordSuccessfulBackup removes a backup from the registry and updates the last success timestamp.
+// recordSuccessfulBackup removes a backup from the registry and triggers a storage scan
+// to update the last backup timestamp. Storage is the single source of truth for history.
 func (r *RunningBackupsRegistryImpl) recordSuccessfulBackup(
-	routineName string,
+	ctx context.Context,
+	routine *model.BackupRoutine,
 	backupType model.BackupType,
-	timestamp time.Time,
 ) {
-	r.getTracker(routineName).recordSuccessfulBackup(routineName, backupType, timestamp)
+	r.getTracker(routine.Name).clearCompletedBackup(backupType)
+	r.scanSingleRoutineHistory(ctx, routine)
 }
 
 // clearFailedBackup deletes a backup from the registry.

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -56,7 +56,7 @@ type RunningBackupsRegistryImpl struct {
 
 var _ RunningBackupsRegistry = (*RunningBackupsRegistryImpl)(nil)
 
-const getStateTimeout = 5 * time.Second
+const getStateTimeout = 15 * time.Second
 
 // NewRunningBackupsRegistry creates a new instance of RunningBackupsRegistryImpl.
 func NewRunningBackupsRegistry(

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -141,8 +141,11 @@ func (r *RunningBackupsRegistryImpl) scanSingleRoutineHistory(ctx context.Contex
 	// Cancel any previous scan that might still be running
 	tracker.cancelScan()
 
-	// Always signal that the (first) sync is done, even on failure.
-	defer tracker.signalSyncDone()
+	// beginScan unblocks getState callers waiting on the cancelled scan
+	// and installs a new channel. endScan closes it when this scan finishes,
+	// so getState always sees post-scan data.
+	scanCh := tracker.beginScan()
+	defer tracker.endScan(scanCh)
 
 	ctxWithCancel, cancelFunc := context.WithCancel(ctx)
 	defer cancelFunc()
@@ -181,13 +184,13 @@ func (r *RunningBackupsRegistryImpl) recordSuccessfulBackup(
 	routine *model.BackupRoutine,
 	backupType model.BackupType,
 ) {
-	r.getTracker(routine.Name).clearCompletedBackup(backupType)
+	r.getTracker(routine.Name).clearBackup(backupType)
 	r.scanSingleRoutineHistory(ctx, routine)
 }
 
 // clearFailedBackup deletes a backup from the registry.
 func (r *RunningBackupsRegistryImpl) clearFailedBackup(routineName string, backupType model.BackupType) {
-	r.getTracker(routineName).clearFailedBackup(backupType)
+	r.getTracker(routineName).clearBackup(backupType)
 }
 
 // GetRoutineState returns the current backup statistics for a routine.

--- a/pkg/service/running_backups_registry.go
+++ b/pkg/service/running_backups_registry.go
@@ -141,7 +141,7 @@ func (r *RunningBackupsRegistryImpl) scanSingleRoutineHistory(ctx context.Contex
 	// Cancel any previous scan that might still be running
 	tracker.cancelScan()
 
-	// beginScan unblocks getState callers waiting on the cancelled scan
+	// beginScan unblocks getState callers waiting on the canceled scan
 	// and installs a new channel. endScan closes it when this scan finishes,
 	// so getState always sees post-scan data.
 	scanCh := tracker.beginScan()
@@ -193,7 +193,7 @@ func (r *RunningBackupsRegistryImpl) recordSuccessfulBackup(
 	backupType model.BackupType,
 ) {
 	r.getTracker(routine.Name).clearBackup(backupType)
-	r.scanSingleRoutineHistory(ctx, routine)
+	_ = r.scanSingleRoutineHistory(ctx, routine)
 }
 
 // clearFailedBackup deletes a backup from the registry.

--- a/pkg/service/running_backups_registry_test.go
+++ b/pkg/service/running_backups_registry_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/backup-go/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -145,7 +146,7 @@ func TestCanceledHistoryScanKeepsPreviousLastRun(t *testing.T) {
 	registry.getTracker(routineName).markScanDone()
 
 	err := registry.scanSingleRoutineHistory(t.Context(), routine)
-	assert.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
 
 	stat := registry.GetRoutineState(routine)
 	assert.Equal(t, previous, stat.LastRunTime)

--- a/pkg/service/running_backups_registry_test.go
+++ b/pkg/service/running_backups_registry_test.go
@@ -25,7 +25,7 @@ func TestRegisterAndCurrentStat(t *testing.T) {
 
 	// Register a full backup handler
 	registry.register(routineName, model.BackupTypeFull, handler)
-	registry.getTracker(routineName).signalSyncDone() // no need to scan history
+	registry.getTracker(routineName).markScanDone() // no need to scan history
 
 	stat := registry.GetRoutineState(&model.BackupRoutine{
 		Name: routineName,
@@ -86,7 +86,7 @@ func TestFinishFull(t *testing.T) {
 	}
 
 	registry.register(routineName, model.BackupTypeFull, handler)
-	registry.getTracker(routineName).signalSyncDone()
+	registry.getTracker(routineName).markScanDone()
 
 	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeFull)
 
@@ -117,7 +117,7 @@ func TestFinishIncremental(t *testing.T) {
 	}
 
 	registry.register(routineName, model.BackupTypeIncremental, handler)
-	registry.getTracker(routineName).signalSyncDone()
+	registry.getTracker(routineName).markScanDone()
 
 	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeIncremental)
 
@@ -157,9 +157,9 @@ func TestGetAllCurrentStats(t *testing.T) {
 
 	// Register handlers for multiple routines
 	registry.register(routine1, model.BackupTypeFull, handler)
-	registry.getTracker(routine1).signalSyncDone() // no need to scan history
+	registry.getTracker(routine1).markScanDone() // no need to scan history
 	registry.register(routine2, model.BackupTypeIncremental, handler)
-	registry.getTracker(routine2).signalSyncDone() // no need to scan history
+	registry.getTracker(routine2).markScanDone() // no need to scan history
 
 	// Get all current stats
 	stats := registry.GetRunningState()

--- a/pkg/service/running_backups_registry_test.go
+++ b/pkg/service/running_backups_registry_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -88,7 +89,7 @@ func TestFinishFull(t *testing.T) {
 	registry.register(routineName, model.BackupTypeFull, handler)
 	registry.getTracker(routineName).markScanDone()
 
-	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeFull)
+	registry.recordSuccessfulBackup(routine, model.BackupTypeFull)
 
 	stat := registry.GetRoutineState(routine)
 	assert.Nil(t, stat.Full)
@@ -119,12 +120,35 @@ func TestFinishIncremental(t *testing.T) {
 	registry.register(routineName, model.BackupTypeIncremental, handler)
 	registry.getTracker(routineName).markScanDone()
 
-	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeIncremental)
+	registry.recordSuccessfulBackup(routine, model.BackupTypeIncremental)
 
 	stat := registry.GetRoutineState(routine)
 	assert.Nil(t, stat.Full)
 	assert.Nil(t, stat.Incremental)
 	assert.Equal(t, now, *stat.LastRunTime.IncrementalBackupTime())
+}
+
+func TestCanceledHistoryScanKeepsPreviousLastRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	previous := model.NewFullBackupTime(time.Now())
+	historyMgr := NewMockHistoryManager(ctrl)
+	historyMgr.EXPECT().FindLastRun(gomock.Any(), gomock.Any()).Return(nil, context.Canceled).Times(1)
+
+	registry := NewRunningBackupsRegistry(historyMgr, nil)
+	routine := &model.BackupRoutine{
+		Name:         routineName,
+		IntervalCron: "@daily",
+	}
+	registry.getTracker(routineName).setLastRun(previous)
+	registry.getTracker(routineName).markScanDone()
+
+	err := registry.scanSingleRoutineHistory(t.Context(), routine)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	stat := registry.GetRoutineState(routine)
+	assert.Equal(t, previous, stat.LastRunTime)
 }
 
 func TestGetAllCurrentStats(t *testing.T) {

--- a/pkg/service/running_backups_registry_test.go
+++ b/pkg/service/running_backups_registry_test.go
@@ -69,21 +69,26 @@ func TestFinishFull(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	registry := NewRunningBackupsRegistry(nil, nil)
+	now := time.Now()
+	backupTime := model.NewFullBackupTime(now)
+
+	historyMgr := NewMockHistoryManager(ctrl)
+	historyMgr.EXPECT().FindLastRun(gomock.Any(), gomock.Any()).Return(backupTime, nil).Times(1)
+
+	registry := NewRunningBackupsRegistry(historyMgr, nil)
 
 	handler := NewMockCancelableBackupHandler(ctrl)
 	handler.EXPECT().GetMetrics().Return(&models.Metrics{}).AnyTimes()
-
-	registry.register(routineName, model.BackupTypeFull, handler)
-	registry.getTracker(routineName).signalSyncDone() // no need to scan history
-
-	now := time.Now()
-	registry.recordSuccessfulBackup(routineName, model.BackupTypeFull, now)
 
 	routine := &model.BackupRoutine{
 		Name:         routineName,
 		IntervalCron: "@daily",
 	}
+
+	registry.register(routineName, model.BackupTypeFull, handler)
+	registry.getTracker(routineName).signalSyncDone()
+
+	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeFull)
 
 	stat := registry.GetRoutineState(routine)
 	assert.Nil(t, stat.Full)
@@ -95,22 +100,26 @@ func TestFinishIncremental(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	registry := NewRunningBackupsRegistry(nil, nil)
+	now := time.Now()
+	backupTime := model.NewBackupTime(now.Add(-1*time.Second), now)
+
+	historyMgr := NewMockHistoryManager(ctrl)
+	historyMgr.EXPECT().FindLastRun(gomock.Any(), gomock.Any()).Return(backupTime, nil).Times(1)
+
+	registry := NewRunningBackupsRegistry(historyMgr, nil)
 
 	handler := NewMockCancelableBackupHandler(ctrl)
 	handler.EXPECT().GetMetrics().Return(&models.Metrics{}).AnyTimes()
-
-	registry.register(routineName, model.BackupTypeIncremental, handler)
-	registry.getTracker(routineName).signalSyncDone() // no need to scan history
-
-	now := time.Now()
-	registry.recordSuccessfulBackup(routineName, model.BackupTypeFull, now.Add(-1*time.Second))
-	registry.recordSuccessfulBackup(routineName, model.BackupTypeIncremental, now)
 
 	routine := &model.BackupRoutine{
 		Name:         routineName,
 		IntervalCron: "@daily",
 	}
+
+	registry.register(routineName, model.BackupTypeIncremental, handler)
+	registry.getTracker(routineName).signalSyncDone()
+
+	registry.recordSuccessfulBackup(t.Context(), routine, model.BackupTypeIncremental)
 
 	stat := registry.GetRoutineState(routine)
 	assert.Nil(t, stat.Full)

--- a/pkg/util/timeutil/measure.go
+++ b/pkg/util/timeutil/measure.go
@@ -7,3 +7,10 @@ func MeasureDuration(f func() error) (time.Duration, error) {
 	err := f()
 	return time.Since(startTime), err
 }
+
+// MeasureDurationWithResult measures the duration of a function that returns a value and an error.
+func MeasureDurationWithResult[T any](f func() (T, error)) (T, time.Duration, error) {
+	startTime := time.Now()
+	value, err := f()
+	return value, time.Since(startTime), err
+}


### PR DESCRIPTION
Instead of setting last timestamp, we trigger new storage rescan. That make logic more robust when multithreading