### PR TITLE
Introduce Enterprise Audit & RBAC Foundation

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -14,8 +14,6 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/log"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server"
-	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/audit"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +64,7 @@ func startService(configFile string, remote bool) error {
 	ctx, stop := systemCtx()
 	defer stop()
 
-	scheduler, httpService, auditor, err := app.InitComponents(ctx, configFile, remote)
+	scheduler, _, httpServer, err := app.InitComponents(ctx, configFile, remote)
 	if err != nil {
 		return err
 	}
@@ -74,7 +72,7 @@ func startService(configFile string, remote bool) error {
 	// start the scheduler only after all the initialization is done
 	scheduler.Start(ctx)
 
-	err = runHTTPServer(ctx, httpService, auditor)
+	err = runHTTPServer(ctx, httpServer)
 
 	// stop the scheduler
 	scheduler.Stop()
@@ -86,9 +84,7 @@ func systemCtx() (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 }
 
-func runHTTPServer(ctx context.Context, service *handlers.Service, auditor audit.Auditor) error {
-	httpServer := server.NewHTTPServer(service)
-
+func runHTTPServer(ctx context.Context, httpServer server.Server) error {
 	// Channel to capture server startup errors
 	errCh := make(chan error, 1)
 	go func() {
@@ -109,7 +105,6 @@ func runHTTPServer(ctx context.Context, service *handlers.Service, auditor audit
 		return err
 	}
 
-	auditor.WriteEvent(context.Background(), "ServerShutdown", audit.StatusSuccess)
 	slog.Info("HTTP server shut down gracefully")
 
 	return nil

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -86,7 +86,7 @@ func systemCtx() (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 }
 
-func runHTTPServer(ctx context.Context, service *handlers.Service, auditor *audit.SimpleAuditor) error {
+func runHTTPServer(ctx context.Context, service *handlers.Service, auditor audit.Auditor) error {
 	httpServer := server.NewHTTPServer(service)
 
 	// Channel to capture server startup errors

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/internal/log"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/audit"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +66,7 @@ func startService(configFile string, remote bool) error {
 	ctx, stop := systemCtx()
 	defer stop()
 
-	scheduler, httpService, err := app.InitComponents(ctx, configFile, remote)
+	scheduler, httpService, auditor, err := app.InitComponents(ctx, configFile, remote)
 	if err != nil {
 		return err
 	}
@@ -73,7 +74,7 @@ func startService(configFile string, remote bool) error {
 	// start the scheduler only after all the initialization is done
 	scheduler.Start(ctx)
 
-	err = runHTTPServer(ctx, httpService)
+	err = runHTTPServer(ctx, httpService, auditor)
 
 	// stop the scheduler
 	scheduler.Stop()
@@ -85,7 +86,7 @@ func systemCtx() (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 }
 
-func runHTTPServer(ctx context.Context, service *handlers.Service) error {
+func runHTTPServer(ctx context.Context, service *handlers.Service, auditor *audit.SimpleAuditor) error {
 	httpServer := server.NewHTTPServer(service)
 
 	// Channel to capture server startup errors
@@ -108,6 +109,7 @@ func runHTTPServer(ctx context.Context, service *handlers.Service) error {
 		return err
 	}
 
+	auditor.WriteEvent(context.Background(), "ServerShutdown", audit.StatusSuccess)
 	slog.Info("HTTP server shut down gracefully")
 
 	return nil

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -10,6 +10,7 @@ import (
 
 	backup "github.com/aerospike/aerospike-backup-service/v3"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/log"
+	"github.com/aerospike/aerospike-backup-service/v3/internal/server"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/configuration"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/audit"
@@ -33,7 +34,7 @@ func InitComponents(
 	ctx context.Context,
 	configFile string,
 	remote bool,
-) (quartz.Scheduler, *handlers.Service, audit.Auditor, error) {
+) (quartz.Scheduler, *handlers.Service, server.Server, error) {
 	resolver := secrets.NewResolver(ctx)
 	operations := newStorageOperations(ctx, resolver)
 	clientManager, nsValidator := newAerospikeLayer(resolver)
@@ -128,7 +129,10 @@ func InitComponents(
 		auditRegistry,
 	)
 
-	return scheduler, httpService, auditor, nil
+	httpServer := server.NewHTTPServer(httpService)
+	auditServer := audit.NewAuditServer(httpServer, auditor)
+
+	return scheduler, httpService, auditServer, nil
 }
 
 func newStorageOperations(ctx context.Context, resolver secrets.Resolver) *storage.Operations {

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -114,15 +114,18 @@ func InitComponents(
 	auditRestoreManager := audit.NewAuditRestoreManager(restoreMgr, auditor)
 	auditBackupScheduler := audit.NewAuditAdHocScheduler(backupScheduler, auditor)
 
+	auditConfigRetriever := audit.NewAuditConfigRetriever(configRetriever)
+	auditBackupReader := audit.NewAuditBackupReader(backendService)
+	auditRegistry := audit.NewAuditRunningBackupsRegistry(registry, auditor)
+
 	httpService := handlers.NewService(
 		ctx,
-		config,
 		auditConfigManager,
 		auditBackupScheduler,
 		auditRestoreManager,
-		configRetriever,
-		backendService,
-		registry,
+		auditConfigRetriever,
+		auditBackupReader,
+		auditRegistry,
 	)
 
 	return scheduler, httpService, nil

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -33,7 +33,7 @@ func InitComponents(
 	ctx context.Context,
 	configFile string,
 	remote bool,
-) (quartz.Scheduler, *handlers.Service, *audit.SimpleAuditor, error) {
+) (quartz.Scheduler, *handlers.Service, audit.Auditor, error) {
 	resolver := secrets.NewResolver(ctx)
 	operations := newStorageOperations(ctx, resolver)
 	clientManager, nsValidator := newAerospikeLayer(resolver)

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	backup "github.com/aerospike/aerospike-backup-service/v3"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/log"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/configuration"
 	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/audit"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
@@ -95,17 +97,32 @@ func InitComponents(
 	prometheus.NewMetricsCollector(registry, restoreJobs).Start(ctx, 1*time.Second)
 
 	configRetriever := service.NewConfigRetriever(backendService, pathService, operations)
+
+	auditor := audit.NewSimpleAuditor(appLogger)
+
+	configManagerImpl := handlers.NewConfigManagerImpl(
+		ctx,
+		config,
+		&sync.Mutex{},
+		nsValidator,
+		configurationManager,
+		configApplier,
+	)
+
+	auditConfigManager := audit.NewAuditConfigManager(configManagerImpl, auditor)
+
+	auditRestoreManager := audit.NewAuditRestoreManager(restoreMgr, auditor)
+	auditBackupScheduler := audit.NewAuditAdHocScheduler(backupScheduler, auditor)
+
 	httpService := handlers.NewService(
 		ctx,
 		config,
-		configApplier,
-		backupScheduler,
-		restoreMgr,
+		auditConfigManager,
+		auditBackupScheduler,
+		auditRestoreManager,
 		configRetriever,
 		backendService,
 		registry,
-		configurationManager,
-		nsValidator,
 	)
 
 	return scheduler, httpService, nil

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -98,7 +98,7 @@ func InitComponents(
 
 	configRetriever := service.NewConfigRetriever(backendService, pathService, operations)
 
-	auditor := audit.NewSimpleAuditor(appLogger)
+	auditor := audit.NewLoggerAuditor(appLogger)
 
 	configManagerImpl := handlers.NewConfigManagerImpl(
 		ctx,

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -33,21 +33,21 @@ func InitComponents(
 	ctx context.Context,
 	configFile string,
 	remote bool,
-) (quartz.Scheduler, *handlers.Service, error) {
+) (quartz.Scheduler, *handlers.Service, *audit.SimpleAuditor, error) {
 	resolver := secrets.NewResolver(ctx)
 	operations := newStorageOperations(ctx, resolver)
 	clientManager, nsValidator := newAerospikeLayer(resolver)
 
 	config, configurationManager, err := configuration.Load(ctx, configFile, remote, nsValidator, operations)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
 	appLogger := initLogger(config)
 
 	scheduler, err := service.NewScheduler(ctx, appLogger)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create scheduler: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create scheduler: %w", err)
 	}
 
 	pathService := service.NewPathService(config.ServiceConfig.GetBackupCommonOrDefault().TimestampFormat)
@@ -79,7 +79,7 @@ func InitComponents(
 
 	err = configApplier.ApplyNewConfig(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to apply new config: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to apply new config: %w", err)
 	}
 
 	restoreJobs := service.NewRestoreJobsHolder()
@@ -128,7 +128,7 @@ func InitComponents(
 		auditRegistry,
 	)
 
-	return scheduler, httpService, nil
+	return scheduler, httpService, auditor, nil
 }
 
 func newStorageOperations(ctx context.Context, resolver secrets.Resolver) *storage.Operations {

--- a/internal/server/handlers/backup.go
+++ b/internal/server/handlers/backup.go
@@ -29,8 +29,8 @@ func (s *Service) GetAllFullBackups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := s.readAllBackups(r.Context(), func(routine *model.BackupRoutine) service.BackupFilter {
-		return service.NewFullBackupFilter(routine).WithTimeBounds(timeBounds)
+	result, err := s.readAllBackups(r.Context(), func(routine string) service.BackupFilter {
+		return service.NewFullBackupFilter(&model.BackupRoutine{Name: routine}).WithTimeBounds(timeBounds)
 	})
 	if err != nil {
 		httpError(w, err)
@@ -64,13 +64,13 @@ func (s *Service) GetFullBackupsForRoutine(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	routine, found := s.config.Routine(routineName)
-	if !found {
+	_, found := s.configManager.ReadRoutine(r.Context(), routineName)
+	if found != nil {
 		httpError(w, errRoutineNotFound(routineName))
 		return
 	}
 
-	filter := service.NewFullBackupFilter(routine).WithTimeBounds(timeBounds)
+	filter := service.NewFullBackupFilter(&model.BackupRoutine{Name: routineName}).WithTimeBounds(timeBounds)
 	result, err := s.readBackupsForRoutine(r.Context(), filter)
 	if err != nil {
 		httpError(w, err)
@@ -97,8 +97,8 @@ func (s *Service) GetAllIncrementalBackups(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	result, err := s.readAllBackups(r.Context(), func(routine *model.BackupRoutine) service.BackupFilter {
-		return service.NewIncrementalBackupFilter(routine).WithTimeBounds(timeBounds)
+	result, err := s.readAllBackups(r.Context(), func(routine string) service.BackupFilter {
+		return service.NewIncrementalBackupFilter(&model.BackupRoutine{Name: routine}).WithTimeBounds(timeBounds)
 	})
 	if err != nil {
 		httpError(w, err)
@@ -132,13 +132,13 @@ func (s *Service) GetIncrementalBackupsForRoutine(w http.ResponseWriter, r *http
 		return
 	}
 
-	routine, found := s.config.Routine(routineName)
-	if !found {
+	_, found := s.configManager.ReadRoutine(r.Context(), routineName)
+	if found != nil {
 		httpError(w, errRoutineNotFound(routineName))
 		return
 	}
 
-	filter := service.NewIncrementalBackupFilter(routine).WithTimeBounds(timeBounds)
+	filter := service.NewIncrementalBackupFilter(&model.BackupRoutine{Name: routineName}).WithTimeBounds(timeBounds)
 	result, err := s.readBackupsForRoutine(r.Context(), filter)
 	if err != nil {
 		httpError(w, err)
@@ -150,16 +150,16 @@ func (s *Service) GetIncrementalBackupsForRoutine(w http.ResponseWriter, r *http
 
 func (s *Service) readAllBackups(
 	ctx context.Context,
-	filter func(routine *model.BackupRoutine) service.BackupFilter,
+	filter func(routine string) service.BackupFilter,
 ) (map[string][]*dto.BackupDetails, error) {
 	result := make(map[string][]*dto.BackupDetails)
-	for _, routine := range s.config.Routines() {
-		routineBackups, err := s.readBackupsForRoutine(ctx, filter(routine))
+	for name := range s.configManager.ReadRoutines(ctx) {
+		routineBackups, err := s.readBackupsForRoutine(ctx, filter(name))
 		if err != nil {
 			return nil, err
 		}
 
-		result[routine.Name] = routineBackups
+		result[name] = routineBackups
 	}
 
 	return result, nil
@@ -174,10 +174,18 @@ func (s *Service) readBackupsForRoutine(
 		return nil, err
 	}
 
-	backupConfig := s.config.BackupConfigCopy()
-	backupDetails := dto.ConvertModelsToDTO(backupList, func(m *model.BackupDetails) *dto.BackupDetails {
-		return dto.NewBackupDetailsFromModel(m, backupConfig)
-	})
+	backupConfig := s.configManager.ReadConfig(ctx)
+	// Fallback mechanism to parse it into model just to get the properties for the DTO
+	backupConfigModel, err := backupConfig.ToModel(dto.ValidationSkipTLSFiles)
+	if err != nil {
+		backupConfigModel = model.NewConfig()
+	}
+
+	backupDetails := make([]*dto.BackupDetails, 0, len(backupList))
+	for i := range backupList {
+		backupDetails = append(
+			backupDetails, dto.NewBackupDetailsFromModel(&backupList[i], backupConfigModel.BackupConfigCopy()))
+	}
 
 	return backupDetails, nil
 }
@@ -237,11 +245,12 @@ func (s *Service) scheduleBackup(
 		return
 	}
 
-	routine, found := s.config.Routine(routineName)
-	if !found {
+	_, err := s.configManager.ReadRoutine(r.Context(), routineName)
+	if err != nil {
 		httpError(w, errRoutineNotFound(routineName))
 		return
 	}
+	routineModel := &model.BackupRoutine{Name: routineName}
 
 	delayMillis, err := parseDelay(r.URL.Query().Get("delay"))
 	if err != nil {
@@ -249,7 +258,7 @@ func (s *Service) scheduleBackup(
 		return
 	}
 
-	err = triggerBackup(routine, time.Duration(delayMillis)*time.Millisecond)
+	err = triggerBackup(routineModel, time.Duration(delayMillis)*time.Millisecond)
 	if err != nil {
 		httpError(w, errors.New("failed to schedule job"))
 		return
@@ -288,13 +297,13 @@ func (s *Service) GetCurrentBackupInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	routine, found := s.config.Routine(routineName)
-	if !found {
+	_, err := s.configManager.ReadRoutine(r.Context(), routineName)
+	if err != nil {
 		httpError(w, errRoutineNotFound(routineName))
 		return
 	}
 
-	currentBackups := dto.NewRoutineStateFromModel(s.registry.GetRoutineState(routine))
+	currentBackups := dto.NewRoutineStateFromModel(s.registry.GetRoutineState(&model.BackupRoutine{Name: routineName}))
 	httpOK(w, currentBackups)
 }
 
@@ -313,7 +322,7 @@ func (s *Service) CancelCurrentBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, found := s.config.Routine(routineName); !found {
+	if _, err := s.configManager.ReadRoutine(r.Context(), routineName); err != nil {
 		httpError(w, errRoutineNotFound(routineName))
 		return
 	}

--- a/internal/server/handlers/backup_test.go
+++ b/internal/server/handlers/backup_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -67,11 +68,13 @@ func TestService_GetAllFullBackups(t *testing.T) {
 			cfg := model.NewConfig()
 			_ = cfg.AddRoutine(&model.BackupRoutine{Name: "routine1"})
 
+			configManager := NewConfigManagerImpl(t.Context(), cfg, &sync.Mutex{}, nil, nil, nil)
+
 			tt.setupMock(mockBackends)
 
 			svc := &Service{
-				config:       cfg,
-				backupReader: mockBackends,
+				configManager: configManager,
+				backupReader:  mockBackends,
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/backups/full", nil)
@@ -130,8 +133,10 @@ func TestService_ScheduleBackupHappyPath(t *testing.T) {
 	config := model.NewConfig()
 	_ = config.AddRoutine(&model.BackupRoutine{Name: "test-routine"})
 
+	configManager := NewConfigManagerImpl(t.Context(), config, &sync.Mutex{}, nil, nil, nil)
+
 	svc := &Service{
-		config: config,
+		configManager: configManager,
 	}
 
 	const incrementalURL = "/v1/backups/incremental/test-routine?delay=1000"
@@ -190,11 +195,15 @@ func testScheduleBackupValidation(
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := model.NewConfig()
-			_ = config.AddRoutine(&model.BackupRoutine{Name: tt.routineName})
+			if tt.routineName != "missing-routine" {
+				_ = config.AddRoutine(&model.BackupRoutine{Name: tt.routineName})
+			}
+
+			configManager := NewConfigManagerImpl(t.Context(), config, &sync.Mutex{}, nil, nil, nil)
 
 			svc := &Service{
 				backupScheduler: service.NewBackupScheduler(nil, nil),
-				config:          config,
+				configManager:   configManager,
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, pathPrefix+tt.routineName, nil)

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -1,14 +1,10 @@
 package handlers
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/validation"
 )
 
 func (s *Service) ConfigActionHandler(_ http.ResponseWriter, _ *http.Request) {
@@ -42,28 +38,9 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// validate static fields.
-	oldConfig := dto.NewConfigFromModel(s.config)
-	if err := validation.ValidateStaticFieldChanges(oldConfig, newConfig); err != nil {
-		httpError(w, errBadRequest(fmt.Errorf("static configuration has changed: %w", err)))
-		return
-	}
-
-	newConfigModel, err := newConfig.ToModel()
+	err = s.configManager.UpdateConfig(r.Context(), newConfig)
 	if err != nil {
 		httpError(w, errBadRequest(err))
-		return
-	}
-
-	err = s.changeConfig(r.Context(), func(config *model.Config) error {
-		config.SetBackupConfig(newConfigModel.BackupConfigCopy())
-		config.InvalidateAllRoutines()
-		s.nsValidator.Validate(r.Context(), config) // validate under the lock
-		return nil
-	})
-
-	if err != nil {
-		httpError(w, err)
 		return
 	}
 
@@ -79,56 +56,11 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 // @Success     200
 // @Failure     400 {string} string
 func (s *Service) ApplyConfig(w http.ResponseWriter, r *http.Request) {
-	// ApplyConfig and changeConfig must be synchronized to prevent race conditions
-	// where one operation reads/writes config while another is in the middle of updating it
-	s.changeConfigLock.Lock()
-	defer s.changeConfigLock.Unlock()
-
-	config, err := s.configurationManager.Read(r.Context())
-	if err != nil {
-		httpError(w, fmt.Errorf("failed to read configuration: %w", err))
-		return
-	}
-
-	// validate static fields.
-	newConfig := dto.NewConfigFromModel(s.config)
-	oldConfig := dto.NewConfigFromModel(config)
-	if err := validation.ValidateStaticFieldChanges(oldConfig, newConfig); err != nil {
-		httpError(w, errBadRequest(fmt.Errorf("static configuration has changed: %w", err)))
-		return
-	}
-
-	s.config.SetBackupConfig(config.BackupConfigCopy())
-	s.config.InvalidateAllRoutines()
-	err = s.configApplier.ApplyNewConfig(s.sysCtx)
-
+	err := s.configManager.ApplyConfig(r.Context())
 	if err != nil {
 		httpError(w, err)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)
-}
-
-func (s *Service) changeConfig(ctx context.Context, updateFunc func(*model.Config) error) error {
-	// ApplyConfig and changeConfig must be synchronized to prevent race conditions
-	// where one operation reads/writes config while another is in the middle of updating it
-	s.changeConfigLock.Lock()
-	defer s.changeConfigLock.Unlock()
-
-	err := updateFunc(s.config)
-	if err != nil {
-		return fmt.Errorf("failed to update configuration: %w", err)
-	}
-
-	err = s.configurationManager.Write(ctx, s.config)
-	if err != nil {
-		return fmt.Errorf("failed to write configuration: %w", err)
-	}
-
-	err = s.configApplier.ApplyNewConfig(s.sysCtx)
-	if err != nil {
-		return fmt.Errorf("failed to apply new configuration: %w", err)
-	}
-
-	return nil
 }

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -18,8 +18,8 @@ func (s *Service) ConfigActionHandler(_ http.ResponseWriter, _ *http.Request) {
 // @Router      /v1/config [get]
 // @Produce     json
 // @Success     200 {object} dto.Config
-func (s *Service) ReadConfig(w http.ResponseWriter, _ *http.Request) {
-	httpOK(w, dto.NewConfigFromModel(s.config))
+func (s *Service) ReadConfig(w http.ResponseWriter, r *http.Request) {
+	httpOK(w, s.configManager.ReadConfig(r.Context()))
 }
 
 // UpdateConfig

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -3,24 +3,60 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"sync"
 
+	"github.com/aerospike/aerospike-backup-service/v3/internal/server/configuration"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/validation"
 )
 
-type backupConfigChangeOptions struct {
+type BackupConfigChangeOptions struct {
 	validateNamespaces bool
 }
 
-// changeBackupConfig applies a mutation to the backup configuration DTO, validates the
+// ConfigManagerImpl applies mutations to the configuration.
+type ConfigManagerImpl struct {
+	config               *model.Config
+	changeConfigLock     *sync.Mutex
+	nsValidator          aerospike.NamespaceValidator
+	configurationManager configuration.Manager
+	configApplier        service.ConfigApplier
+	sysCtx               context.Context //nolint:containedctx
+}
+
+// NewConfigManagerImpl creates a new configuration manager.
+func NewConfigManagerImpl(
+	sysCtx context.Context,
+	config *model.Config,
+	changeConfigLock *sync.Mutex,
+	nsValidator aerospike.NamespaceValidator,
+	configurationManager configuration.Manager,
+	configApplier service.ConfigApplier,
+) *ConfigManagerImpl {
+	return &ConfigManagerImpl{
+		config:               config,
+		changeConfigLock:     changeConfigLock,
+		nsValidator:          nsValidator,
+		configurationManager: configurationManager,
+		configApplier:        configApplier,
+		sysCtx:               sysCtx,
+	}
+}
+
+// ChangeBackupConfig applies a mutation to the backup configuration DTO, validates the
 // full configuration via ToModel, and persists the result.
 // The mutate function returns routine names that should be rescheduled and rescanned.
-func (s *Service) changeBackupConfig(
+func (s *ConfigManagerImpl) ChangeBackupConfig(
 	ctx context.Context,
+	action string,
+	resourceID string,
 	mutate func(*dto.Config) ([]string, error),
-	opts ...func(*backupConfigChangeOptions),
+	opts ...func(*BackupConfigChangeOptions),
 ) error {
-	options := backupConfigChangeOptions{}
+	options := BackupConfigChangeOptions{}
 	for _, opt := range opts {
 		opt(&options)
 	}
@@ -57,7 +93,7 @@ func (s *Service) changeBackupConfig(
 	return nil
 }
 
-func withNamespaceValidation(opts *backupConfigChangeOptions) {
+func WithNamespaceValidation(opts *BackupConfigChangeOptions) {
 	opts.validateNamespaces = true
 }
 
@@ -96,5 +132,71 @@ func ensureStorageNotInUse(config *dto.Config, storageName string) error {
 			return fmt.Errorf("delete storage %q: %w: it is used in routine %q", storageName, model.ErrInUse, routineName)
 		}
 	}
+	return nil
+}
+
+// UpdateConfig updates the configuration for the service.
+func (s *ConfigManagerImpl) UpdateConfig(ctx context.Context, newConfig *dto.Config) error {
+	// validate static fields.
+	oldConfig := dto.NewConfigFromModel(s.config)
+	if err := validation.ValidateStaticFieldChanges(oldConfig, newConfig); err != nil {
+		return fmt.Errorf("static configuration has changed: %w", err)
+	}
+
+	newConfigModel, err := newConfig.ToModel(dto.ValidationSkipTLSFiles) // matching what UpdateConfig did
+	if err != nil {
+		return err
+	}
+
+	return s.changeConfig(ctx, func(config *model.Config) error {
+		config.SetBackupConfig(newConfigModel.BackupConfigCopy())
+		config.InvalidateAllRoutines()
+		s.nsValidator.Validate(ctx, config) // validate under the lock
+		return nil
+	})
+}
+
+// ApplyConfig reloads the configuration from the config file.
+func (s *ConfigManagerImpl) ApplyConfig(ctx context.Context) error {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+
+	config, err := s.configurationManager.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to read configuration: %w", err)
+	}
+
+	newConfig := dto.NewConfigFromModel(s.config)
+	oldConfig := dto.NewConfigFromModel(config)
+	if err := validation.ValidateStaticFieldChanges(oldConfig, newConfig); err != nil {
+		return fmt.Errorf("static configuration has changed: %w", err)
+	}
+
+	s.config.SetBackupConfig(config.BackupConfigCopy())
+	s.config.InvalidateAllRoutines()
+	err = s.configApplier.ApplyNewConfig(s.sysCtx)
+
+	return err
+}
+
+func (s *ConfigManagerImpl) changeConfig(ctx context.Context, updateFunc func(*model.Config) error) error {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+
+	err := updateFunc(s.config)
+	if err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
+
+	err = s.configurationManager.Write(ctx, s.config)
+	if err != nil {
+		return fmt.Errorf("failed to write configuration: %w", err)
+	}
+
+	err = s.configApplier.ApplyNewConfig(s.sysCtx)
+	if err != nil {
+		return fmt.Errorf("failed to apply new configuration: %w", err)
+	}
+
 	return nil
 }

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -46,13 +46,159 @@ func NewConfigManagerImpl(
 	}
 }
 
-// ChangeBackupConfig applies a mutation to the backup configuration DTO, validates the
-// full configuration via ToModel, and persists the result.
-// The mutate function returns routine names that should be rescheduled and rescanned.
-func (s *ConfigManagerImpl) ChangeBackupConfig(
+func (s *ConfigManagerImpl) AddAerospikeCluster(ctx context.Context, name string, newCluster *dto.AerospikeCluster) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.AerospikeClusters[name]; exists {
+			return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
+		}
+		config.AerospikeClusters[name] = newCluster
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) UpdateAerospikeCluster(ctx context.Context, name string, updatedCluster *dto.AerospikeCluster) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.AerospikeClusters[name]; !exists {
+			return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)
+		}
+		config.AerospikeClusters[name] = updatedCluster
+		return nil, nil
+	}, WithNamespaceValidation)
+}
+
+func (s *ConfigManagerImpl) DeleteAerospikeCluster(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.AerospikeClusters[name]; !exists {
+			return nil, fmt.Errorf("delete Aerospike cluster %q: %w", name, model.ErrNotFound)
+		}
+		if err := ensureClusterNotInUse(config, name); err != nil {
+			return nil, err
+		}
+		delete(config.AerospikeClusters, name)
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) AddPolicy(ctx context.Context, name string, newPolicy *dto.BackupPolicy) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupPolicies[name]; exists {
+			return nil, fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
+		}
+		config.BackupPolicies[name] = newPolicy
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) UpdatePolicy(ctx context.Context, name string, updatedPolicy *dto.BackupPolicy) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupPolicies[name]; !exists {
+			return nil, fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
+		}
+		config.BackupPolicies[name] = updatedPolicy
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) DeletePolicy(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupPolicies[name]; !exists {
+			return nil, fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
+		}
+		if err := ensurePolicyNotInUse(config, name); err != nil {
+			return nil, err
+		}
+		delete(config.BackupPolicies, name)
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) AddRoutine(ctx context.Context, name string, newRoutine *dto.BackupRoutine) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupRoutines[name]; exists {
+			return nil, fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
+		}
+		config.BackupRoutines[name] = newRoutine
+		return []string{name}, nil
+	}, WithNamespaceValidation)
+}
+
+func (s *ConfigManagerImpl) UpdateRoutine(ctx context.Context, name string, updatedRoutine *dto.BackupRoutine) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupRoutines[name]; !exists {
+			return nil, fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
+		}
+		config.BackupRoutines[name] = updatedRoutine
+		return []string{name}, nil
+	}, WithNamespaceValidation)
+}
+
+func (s *ConfigManagerImpl) DeleteRoutine(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.BackupRoutines[name]; !exists {
+			return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
+		}
+		delete(config.BackupRoutines, name)
+		return []string{name}, nil
+	})
+}
+
+func (s *ConfigManagerImpl) EnableRoutine(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		routine, exists := config.BackupRoutines[name]
+		if !exists {
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
+		}
+		routine.Disabled = false
+		return []string{name}, nil
+	})
+}
+
+func (s *ConfigManagerImpl) DisableRoutine(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		routine, exists := config.BackupRoutines[name]
+		if !exists {
+			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
+		}
+		routine.Disabled = true
+		return []string{name}, nil
+	})
+}
+
+func (s *ConfigManagerImpl) AddStorage(ctx context.Context, name string, newStorage *dto.Storage) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.Storage[name]; exists {
+			return nil, fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
+		}
+		config.Storage[name] = newStorage
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) UpdateStorage(ctx context.Context, name string, updatedStorage *dto.Storage) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.Storage[name]; !exists {
+			return nil, fmt.Errorf("update storage %q: %w", name, model.ErrNotFound)
+		}
+		config.Storage[name] = updatedStorage
+		return routinesUsingStorage(config, name), nil
+	})
+}
+
+func (s *ConfigManagerImpl) DeleteStorage(ctx context.Context, name string) error {
+	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
+		if _, exists := config.Storage[name]; !exists {
+			return nil, fmt.Errorf("delete storage %q: %w", name, model.ErrNotFound)
+		}
+		if err := ensureStorageNotInUse(config, name); err != nil {
+			return nil, err
+		}
+		delete(config.Storage, name)
+		return nil, nil
+	})
+}
+
+func (s *ConfigManagerImpl) changeConfigInternal(
 	ctx context.Context,
-	action string,
-	resourceID string,
 	mutate func(*dto.Config) ([]string, error),
 	opts ...func(*BackupConfigChangeOptions),
 ) error {

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -13,10 +13,6 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/validation"
 )
 
-type BackupConfigChangeOptions struct {
-	validateNamespaces bool
-}
-
 // ConfigManagerImpl applies mutations to the configuration.
 type ConfigManagerImpl struct {
 	config               *model.Config
@@ -46,7 +42,89 @@ func NewConfigManagerImpl(
 	}
 }
 
-func (s *ConfigManagerImpl) AddAerospikeCluster(ctx context.Context, name string, newCluster *dto.AerospikeCluster) error {
+func (s *ConfigManagerImpl) ReadConfig(_ context.Context) *dto.Config {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	return dto.NewConfigFromModel(s.config)
+}
+
+func (s *ConfigManagerImpl) ReadAerospikeClusters(_ context.Context) map[string]*dto.AerospikeCluster {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	backupConfig := s.config.BackupConfigCopy()
+	return dto.ConvertModelMapToDTO(
+		backupConfig.AerospikeClusters,
+		func(m *model.AerospikeCluster) *dto.AerospikeCluster {
+			return dto.NewClusterFromModel(m, backupConfig)
+		})
+}
+
+func (s *ConfigManagerImpl) ReadAerospikeCluster(_ context.Context, name string) (*dto.AerospikeCluster, error) {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	backupConfig := s.config.BackupConfigCopy()
+	cluster, ok := backupConfig.AerospikeClusters[name]
+	if !ok {
+		return nil, fmt.Errorf("read Aerospike cluster %q: %w", name, model.ErrNotFound)
+	}
+	return dto.NewClusterFromModel(cluster, backupConfig), nil
+}
+
+func (s *ConfigManagerImpl) ReadPolicies(_ context.Context) map[string]*dto.BackupPolicy {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	return dto.ConvertModelMapToDTO(s.config.BackupConfigCopy().BackupPolicies, dto.NewBackupPolicyFromModel)
+}
+
+func (s *ConfigManagerImpl) ReadPolicy(_ context.Context, name string) (*dto.BackupPolicy, error) {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	policy, ok := s.config.BackupConfigCopy().BackupPolicies[name]
+	if !ok {
+		return nil, fmt.Errorf("read backup policy %q: %w", name, model.ErrNotFound)
+	}
+	return dto.NewBackupPolicyFromModel(policy), nil
+}
+
+func (s *ConfigManagerImpl) ReadRoutines(_ context.Context) map[string]*dto.BackupRoutine {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	return dto.ConvertModelMapToDTO(s.config.Routines(), func(m *model.BackupRoutine) *dto.BackupRoutine {
+		return dto.NewRoutineFromModel(m, s.config)
+	})
+}
+
+func (s *ConfigManagerImpl) ReadRoutine(_ context.Context, name string) (*dto.BackupRoutine, error) {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	routine, found := s.config.Routine(name)
+	if !found {
+		return nil, fmt.Errorf("read backup routine %q: %w", name, model.ErrNotFound)
+	}
+	return dto.NewRoutineFromModel(routine, s.config), nil
+}
+
+func (s *ConfigManagerImpl) ReadAllStorage(_ context.Context) map[string]*dto.Storage {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	backupConfig := s.config.BackupConfigCopy()
+	return dto.ConvertStorageMapToDTO(backupConfig.Storage, backupConfig)
+}
+
+func (s *ConfigManagerImpl) ReadStorage(_ context.Context, name string) (*dto.Storage, error) {
+	s.changeConfigLock.Lock()
+	defer s.changeConfigLock.Unlock()
+	backupConfig := s.config.BackupConfigCopy()
+	storage, ok := backupConfig.Storage[name]
+	if !ok {
+		return nil, fmt.Errorf("read storage %q: %w", name, model.ErrNotFound)
+	}
+	return dto.NewStorageFromModel(storage, backupConfig), nil
+}
+
+func (s *ConfigManagerImpl) AddAerospikeCluster(
+	ctx context.Context, name string, newCluster *dto.AerospikeCluster,
+) error {
 	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
 		if _, exists := config.AerospikeClusters[name]; exists {
 			return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
@@ -56,7 +134,9 @@ func (s *ConfigManagerImpl) AddAerospikeCluster(ctx context.Context, name string
 	})
 }
 
-func (s *ConfigManagerImpl) UpdateAerospikeCluster(ctx context.Context, name string, updatedCluster *dto.AerospikeCluster) error {
+func (s *ConfigManagerImpl) UpdateAerospikeCluster(
+	ctx context.Context, name string, updatedCluster *dto.AerospikeCluster,
+) error {
 	return s.changeConfigInternal(ctx, func(config *dto.Config) ([]string, error) {
 		if _, exists := config.AerospikeClusters[name]; !exists {
 			return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
 // AddAerospikeCluster
@@ -46,15 +45,8 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/clusters [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.AerospikeCluster
-func (s *Service) ReadAerospikeClusters(w http.ResponseWriter, _ *http.Request) {
-	backupConfig := s.config.BackupConfigCopy()
-	clusters := dto.ConvertModelMapToDTO(
-		backupConfig.AerospikeClusters,
-		func(m *model.AerospikeCluster) *dto.AerospikeCluster {
-			return dto.NewClusterFromModel(m, backupConfig)
-		})
-
-	httpOK(w, clusters)
+func (s *Service) ReadAerospikeClusters(w http.ResponseWriter, r *http.Request) {
+	httpOK(w, s.configManager.ReadAerospikeClusters(r.Context()))
 }
 
 // ReadAerospikeCluster reads a specific Aerospike cluster from the configuration given its name.
@@ -73,14 +65,14 @@ func (s *Service) ReadAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errMissingClusterName)
 		return
 	}
-	backupConfig := s.config.BackupConfigCopy()
-	cluster, ok := backupConfig.AerospikeClusters[name]
-	if !ok {
+
+	cluster, err := s.configManager.ReadAerospikeCluster(r.Context(), name)
+	if err != nil {
 		httpError(w, errNotFound("cluster", name))
 		return
 	}
 
-	httpOK(w, dto.NewClusterFromModel(cluster, backupConfig))
+	httpOK(w, cluster)
 }
 
 // UpdateAerospikeCluster updates an existing Aerospike cluster in the configuration.

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
@@ -32,14 +31,7 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddAerospikeCluster", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.AerospikeClusters[name]; exists {
-				return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
-			}
-			config.AerospikeClusters[name] = newCluster
-			return nil, nil
-		}); err != nil {
+	if err = s.configManager.AddAerospikeCluster(r.Context(), name, newCluster); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -114,14 +106,7 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateAerospikeCluster", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.AerospikeClusters[name]; !exists {
-				return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)
-			}
-			config.AerospikeClusters[name] = updatedCluster
-			return nil, nil
-		}, WithNamespaceValidation); err != nil {
+	if err = s.configManager.UpdateAerospikeCluster(r.Context(), name, updatedCluster); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -144,17 +129,7 @@ func (s *Service) DeleteAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteAerospikeCluster", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.AerospikeClusters[name]; !exists {
-				return nil, fmt.Errorf("delete Aerospike cluster %q: %w", name, model.ErrNotFound)
-			}
-			if err := ensureClusterNotInUse(config, name); err != nil {
-				return nil, err
-			}
-			delete(config.AerospikeClusters, name)
-			return nil, nil
-		})
+	err := s.configManager.DeleteAerospikeCluster(r.Context(), name)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_cluster.go
+++ b/internal/server/handlers/config_cluster.go
@@ -32,13 +32,14 @@ func (s *Service) AddAerospikeCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.AerospikeClusters[name]; exists {
-			return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
-		}
-		config.AerospikeClusters[name] = newCluster
-		return nil, nil
-	}); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddAerospikeCluster", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.AerospikeClusters[name]; exists {
+				return nil, fmt.Errorf("add Aerospike cluster %q: %w", name, model.ErrAlreadyExists)
+			}
+			config.AerospikeClusters[name] = newCluster
+			return nil, nil
+		}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -113,13 +114,14 @@ func (s *Service) UpdateAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.AerospikeClusters[name]; !exists {
-			return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)
-		}
-		config.AerospikeClusters[name] = updatedCluster
-		return nil, nil
-	}, withNamespaceValidation); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateAerospikeCluster", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.AerospikeClusters[name]; !exists {
+				return nil, fmt.Errorf("update Aerospike cluster %q: %w", name, model.ErrNotFound)
+			}
+			config.AerospikeClusters[name] = updatedCluster
+			return nil, nil
+		}, WithNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -142,16 +144,17 @@ func (s *Service) DeleteAerospikeCluster(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.AerospikeClusters[name]; !exists {
-			return nil, fmt.Errorf("delete Aerospike cluster %q: %w", name, model.ErrNotFound)
-		}
-		if err := ensureClusterNotInUse(config, name); err != nil {
-			return nil, err
-		}
-		delete(config.AerospikeClusters, name)
-		return nil, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteAerospikeCluster", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.AerospikeClusters[name]; !exists {
+				return nil, fmt.Errorf("delete Aerospike cluster %q: %w", name, model.ErrNotFound)
+			}
+			if err := ensureClusterNotInUse(config, name); err != nil {
+				return nil, err
+			}
+			delete(config.AerospikeClusters, name)
+			return nil, nil
+		})
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_cluster_test.go
+++ b/internal/server/handlers/config_cluster_test.go
@@ -79,10 +79,10 @@ func TestAddAerospikeCluster(t *testing.T) {
 
 func TestReadAerospikeClusters(t *testing.T) {
 	svc := setupTestService()
-	svc.config = model.NewConfig()
+	configManager := svc.configManager.(*ConfigManagerImpl)
 
-	_ = svc.config.AddCluster("cluster1", &model.AerospikeCluster{})
-	_ = svc.config.AddCluster("cluster2", &model.AerospikeCluster{})
+	_ = configManager.config.AddCluster("cluster1", &model.AerospikeCluster{})
+	_ = configManager.config.AddCluster("cluster2", &model.AerospikeCluster{})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/clusters", nil)
 	w := httptest.NewRecorder()
@@ -131,8 +131,9 @@ func TestReadAerospikeCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
+			configManager := svc.configManager.(*ConfigManagerImpl)
 			if tt.cluster != nil {
-				_ = svc.config.AddCluster(tt.clusterName, tt.cluster)
+				_ = configManager.config.AddCluster(tt.clusterName, tt.cluster)
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/clusters/"+tt.clusterName, nil)
@@ -188,13 +189,14 @@ func TestUpdateAerospikeCluster(t *testing.T) {
 
 			mockNsValidator := aerospike.NewMockNamespaceValidator(ctrl)
 			svc := setupTestService(mockNsValidator)
+			configManager := svc.configManager.(*ConfigManagerImpl)
 
 			if tt.runValidation {
-				mockNsValidator.EXPECT().Validate(gomock.Any(), gomock.Eq(svc.config))
+				mockNsValidator.EXPECT().Validate(gomock.Any(), gomock.Eq(configManager.config))
 			}
 
 			initialCluster := &model.AerospikeCluster{}
-			_ = svc.config.AddCluster("test-cluster", initialCluster)
+			_ = configManager.config.AddCluster("test-cluster", initialCluster)
 
 			req := httptest.NewRequestWithContext(
 				t.Context(),
@@ -245,7 +247,8 @@ func TestDeleteAerospikeCluster(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
-			_ = svc.config.AddCluster("test-cluster", &model.AerospikeCluster{})
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddCluster("test-cluster", &model.AerospikeCluster{})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/v1/config/clusters/"+tt.clusterName, nil)
 			req.SetPathValue("name", tt.clusterName)

--- a/internal/server/handlers/config_cluster_test.go
+++ b/internal/server/handlers/config_cluster_test.go
@@ -186,9 +186,8 @@ func TestUpdateAerospikeCluster(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			svc := setupTestService()
 			mockNsValidator := aerospike.NewMockNamespaceValidator(ctrl)
-			svc.nsValidator = mockNsValidator
+			svc := setupTestService(mockNsValidator)
 
 			if tt.runValidation {
 				mockNsValidator.EXPECT().Validate(gomock.Any(), gomock.Eq(svc.config))

--- a/internal/server/handlers/config_manager.go
+++ b/internal/server/handlers/config_manager.go
@@ -1,0 +1,30 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+)
+
+// ConfigManager defines the interface for mutating configuration state.
+// By isolating this in an interface, we guarantee that all config changes
+// can be intercepted for Auditing and future RBAC validation.
+type ConfigManager interface {
+	// ChangeBackupConfig applies a mutation to the backup configuration DTO,
+	// validates the full configuration via ToModel, and persists the result.
+	// action: e.g. "AddAerospikeCluster"
+	// resourceID: e.g. cluster name
+	ChangeBackupConfig(
+		ctx context.Context,
+		action string,
+		resourceID string,
+		mutate func(*dto.Config) ([]string, error),
+		opts ...func(*BackupConfigChangeOptions),
+	) error
+
+	// UpdateConfig updates the configuration for the service.
+	UpdateConfig(ctx context.Context, newConfig *dto.Config) error
+
+	// ApplyConfig reloads the configuration from the config file.
+	ApplyConfig(ctx context.Context) error
+}

--- a/internal/server/handlers/config_manager.go
+++ b/internal/server/handlers/config_manager.go
@@ -10,21 +10,24 @@ import (
 // By isolating this in an interface, we guarantee that all config changes
 // can be intercepted for Auditing and future RBAC validation.
 type ConfigManager interface {
-	// ChangeBackupConfig applies a mutation to the backup configuration DTO,
-	// validates the full configuration via ToModel, and persists the result.
-	// action: e.g. "AddAerospikeCluster"
-	// resourceID: e.g. cluster name
-	ChangeBackupConfig(
-		ctx context.Context,
-		action string,
-		resourceID string,
-		mutate func(*dto.Config) ([]string, error),
-		opts ...func(*BackupConfigChangeOptions),
-	) error
-
-	// UpdateConfig updates the configuration for the service.
 	UpdateConfig(ctx context.Context, newConfig *dto.Config) error
-
-	// ApplyConfig reloads the configuration from the config file.
 	ApplyConfig(ctx context.Context) error
+
+	AddAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error
+	UpdateAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error
+	DeleteAerospikeCluster(ctx context.Context, name string) error
+
+	AddPolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error
+	UpdatePolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error
+	DeletePolicy(ctx context.Context, name string) error
+
+	AddRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error
+	UpdateRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error
+	DeleteRoutine(ctx context.Context, name string) error
+	EnableRoutine(ctx context.Context, name string) error
+	DisableRoutine(ctx context.Context, name string) error
+
+	AddStorage(ctx context.Context, name string, storage *dto.Storage) error
+	UpdateStorage(ctx context.Context, name string, storage *dto.Storage) error
+	DeleteStorage(ctx context.Context, name string) error
 }

--- a/internal/server/handlers/config_manager.go
+++ b/internal/server/handlers/config_manager.go
@@ -6,28 +6,67 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 )
 
+type BackupConfigChangeOptions struct {
+	validateNamespaces bool
+}
+
 // ConfigManager defines the interface for mutating configuration state.
 // By isolating this in an interface, we guarantee that all config changes
 // can be intercepted for Auditing and future RBAC validation.
 type ConfigManager interface {
+	// UpdateConfig updates the configuration for the service.
 	UpdateConfig(ctx context.Context, newConfig *dto.Config) error
+	// ApplyConfig reloads the configuration from the config file.
 	ApplyConfig(ctx context.Context) error
 
+	// ReadConfig returns the service configuration DTO.
+	ReadConfig(ctx context.Context) *dto.Config
+
+	// ReadAerospikeClusters reads all Aerospike clusters from the configuration.
+	ReadAerospikeClusters(ctx context.Context) map[string]*dto.AerospikeCluster
+	// AddAerospikeCluster adds a new Aerospike cluster.
 	AddAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error
+	// ReadAerospikeCluster reads a specific Aerospike cluster by name.
+	ReadAerospikeCluster(ctx context.Context, name string) (*dto.AerospikeCluster, error)
+	// UpdateAerospikeCluster updates an existing Aerospike cluster.
 	UpdateAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error
+	// DeleteAerospikeCluster deletes an Aerospike cluster by name.
 	DeleteAerospikeCluster(ctx context.Context, name string) error
 
+	// ReadPolicies reads all backup policies from the configuration.
+	ReadPolicies(ctx context.Context) map[string]*dto.BackupPolicy
+	// AddPolicy adds a new backup policy.
 	AddPolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error
+	// ReadPolicy reads a specific backup policy by name.
+	ReadPolicy(ctx context.Context, name string) (*dto.BackupPolicy, error)
+	// UpdatePolicy updates an existing backup policy.
 	UpdatePolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error
+	// DeletePolicy deletes a backup policy by name.
 	DeletePolicy(ctx context.Context, name string) error
 
+	// ReadRoutines reads all backup routines from the configuration.
+	ReadRoutines(ctx context.Context) map[string]*dto.BackupRoutine
+	// AddRoutine adds a new backup routine.
 	AddRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error
+	// ReadRoutine reads a specific backup routine by name.
+	ReadRoutine(ctx context.Context, name string) (*dto.BackupRoutine, error)
+	// UpdateRoutine updates an existing backup routine.
 	UpdateRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error
+	// DeleteRoutine deletes a backup routine by name.
 	DeleteRoutine(ctx context.Context, name string) error
+	// EnableRoutine enables a disabled backup routine.
 	EnableRoutine(ctx context.Context, name string) error
+	// DisableRoutine disables an active backup routine.
 	DisableRoutine(ctx context.Context, name string) error
 
+	// ReadAllStorage reads all storage configurations.
+	ReadAllStorage(ctx context.Context) map[string]*dto.Storage
+	// AddStorage adds a new storage configuration.
 	AddStorage(ctx context.Context, name string, storage *dto.Storage) error
+	// ReadStorage reads a specific storage configuration by name.
+	ReadStorage(ctx context.Context, name string) (*dto.Storage, error)
+	// UpdateStorage updates an existing storage configuration.
 	UpdateStorage(ctx context.Context, name string, storage *dto.Storage) error
+	// DeleteStorage deletes a storage configuration by name.
 	DeleteStorage(ctx context.Context, name string) error
 }

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -45,9 +45,8 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/policies [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.BackupPolicy
-func (s *Service) ReadPolicies(w http.ResponseWriter, _ *http.Request) {
-	policies := dto.ConvertModelMapToDTO(s.config.BackupConfigCopy().BackupPolicies, dto.NewBackupPolicyFromModel)
-	httpOK(w, policies)
+func (s *Service) ReadPolicies(w http.ResponseWriter, r *http.Request) {
+	httpOK(w, s.configManager.ReadPolicies(r.Context()))
 }
 
 // ReadPolicy reads a specific backup policy from the configuration given its name.
@@ -66,13 +65,14 @@ func (s *Service) ReadPolicy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errMissingPolicyName)
 		return
 	}
-	policy, ok := s.config.BackupConfigCopy().BackupPolicies[name]
-	if !ok {
+
+	policy, err := s.configManager.ReadPolicy(r.Context(), name)
+	if err != nil {
 		httpError(w, errNotFound("policy", name))
 		return
 	}
 
-	httpOK(w, dto.NewBackupPolicyFromModel(policy))
+	httpOK(w, policy)
 }
 
 // UpdatePolicy updates an existing policy in the configuration.

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -32,13 +32,14 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupPolicies[name]; exists {
-			return nil, fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
-		}
-		config.BackupPolicies[name] = newPolicy
-		return nil, nil
-	}); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddPolicy", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupPolicies[name]; exists {
+				return nil, fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
+			}
+			config.BackupPolicies[name] = newPolicy
+			return nil, nil
+		}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -106,13 +107,14 @@ func (s *Service) UpdatePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupPolicies[name]; !exists {
-			return nil, fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
-		}
-		config.BackupPolicies[name] = updatedPolicy
-		return nil, nil
-	}); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdatePolicy", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupPolicies[name]; !exists {
+				return nil, fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
+			}
+			config.BackupPolicies[name] = updatedPolicy
+			return nil, nil
+		}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -135,16 +137,17 @@ func (s *Service) DeletePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupPolicies[name]; !exists {
-			return nil, fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
-		}
-		if err := ensurePolicyNotInUse(config, name); err != nil {
-			return nil, err
-		}
-		delete(config.BackupPolicies, name)
-		return nil, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "DeletePolicy", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupPolicies[name]; !exists {
+				return nil, fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
+			}
+			if err := ensurePolicyNotInUse(config, name); err != nil {
+				return nil, err
+			}
+			delete(config.BackupPolicies, name)
+			return nil, nil
+		})
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_policy.go
+++ b/internal/server/handlers/config_policy.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
 // AddPolicy
@@ -32,14 +30,7 @@ func (s *Service) AddPolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddPolicy", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupPolicies[name]; exists {
-				return nil, fmt.Errorf("add backup policy %q: %w", name, model.ErrAlreadyExists)
-			}
-			config.BackupPolicies[name] = newPolicy
-			return nil, nil
-		}); err != nil {
+	if err = s.configManager.AddPolicy(r.Context(), name, newPolicy); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -107,14 +98,7 @@ func (s *Service) UpdatePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdatePolicy", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupPolicies[name]; !exists {
-				return nil, fmt.Errorf("update backup policy %q: %w", name, model.ErrNotFound)
-			}
-			config.BackupPolicies[name] = updatedPolicy
-			return nil, nil
-		}); err != nil {
+	if err = s.configManager.UpdatePolicy(r.Context(), name, updatedPolicy); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -137,17 +121,7 @@ func (s *Service) DeletePolicy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "DeletePolicy", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupPolicies[name]; !exists {
-				return nil, fmt.Errorf("delete backup policy %q: %w", name, model.ErrNotFound)
-			}
-			if err := ensurePolicyNotInUse(config, name); err != nil {
-				return nil, err
-			}
-			delete(config.BackupPolicies, name)
-			return nil, nil
-		})
+	err := s.configManager.DeletePolicy(r.Context(), name)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_policy_test.go
+++ b/internal/server/handlers/config_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
@@ -280,9 +281,8 @@ func TestUpdatePolicy_Case2_ClusterMaxSetBeforeParallelIncrease(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	svc := setupTestService()
 	mockNsValidator := aerospike.NewMockNamespaceValidator(ctrl)
-	svc.nsValidator = mockNsValidator
+	svc := setupTestService(mockNsValidator)
 	mockNsValidator.EXPECT().Validate(gomock.Any(), gomock.Any()).Times(1)
 
 	entities := addValidBackupConfig(svc)
@@ -319,20 +319,33 @@ func TestUpdatePolicy_Case2_ClusterMaxSetBeforeParallelIncrease(t *testing.T) {
 }
 
 // Helper function to setup test service with mocked dependencies.
-func setupTestService() *Service {
+func setupTestService(nsValidator ...aerospike.NamespaceValidator) *Service {
 	mockConfigApplier := &MockConfigApplier{}
 	mockConfigurationManager := &configurationManagerMock{}
 
+	config := model.NewConfig()
+	var validator aerospike.NamespaceValidator
+	if len(nsValidator) > 0 {
+		validator = nsValidator[0]
+	}
+
+	configManager := NewConfigManagerImpl(
+		context.Background(),
+		config,
+		&sync.Mutex{},
+		validator,
+		mockConfigurationManager,
+		mockConfigApplier,
+	)
+
 	return NewService(
 		context.Background(),
-		model.NewConfig(),
-		mockConfigApplier,
+		config,
+		configManager,
 		nil,
 		nil,
 		nil,
 		nil,
-		nil,
-		mockConfigurationManager,
 		nil,
 	)
 }

--- a/internal/server/handlers/config_policy_test.go
+++ b/internal/server/handlers/config_policy_test.go
@@ -73,9 +73,9 @@ func TestAddPolicy(t *testing.T) {
 
 func TestReadPolicies(t *testing.T) {
 	svc := setupTestService()
-	svc.config = model.NewConfig()
-	_ = svc.config.AddPolicy("policy1", &model.BackupPolicy{})
-	_ = svc.config.AddPolicy("policy2", &model.BackupPolicy{})
+	configManager := svc.configManager.(*ConfigManagerImpl)
+	_ = configManager.config.AddPolicy("policy1", &model.BackupPolicy{})
+	_ = configManager.config.AddPolicy("policy2", &model.BackupPolicy{})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/policies", nil)
 	w := httptest.NewRecorder()
@@ -124,8 +124,9 @@ func TestReadPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
+			configManager := svc.configManager.(*ConfigManagerImpl)
 			if tt.policy != nil {
-				_ = svc.config.AddPolicy(tt.policyName, tt.policy)
+				_ = configManager.config.AddPolicy(tt.policyName, tt.policy)
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/policies/"+tt.policyName, nil)
@@ -245,7 +246,8 @@ func TestDeletePolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
-			_ = svc.config.AddPolicy("test-policy", &model.BackupPolicy{})
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddPolicy("test-policy", &model.BackupPolicy{})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/v1/config/policies/"+tt.policyName, nil)
 			req.SetPathValue("name", tt.policyName)
@@ -340,7 +342,6 @@ func setupTestService(nsValidator ...aerospike.NamespaceValidator) *Service {
 
 	return NewService(
 		context.Background(),
-		config,
 		configManager,
 		nil,
 		nil,

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -32,13 +32,14 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupRoutines[name]; exists {
-			return nil, fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
-		}
-		config.BackupRoutines[name] = newRoutine
-		return []string{name}, nil
-	}, withNamespaceValidation); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddRoutine", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupRoutines[name]; exists {
+				return nil, fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
+			}
+			config.BackupRoutines[name] = newRoutine
+			return []string{name}, nil
+		}, WithNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -110,13 +111,14 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupRoutines[name]; !exists {
-			return nil, fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
-		}
-		config.BackupRoutines[name] = updatedRoutine
-		return []string{name}, nil
-	}, withNamespaceValidation); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateRoutine", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupRoutines[name]; !exists {
+				return nil, fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
+			}
+			config.BackupRoutines[name] = updatedRoutine
+			return []string{name}, nil
+		}, WithNamespaceValidation); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -139,13 +141,14 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.BackupRoutines[name]; !exists {
-			return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
-		}
-		delete(config.BackupRoutines, name)
-		return []string{name}, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteRoutine", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.BackupRoutines[name]; !exists {
+				return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
+			}
+			delete(config.BackupRoutines, name)
+			return []string{name}, nil
+		})
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -169,14 +172,15 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		routine, exists := config.BackupRoutines[name]
-		if !exists {
-			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
-		}
-		routine.Disabled = false
-		return []string{name}, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "EnableRoutine", name,
+		func(config *dto.Config) ([]string, error) {
+			routine, exists := config.BackupRoutines[name]
+			if !exists {
+				return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
+			}
+			routine.Disabled = false
+			return []string{name}, nil
+		})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(name))
@@ -204,14 +208,15 @@ func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		routine, exists := config.BackupRoutines[name]
-		if !exists {
-			return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
-		}
-		routine.Disabled = true
-		return []string{name}, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "DisableRoutine", name,
+		func(config *dto.Config) ([]string, error) {
+			routine, exists := config.BackupRoutines[name]
+			if !exists {
+				return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
+			}
+			routine.Disabled = true
+			return []string{name}, nil
+		})
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(name))

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -47,12 +47,8 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 // @Produce     json
 // @Success  	200 {object} map[string]dto.BackupRoutine
 // @Failure     400 {string} string
-func (s *Service) ReadRoutines(w http.ResponseWriter, _ *http.Request) {
-	routines := dto.ConvertModelMapToDTO(s.config.Routines(), func(m *model.BackupRoutine) *dto.BackupRoutine {
-		return dto.NewRoutineFromModel(m, s.config)
-	})
-
-	httpOK(w, routines)
+func (s *Service) ReadRoutines(w http.ResponseWriter, r *http.Request) {
+	httpOK(w, s.configManager.ReadRoutines(r.Context()))
 }
 
 // ReadRoutine reads a specific routine from the configuration given its name.
@@ -71,13 +67,14 @@ func (s *Service) ReadRoutine(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errMissingRoutineName)
 		return
 	}
-	routine, found := s.config.Routine(name)
-	if !found {
+
+	routine, err := s.configManager.ReadRoutine(r.Context(), name)
+	if err != nil {
 		httpError(w, errRoutineNotFound(name))
 		return
 	}
 
-	httpOK(w, dto.NewRoutineFromModel(routine, s.config))
+	httpOK(w, routine)
 }
 
 // UpdateRoutine updates an existing backup routine in the configuration.

--- a/internal/server/handlers/config_routine.go
+++ b/internal/server/handlers/config_routine.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
@@ -32,14 +31,7 @@ func (s *Service) AddRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddRoutine", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupRoutines[name]; exists {
-				return nil, fmt.Errorf("add backup routine %q: %w", name, model.ErrAlreadyExists)
-			}
-			config.BackupRoutines[name] = newRoutine
-			return []string{name}, nil
-		}, WithNamespaceValidation); err != nil {
+	if err = s.configManager.AddRoutine(r.Context(), name, newRoutine); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -111,14 +103,7 @@ func (s *Service) UpdateRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateRoutine", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupRoutines[name]; !exists {
-				return nil, fmt.Errorf("update backup routine %q: %w", name, model.ErrNotFound)
-			}
-			config.BackupRoutines[name] = updatedRoutine
-			return []string{name}, nil
-		}, WithNamespaceValidation); err != nil {
+	if err = s.configManager.UpdateRoutine(r.Context(), name, updatedRoutine); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -141,14 +126,7 @@ func (s *Service) DeleteRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteRoutine", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.BackupRoutines[name]; !exists {
-				return nil, fmt.Errorf("delete backup routine %q: %w", name, model.ErrNotFound)
-			}
-			delete(config.BackupRoutines, name)
-			return []string{name}, nil
-		})
+	err := s.configManager.DeleteRoutine(r.Context(), name)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -172,15 +150,7 @@ func (s *Service) EnableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "EnableRoutine", name,
-		func(config *dto.Config) ([]string, error) {
-			routine, exists := config.BackupRoutines[name]
-			if !exists {
-				return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
-			}
-			routine.Disabled = false
-			return []string{name}, nil
-		})
+	err := s.configManager.EnableRoutine(r.Context(), name)
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(name))
@@ -208,15 +178,7 @@ func (s *Service) DisableRoutine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "DisableRoutine", name,
-		func(config *dto.Config) ([]string, error) {
-			routine, exists := config.BackupRoutines[name]
-			if !exists {
-				return nil, fmt.Errorf("toggle disable for backup routine %q: %w", name, model.ErrNotFound)
-			}
-			routine.Disabled = true
-			return []string{name}, nil
-		})
+	err := s.configManager.DisableRoutine(r.Context(), name)
 	if err != nil {
 		if errors.Is(err, model.ErrNotFound) {
 			httpError(w, errRoutineNotFound(name))

--- a/internal/server/handlers/config_routine_test.go
+++ b/internal/server/handlers/config_routine_test.go
@@ -41,7 +41,8 @@ func TestAddRoutine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
-			_ = svc.config.AddPolicy("test-policy", &model.BackupPolicy{})
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddPolicy("test-policy", &model.BackupPolicy{})
 
 			req := httptest.NewRequestWithContext(
 				t.Context(),
@@ -64,9 +65,9 @@ func TestAddRoutine(t *testing.T) {
 
 func TestReadRoutines(t *testing.T) {
 	svc := setupTestService()
-	svc.config = model.NewConfig()
-	_ = svc.config.AddRoutine(&model.BackupRoutine{Name: "routine1"})
-	_ = svc.config.AddRoutine(&model.BackupRoutine{Name: "routine2"})
+	configManager := svc.configManager.(*ConfigManagerImpl)
+	_ = configManager.config.AddRoutine(&model.BackupRoutine{Name: "routine1"})
+	_ = configManager.config.AddRoutine(&model.BackupRoutine{Name: "routine2"})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/routines", nil)
 	w := httptest.NewRecorder()
@@ -113,8 +114,9 @@ func TestReadRoutine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
+			configManager := svc.configManager.(*ConfigManagerImpl)
 			if tt.routine != nil {
-				_ = svc.config.AddRoutine(tt.routine)
+				_ = configManager.config.AddRoutine(tt.routine)
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/routines/"+tt.routineName, nil)
@@ -207,7 +209,8 @@ func TestDeleteRoutine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
-			_ = svc.config.AddRoutine(&model.BackupRoutine{Name: "test-routine"})
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddRoutine(&model.BackupRoutine{Name: "test-routine"})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/v1/config/routines/"+tt.routineName, nil)
 			req.SetPathValue("name", tt.routineName)
@@ -274,7 +277,8 @@ func TestEnableRoutine(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Contains(t, w.Body.String(), tt.expectedError)
 			} else {
-				updated, ok := svc.config.Routine(tt.routineName)
+				configManager := svc.configManager.(*ConfigManagerImpl)
+				updated, ok := configManager.config.Routine(tt.routineName)
 				require.True(t, ok)
 				assert.False(t, updated.Disabled)
 			}
@@ -337,7 +341,8 @@ func TestDisableRoutine(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Contains(t, w.Body.String(), tt.expectedError)
 			} else {
-				updated, ok := svc.config.Routine(tt.routineName)
+				configManager := svc.configManager.(*ConfigManagerImpl)
+				updated, ok := configManager.config.Routine(tt.routineName)
 				require.True(t, ok)
 				assert.True(t, updated.Disabled)
 			}

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -32,13 +32,14 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.Storage[name]; exists {
-			return nil, fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
-		}
-		config.Storage[name] = newStorage
-		return nil, nil
-	}); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddStorage", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.Storage[name]; exists {
+				return nil, fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
+			}
+			config.Storage[name] = newStorage
+			return nil, nil
+		}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -107,13 +108,14 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.Storage[name]; !exists {
-			return nil, fmt.Errorf("update storage %q: %w", name, model.ErrNotFound)
-		}
-		config.Storage[name] = updatedStorage
-		return routinesUsingStorage(config, name), nil
-	}); err != nil {
+	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateStorage", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.Storage[name]; !exists {
+				return nil, fmt.Errorf("update storage %q: %w", name, model.ErrNotFound)
+			}
+			config.Storage[name] = updatedStorage
+			return routinesUsingStorage(config, name), nil
+		}); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -136,16 +138,17 @@ func (s *Service) DeleteStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.changeBackupConfig(r.Context(), func(config *dto.Config) ([]string, error) {
-		if _, exists := config.Storage[name]; !exists {
-			return nil, fmt.Errorf("delete storage %q: %w", name, model.ErrNotFound)
-		}
-		if err := ensureStorageNotInUse(config, name); err != nil {
-			return nil, err
-		}
-		delete(config.Storage, name)
-		return nil, nil
-	})
+	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteStorage", name,
+		func(config *dto.Config) ([]string, error) {
+			if _, exists := config.Storage[name]; !exists {
+				return nil, fmt.Errorf("delete storage %q: %w", name, model.ErrNotFound)
+			}
+			if err := ensureStorageNotInUse(config, name); err != nil {
+				return nil, err
+			}
+			delete(config.Storage, name)
+			return nil, nil
+		})
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
 // AddStorage
@@ -32,14 +30,7 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "AddStorage", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.Storage[name]; exists {
-				return nil, fmt.Errorf("add storage %q: %w", name, model.ErrAlreadyExists)
-			}
-			config.Storage[name] = newStorage
-			return nil, nil
-		}); err != nil {
+	if err = s.configManager.AddStorage(r.Context(), name, newStorage); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -108,14 +99,7 @@ func (s *Service) UpdateStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = s.configManager.ChangeBackupConfig(r.Context(), "UpdateStorage", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.Storage[name]; !exists {
-				return nil, fmt.Errorf("update storage %q: %w", name, model.ErrNotFound)
-			}
-			config.Storage[name] = updatedStorage
-			return routinesUsingStorage(config, name), nil
-		}); err != nil {
+	if err = s.configManager.UpdateStorage(r.Context(), name, updatedStorage); err != nil {
 		httpError(w, errBadRequest(err))
 		return
 	}
@@ -138,17 +122,7 @@ func (s *Service) DeleteStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.configManager.ChangeBackupConfig(r.Context(), "DeleteStorage", name,
-		func(config *dto.Config) ([]string, error) {
-			if _, exists := config.Storage[name]; !exists {
-				return nil, fmt.Errorf("delete storage %q: %w", name, model.ErrNotFound)
-			}
-			if err := ensureStorageNotInUse(config, name); err != nil {
-				return nil, err
-			}
-			delete(config.Storage, name)
-			return nil, nil
-		})
+	err := s.configManager.DeleteStorage(r.Context(), name)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return

--- a/internal/server/handlers/config_storage.go
+++ b/internal/server/handlers/config_storage.go
@@ -45,9 +45,8 @@ func (s *Service) AddStorage(w http.ResponseWriter, r *http.Request) {
 // @Router      /v1/config/storage [get]
 // @Produce     json
 // @Success  	200 {object} map[string]dto.Storage
-func (s *Service) ReadAllStorage(w http.ResponseWriter, _ *http.Request) {
-	backupConfig := s.config.BackupConfigCopy()
-	httpOK(w, dto.ConvertStorageMapToDTO(backupConfig.Storage, backupConfig))
+func (s *Service) ReadAllStorage(w http.ResponseWriter, r *http.Request) {
+	httpOK(w, s.configManager.ReadAllStorage(r.Context()))
 }
 
 // ReadStorage  reads a specific storage from the configuration given its name.
@@ -66,14 +65,14 @@ func (s *Service) ReadStorage(w http.ResponseWriter, r *http.Request) {
 		httpError(w, errMissingStorageName)
 		return
 	}
-	backupConfig := s.config.BackupConfigCopy()
-	storage, ok := backupConfig.Storage[name]
-	if !ok {
+
+	storage, err := s.configManager.ReadStorage(r.Context(), name)
+	if err != nil {
 		httpError(w, errNotFound("storage", name))
 		return
 	}
 
-	httpOK(w, dto.NewStorageFromModel(storage, backupConfig))
+	httpOK(w, storage)
 }
 
 // UpdateStorage updates an existing storage in the configuration.

--- a/internal/server/handlers/config_storage_test.go
+++ b/internal/server/handlers/config_storage_test.go
@@ -68,10 +68,10 @@ func TestAddStorage(t *testing.T) {
 
 func TestReadAllStorage(t *testing.T) {
 	svc := setupTestService()
-	svc.config = model.NewConfig()
+	configManager := svc.configManager.(*ConfigManagerImpl)
 
-	_ = svc.config.AddStorage("storage1", &model.LocalStorage{})
-	_ = svc.config.AddStorage("storage2", &model.LocalStorage{})
+	_ = configManager.config.AddStorage("storage1", &model.LocalStorage{})
+	_ = configManager.config.AddStorage("storage2", &model.LocalStorage{})
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/storage", nil)
 	w := httptest.NewRecorder()
@@ -119,8 +119,9 @@ func TestReadStorage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
+			configManager := svc.configManager.(*ConfigManagerImpl)
 			if tt.storage != nil {
-				_ = svc.config.AddStorage(tt.storageName, tt.storage)
+				_ = configManager.config.AddStorage(tt.storageName, tt.storage)
 			}
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config/storage/"+tt.storageName, nil)
@@ -171,7 +172,8 @@ func TestUpdateStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
 			initialStorage := &model.LocalStorage{Path: "/"}
-			_ = svc.config.AddStorage("test-storage", initialStorage)
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddStorage("test-storage", initialStorage)
 
 			req := httptest.NewRequestWithContext(
 				t.Context(),
@@ -222,7 +224,8 @@ func TestDeleteStorage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			svc := setupTestService()
-			_ = svc.config.AddStorage("test-storage", &model.LocalStorage{})
+			configManager := svc.configManager.(*ConfigManagerImpl)
+			_ = configManager.config.AddStorage("test-storage", &model.LocalStorage{})
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/v1/config/storage/"+tt.storageName, nil)
 			req.SetPathValue("name", tt.storageName)

--- a/internal/server/handlers/restore.go
+++ b/internal/server/handlers/restore.go
@@ -52,7 +52,13 @@ func (s *Service) restoreByPath(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restoreRequest, err := request.ToModel(s.config)
+	configModel, err := s.configManager.ReadConfig(r.Context()).ToModel(dto.ValidationSkipTLSFiles)
+	if err != nil {
+		httpError(w, errBadRequest(err))
+		return
+	}
+
+	restoreRequest, err := request.ToModel(configModel)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -90,7 +96,13 @@ func (s *Service) RestoreByTimeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	restoreRequest, err := request.ToModel(s.config)
+	configModel, err := s.configManager.ReadConfig(r.Context()).ToModel(dto.ValidationSkipTLSFiles)
+	if err != nil {
+		httpError(w, errBadRequest(err))
+		return
+	}
+
+	restoreRequest, err := request.ToModel(configModel)
 	if err != nil {
 		httpError(w, errBadRequest(err))
 		return
@@ -212,9 +224,21 @@ func (s *Service) RetrieveConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	routine, found := s.config.Routine(routineName)
-	if !found {
+	routineDto, err := s.configManager.ReadRoutine(r.Context(), routineName)
+	if err != nil {
 		httpError(w, errRoutineNotFound(routineName))
+		return
+	}
+
+	configModel, err := s.configManager.ReadConfig(r.Context()).ToModel(dto.ValidationSkipTLSFiles)
+	if err != nil {
+		httpError(w, errBadRequest(err))
+		return
+	}
+
+	routine, err := routineDto.ToModel(configModel.BackupConfigCopy(), routineName)
+	if err != nil {
+		httpError(w, errBadRequest(err))
 		return
 	}
 

--- a/internal/server/handlers/service.go
+++ b/internal/server/handlers/service.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
 )
@@ -10,7 +11,6 @@ import (
 // Service holds all dependencies required to access business logic from endpoints.
 type Service struct {
 	sysCtx          context.Context //nolint:containedctx
-	config          *model.Config
 	configManager   ConfigManager
 	backupScheduler service.AdHocScheduler
 	restoreManager  service.RestoreManager
@@ -21,7 +21,6 @@ type Service struct {
 
 func NewService(
 	ctx context.Context,
-	config *model.Config,
 	configManager ConfigManager,
 	backupScheduler service.AdHocScheduler,
 	restoreManager service.RestoreManager,
@@ -31,7 +30,6 @@ func NewService(
 ) *Service {
 	return &Service{
 		sysCtx:          ctx,
-		config:          config,
 		configManager:   configManager,
 		backupScheduler: backupScheduler,
 		restoreManager:  restoreManager,
@@ -43,7 +41,8 @@ func NewService(
 
 // HTTPServerConfig returns the HTTP server config.
 func (s *Service) HTTPServerConfig() *model.HTTPServerConfig {
-	return s.config.ServiceConfig.GetHTTPServerOrDefault()
+	modelConfig, _ := s.configManager.ReadConfig(s.sysCtx).ToModel(dto.ValidationSkipTLSFiles)
+	return modelConfig.ServiceConfig.GetHTTPServerOrDefault()
 }
 
 // RunningBackupsRegistry defines the interface for managing running backups and their statuses.

--- a/internal/server/handlers/service.go
+++ b/internal/server/handlers/service.go
@@ -2,53 +2,42 @@ package handlers
 
 import (
 	"context"
-	"sync"
 
-	"github.com/aerospike/aerospike-backup-service/v3/internal/server/configuration"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
 )
 
 // Service holds all dependencies required to access business logic from endpoints.
 type Service struct {
-	sysCtx               context.Context //nolint:containedctx
-	config               *model.Config
-	configApplier        service.ConfigApplier
-	backupScheduler      service.AdHocScheduler
-	restoreManager       service.RestoreManager
-	configRetriever      service.ConfigRetriever
-	backupReader         service.BackupReader
-	registry             RunningBackupsRegistry
-	configurationManager configuration.Manager
-	nsValidator          aerospike.NamespaceValidator
-
-	changeConfigLock sync.Mutex
+	sysCtx          context.Context //nolint:containedctx
+	config          *model.Config
+	configManager   ConfigManager
+	backupScheduler service.AdHocScheduler
+	restoreManager  service.RestoreManager
+	configRetriever service.ConfigRetriever
+	backupReader    service.BackupReader
+	registry        RunningBackupsRegistry
 }
 
 func NewService(
 	ctx context.Context,
 	config *model.Config,
-	configApplier service.ConfigApplier,
+	configManager ConfigManager,
 	backupScheduler service.AdHocScheduler,
 	restoreManager service.RestoreManager,
 	configRetriever service.ConfigRetriever,
 	backupReader service.BackupReader,
 	registry RunningBackupsRegistry,
-	configurationManager configuration.Manager,
-	nsValidator aerospike.NamespaceValidator,
 ) *Service {
 	return &Service{
-		sysCtx:               ctx,
-		config:               config,
-		configApplier:        configApplier,
-		backupScheduler:      backupScheduler,
-		restoreManager:       restoreManager,
-		configRetriever:      configRetriever,
-		backupReader:         backupReader,
-		registry:             registry,
-		configurationManager: configurationManager,
-		nsValidator:          nsValidator,
+		sysCtx:          ctx,
+		config:          config,
+		configManager:   configManager,
+		backupScheduler: backupScheduler,
+		restoreManager:  restoreManager,
+		configRetriever: configRetriever,
+		backupReader:    backupReader,
+		registry:        registry,
 	}
 }
 

--- a/internal/server/handlers/test_helpers_test.go
+++ b/internal/server/handlers/test_helpers_test.go
@@ -32,9 +32,10 @@ func addValidBackupRoutine(svc *Service, routineName string, disabled bool) vali
 		storage: &model.LocalStorage{Path: "/tmp/backup"},
 	}
 
-	_ = svc.config.AddPolicy(entities.policyName, entities.policy)
-	_ = svc.config.AddCluster(entities.clusterName, entities.cluster)
-	_ = svc.config.AddStorage(entities.storageName, entities.storage)
+	configManager := svc.configManager.(*ConfigManagerImpl)
+	_ = configManager.config.AddPolicy(entities.policyName, entities.policy)
+	_ = configManager.config.AddCluster(entities.clusterName, entities.cluster)
+	_ = configManager.config.AddStorage(entities.storageName, entities.storage)
 
 	routine := &model.BackupRoutine{
 		Name:          routineName,
@@ -45,7 +46,7 @@ func addValidBackupRoutine(svc *Service, routineName string, disabled bool) vali
 		Namespaces:    []string{},
 		Disabled:      disabled,
 	}
-	_ = svc.config.AddRoutine(routine)
+	_ = configManager.config.AddRoutine(routine)
 
 	return entities
 }

--- a/internal/server/middleware/logger.go
+++ b/internal/server/middleware/logger.go
@@ -1,17 +1,11 @@
 package middleware
 
 import (
-	"bytes"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 )
-
-const maxLogSize = 10_000 // Maximum size of request body to log in bytes.
 
 // RequestLogger returns a middleware that logs request details using provided logger.
 func RequestLogger(logger *slog.Logger, skipPaths []string) Middleware {
@@ -24,13 +18,6 @@ func RequestLogger(logger *slog.Logger, skipPaths []string) Middleware {
 					next.ServeHTTP(w, r)
 					return
 				}
-			}
-
-			body, err := readRequestBody(r)
-			if err != nil {
-				logger.Error("Failed to read request body", attr.Error(err))
-				http.Error(w, "Failed to read request body: "+err.Error(), http.StatusInternalServerError)
-				return
 			}
 
 			rw := newCapturingResponseWriter(w)
@@ -46,11 +33,8 @@ func RequestLogger(logger *slog.Logger, skipPaths []string) Middleware {
 				slog.String("ip", r.RemoteAddr),
 			}
 
-			if len(body) > 0 {
-				attrs = append(attrs, slog.String("requestBody", string(body[:min(len(body), maxLogSize)])))
-			}
-
 			// Log based on response status
+
 			var (
 				msg      string
 				logLevel slog.Level
@@ -74,22 +58,6 @@ func RequestLogger(logger *slog.Logger, skipPaths []string) Middleware {
 			logger.LogAttrs(r.Context(), logLevel, msg, attrs...)
 		})
 	}
-}
-
-// readRequestBody reads the request body and resets is, so it can be used by subsequent handlers.
-func readRequestBody(r *http.Request) ([]byte, error) {
-	bodyBytes, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = r.Body.Close(); err != nil {
-		return nil, err
-	}
-
-	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-
-	return bodyBytes, nil
 }
 
 // capturingResponseWriter captures the status code and error message.

--- a/internal/server/middleware/logger_test.go
+++ b/internal/server/middleware/logger_test.go
@@ -33,11 +33,6 @@ func (l *testLogger) WithAttrs(_ []slog.Attr) slog.Handler         { return l }
 func (l *testLogger) WithGroup(_ string) slog.Handler              { return l }
 func (l *testLogger) Enabled(_ context.Context, _ slog.Level) bool { return true }
 
-type errorReader struct{}
-
-func (errorReader) Read(_ []byte) (n int, err error) {
-	return 0, io.ErrUnexpectedEOF
-}
 func TestRequestLogger(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -81,15 +76,6 @@ func TestRequestLogger(t *testing.T) {
 			name:    "skipped path",
 			path:    "/metrics",
 			handler: func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
-		},
-		{
-			name:         "request body read error",
-			path:         "/api/test",
-			handler:      func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
-			body:         &errorReader{},
-			wantLevel:    slog.LevelError,
-			wantMsg:      "Failed to read request body",
-			wantErrorMsg: "unexpected EOF",
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,13 +18,21 @@ const (
 	shutdownTimeout = 30 * time.Second
 )
 
+// Server represents an HTTP server that can be started and gracefully shut down.
+type Server interface {
+	// Start starts the server.
+	Start() error
+	// Shutdown gracefully shuts down the server.
+	Shutdown() error
+}
+
 // HTTPServer is the backup service HTTP server wrapper.
 type HTTPServer struct {
 	server *http.Server
 }
 
 // NewHTTPServer returns a new instance of HTTPServer.
-func NewHTTPServer(service *handlers.Service) *HTTPServer {
+func NewHTTPServer(service *handlers.Service) Server {
 	serverConfig := service.HTTPServerConfig()
 	addr := fmt.Sprintf("%s:%d", serverConfig.GetAddressOrDefault(), serverConfig.GetPortOrDefault())
 

--- a/pkg/audit/adhoc_scheduler.go
+++ b/pkg/audit/adhoc_scheduler.go
@@ -1,0 +1,50 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
+)
+
+type auditAdHocScheduler struct {
+	underlying service.AdHocScheduler
+	auditor    Auditor
+}
+
+var _ service.AdHocScheduler = (*auditAdHocScheduler)(nil)
+
+// NewAuditAdHocScheduler wraps an existing AdHocScheduler with audit logging.
+func NewAuditAdHocScheduler(underlying service.AdHocScheduler, auditor Auditor) service.AdHocScheduler {
+	return &auditAdHocScheduler{
+		underlying: underlying,
+		auditor:    auditor,
+	}
+}
+
+func (a *auditAdHocScheduler) TriggerAdHocFullBackup(routine *model.BackupRoutine, delay time.Duration) error {
+	err := a.underlying.TriggerAdHocFullBackup(routine, delay)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(context.Background(), "TriggerAdHocFullBackup", status, slog.String("routine", routine.Name))
+
+	return err
+}
+
+func (a *auditAdHocScheduler) TriggerAdHocIncrementalBackup(routine *model.BackupRoutine, delay time.Duration) error {
+	err := a.underlying.TriggerAdHocIncrementalBackup(routine, delay)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(context.Background(), "TriggerAdHocIncrementalBackup", status,
+		slog.String("routine", routine.Name))
+
+	return err
+}

--- a/pkg/audit/adhoc_scheduler.go
+++ b/pkg/audit/adhoc_scheduler.go
@@ -26,25 +26,12 @@ func NewAuditAdHocScheduler(underlying service.AdHocScheduler, auditor Auditor) 
 
 func (a *auditAdHocScheduler) TriggerAdHocFullBackup(routine *model.BackupRoutine, delay time.Duration) error {
 	err := a.underlying.TriggerAdHocFullBackup(routine, delay)
-
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(context.Background(), "TriggerAdHocFullBackup", status, slog.String("routine", routine.Name))
-
+	a.auditor.WriteEvent(context.Background(), "TriggerAdHocFullBackup", EventStatusFromError(err), slog.String("routine", routine.Name))
 	return err
 }
 
 func (a *auditAdHocScheduler) TriggerAdHocIncrementalBackup(routine *model.BackupRoutine, delay time.Duration) error {
 	err := a.underlying.TriggerAdHocIncrementalBackup(routine, delay)
-
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(context.Background(), "TriggerAdHocIncrementalBackup", status,
-		slog.String("routine", routine.Name))
-
+	a.auditor.WriteEvent(context.Background(), "TriggerAdHocIncrementalBackup", EventStatusFromError(err), slog.String("routine", routine.Name))
 	return err
 }

--- a/pkg/audit/adhoc_scheduler.go
+++ b/pkg/audit/adhoc_scheduler.go
@@ -26,12 +26,22 @@ func NewAuditAdHocScheduler(underlying service.AdHocScheduler, auditor Auditor) 
 
 func (a *auditAdHocScheduler) TriggerAdHocFullBackup(routine *model.BackupRoutine, delay time.Duration) error {
 	err := a.underlying.TriggerAdHocFullBackup(routine, delay)
-	a.auditor.WriteEvent(context.Background(), "TriggerAdHocFullBackup", EventStatusFromError(err), slog.String("routine", routine.Name))
+	a.auditor.WriteEvent(
+		context.Background(),
+		"TriggerAdHocFullBackup",
+		EventStatusFromError(err),
+		slog.String("routine", routine.Name),
+	)
 	return err
 }
 
 func (a *auditAdHocScheduler) TriggerAdHocIncrementalBackup(routine *model.BackupRoutine, delay time.Duration) error {
 	err := a.underlying.TriggerAdHocIncrementalBackup(routine, delay)
-	a.auditor.WriteEvent(context.Background(), "TriggerAdHocIncrementalBackup", EventStatusFromError(err), slog.String("routine", routine.Name))
+	a.auditor.WriteEvent(
+		context.Background(),
+		"TriggerAdHocIncrementalBackup",
+		EventStatusFromError(err),
+		slog.String("routine", routine.Name),
+	)
 	return err
 }

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -14,7 +14,6 @@ const (
 	StatusDenied  EventStatus = "Denied" // For future RBAC
 )
 
-// Auditor provides an interface for emitting structured audit events.
 // EventStatusFromError returns StatusSuccess if err is nil, StatusFailed otherwise.
 func EventStatusFromError(err error) EventStatus {
 	if err != nil {
@@ -23,6 +22,7 @@ func EventStatusFromError(err error) EventStatus {
 	return StatusSuccess
 }
 
+// Auditor provides an interface for emitting structured audit events.
 type Auditor interface {
 	// WriteEvent records an audit log entry.
 	// action: The logical operation (e.g., "AddAerospikeCluster")

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -23,28 +23,25 @@ type Auditor interface {
 	WriteEvent(ctx context.Context, action string, status EventStatus, attrs ...slog.Attr)
 }
 
-// SimpleAuditor is a basic implementation of Auditor that writes to a slog.Logger.
-type SimpleAuditor struct {
+// LoggerAuditor is a basic implementation of Auditor that writes to a slog.Logger.
+type LoggerAuditor struct {
 	logger *slog.Logger
 }
 
-// NewSimpleAuditor creates a new SimpleAuditor.
-func NewSimpleAuditor(logger *slog.Logger) *SimpleAuditor {
-	if logger == nil {
-		logger = slog.Default()
-	}
-	return &SimpleAuditor{
-		logger: logger,
+// NewLoggerAuditor creates a new LoggerAuditor.
+func NewLoggerAuditor(logger *slog.Logger) *LoggerAuditor {
+	return &LoggerAuditor{
+		logger: logger.WithGroup("audit"),
 	}
 }
 
 // WriteEvent records an audit log entry using the underlying logger.
-func (a *SimpleAuditor) WriteEvent(ctx context.Context, action string, status EventStatus, attrs ...slog.Attr) {
-	allAttrs := make([]any, 0, len(attrs)+2)
-	allAttrs = append(allAttrs, slog.String("action", action), slog.String("status", string(status)))
+func (a *LoggerAuditor) WriteEvent(ctx context.Context, action string, status EventStatus, attrs ...slog.Attr) {
+	allAttrs := make([]any, 0, len(attrs)+1)
+	allAttrs = append(allAttrs, slog.String("status", string(status)))
 	for _, attr := range attrs {
 		allAttrs = append(allAttrs, attr)
 	}
 
-	a.logger.InfoContext(ctx, "Audit Event", allAttrs...)
+	a.logger.InfoContext(ctx, action, allAttrs...)
 }

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -1,0 +1,50 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+)
+
+// EventStatus represents the outcome of an audited operation.
+type EventStatus string
+
+const (
+	StatusSuccess EventStatus = "Success"
+	StatusFailed  EventStatus = "Failed"
+	StatusDenied  EventStatus = "Denied" // For future RBAC
+)
+
+// Auditor provides an interface for emitting structured audit events.
+type Auditor interface {
+	// WriteEvent records an audit log entry.
+	// action: The logical operation (e.g., "AddAerospikeCluster")
+	// status: Outcome of the operation
+	// attrs: Additional safe, structured metadata
+	WriteEvent(ctx context.Context, action string, status EventStatus, attrs ...slog.Attr)
+}
+
+// SimpleAuditor is a basic implementation of Auditor that writes to a slog.Logger.
+type SimpleAuditor struct {
+	logger *slog.Logger
+}
+
+// NewSimpleAuditor creates a new SimpleAuditor.
+func NewSimpleAuditor(logger *slog.Logger) *SimpleAuditor {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &SimpleAuditor{
+		logger: logger,
+	}
+}
+
+// WriteEvent records an audit log entry using the underlying logger.
+func (a *SimpleAuditor) WriteEvent(ctx context.Context, action string, status EventStatus, attrs ...slog.Attr) {
+	allAttrs := make([]any, 0, len(attrs)+2)
+	allAttrs = append(allAttrs, slog.String("action", action), slog.String("status", string(status)))
+	for _, attr := range attrs {
+		allAttrs = append(allAttrs, attr)
+	}
+
+	a.logger.InfoContext(ctx, "Audit Event", allAttrs...)
+}

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -15,6 +15,14 @@ const (
 )
 
 // Auditor provides an interface for emitting structured audit events.
+// EventStatusFromError returns StatusSuccess if err is nil, StatusFailed otherwise.
+func EventStatusFromError(err error) EventStatus {
+	if err != nil {
+		return StatusFailed
+	}
+	return StatusSuccess
+}
+
 type Auditor interface {
 	// WriteEvent records an audit log entry.
 	// action: The logical operation (e.g., "AddAerospikeCluster")

--- a/pkg/audit/backup_reader.go
+++ b/pkg/audit/backup_reader.go
@@ -1,0 +1,28 @@
+package audit
+
+import (
+	"context"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
+)
+
+type auditBackupReader struct {
+	underlying service.BackupReader
+}
+
+var _ service.BackupReader = (*auditBackupReader)(nil)
+
+// NewAuditBackupReader wraps an existing BackupReader to allow future security/RBAC additions.
+// Currently it just passes through as read-only operations don't emit audit logs by default.
+func NewAuditBackupReader(underlying service.BackupReader) service.BackupReader {
+	return &auditBackupReader{
+		underlying: underlying,
+	}
+}
+
+func (a *auditBackupReader) GetBackups(
+	ctx context.Context, filter service.BackupFilter,
+) ([]model.BackupDetails, error) {
+	return a.underlying.GetBackups(ctx, filter)
+}

--- a/pkg/audit/config_manager.go
+++ b/pkg/audit/config_manager.go
@@ -23,7 +23,21 @@ func NewAuditConfigManager(underlying handlers.ConfigManager, auditor Auditor) h
 	}
 }
 
-func (a *auditConfigManager) AddAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error {
+func (a *auditConfigManager) ReadConfig(ctx context.Context) *dto.Config {
+	return a.underlying.ReadConfig(ctx)
+}
+
+func (a *auditConfigManager) ReadAerospikeClusters(ctx context.Context) map[string]*dto.AerospikeCluster {
+	return a.underlying.ReadAerospikeClusters(ctx)
+}
+
+func (a *auditConfigManager) ReadAerospikeCluster(ctx context.Context, name string) (*dto.AerospikeCluster, error) {
+	return a.underlying.ReadAerospikeCluster(ctx, name)
+}
+
+func (a *auditConfigManager) AddAerospikeCluster(
+	ctx context.Context, name string, cluster *dto.AerospikeCluster,
+) error {
 	err := a.underlying.AddAerospikeCluster(ctx, name, cluster)
 	status := StatusSuccess
 	if err != nil {
@@ -33,7 +47,9 @@ func (a *auditConfigManager) AddAerospikeCluster(ctx context.Context, name strin
 	return err
 }
 
-func (a *auditConfigManager) UpdateAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error {
+func (a *auditConfigManager) UpdateAerospikeCluster(
+	ctx context.Context, name string, cluster *dto.AerospikeCluster,
+) error {
 	err := a.underlying.UpdateAerospikeCluster(ctx, name, cluster)
 	status := StatusSuccess
 	if err != nil {
@@ -51,6 +67,14 @@ func (a *auditConfigManager) DeleteAerospikeCluster(ctx context.Context, name st
 	}
 	a.auditor.WriteEvent(ctx, "DeleteAerospikeCluster", status, slog.String("resource", name))
 	return err
+}
+
+func (a *auditConfigManager) ReadPolicies(ctx context.Context) map[string]*dto.BackupPolicy {
+	return a.underlying.ReadPolicies(ctx)
+}
+
+func (a *auditConfigManager) ReadPolicy(ctx context.Context, name string) (*dto.BackupPolicy, error) {
+	return a.underlying.ReadPolicy(ctx, name)
 }
 
 func (a *auditConfigManager) AddPolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error {
@@ -81,6 +105,14 @@ func (a *auditConfigManager) DeletePolicy(ctx context.Context, name string) erro
 	}
 	a.auditor.WriteEvent(ctx, "DeletePolicy", status, slog.String("resource", name))
 	return err
+}
+
+func (a *auditConfigManager) ReadRoutines(ctx context.Context) map[string]*dto.BackupRoutine {
+	return a.underlying.ReadRoutines(ctx)
+}
+
+func (a *auditConfigManager) ReadRoutine(ctx context.Context, name string) (*dto.BackupRoutine, error) {
+	return a.underlying.ReadRoutine(ctx, name)
 }
 
 func (a *auditConfigManager) AddRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error {
@@ -131,6 +163,14 @@ func (a *auditConfigManager) DisableRoutine(ctx context.Context, name string) er
 	}
 	a.auditor.WriteEvent(ctx, "DisableRoutine", status, slog.String("resource", name))
 	return err
+}
+
+func (a *auditConfigManager) ReadAllStorage(ctx context.Context) map[string]*dto.Storage {
+	return a.underlying.ReadAllStorage(ctx)
+}
+
+func (a *auditConfigManager) ReadStorage(ctx context.Context, name string) (*dto.Storage, error) {
+	return a.underlying.ReadStorage(ctx, name)
 }
 
 func (a *auditConfigManager) AddStorage(ctx context.Context, name string, storage *dto.Storage) error {

--- a/pkg/audit/config_manager.go
+++ b/pkg/audit/config_manager.go
@@ -23,23 +23,143 @@ func NewAuditConfigManager(underlying handlers.ConfigManager, auditor Auditor) h
 	}
 }
 
-// ChangeBackupConfig delegates to the underlying manager and audits the operation.
-func (a *auditConfigManager) ChangeBackupConfig(
-	ctx context.Context,
-	action string,
-	resourceID string,
-	mutate func(*dto.Config) ([]string, error),
-	opts ...func(*handlers.BackupConfigChangeOptions),
-) error {
-	err := a.underlying.ChangeBackupConfig(ctx, action, resourceID, mutate, opts...)
-
+func (a *auditConfigManager) AddAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error {
+	err := a.underlying.AddAerospikeCluster(ctx, name, cluster)
 	status := StatusSuccess
 	if err != nil {
 		status = StatusFailed
 	}
+	a.auditor.WriteEvent(ctx, "AddAerospikeCluster", status, slog.String("resource", name))
+	return err
+}
 
-	a.auditor.WriteEvent(ctx, action, status, slog.String("resource", resourceID))
+func (a *auditConfigManager) UpdateAerospikeCluster(ctx context.Context, name string, cluster *dto.AerospikeCluster) error {
+	err := a.underlying.UpdateAerospikeCluster(ctx, name, cluster)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "UpdateAerospikeCluster", status, slog.String("resource", name))
+	return err
+}
 
+func (a *auditConfigManager) DeleteAerospikeCluster(ctx context.Context, name string) error {
+	err := a.underlying.DeleteAerospikeCluster(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "DeleteAerospikeCluster", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) AddPolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error {
+	err := a.underlying.AddPolicy(ctx, name, policy)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "AddPolicy", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) UpdatePolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error {
+	err := a.underlying.UpdatePolicy(ctx, name, policy)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "UpdatePolicy", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) DeletePolicy(ctx context.Context, name string) error {
+	err := a.underlying.DeletePolicy(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "DeletePolicy", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) AddRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error {
+	err := a.underlying.AddRoutine(ctx, name, routine)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "AddRoutine", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) UpdateRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error {
+	err := a.underlying.UpdateRoutine(ctx, name, routine)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "UpdateRoutine", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) DeleteRoutine(ctx context.Context, name string) error {
+	err := a.underlying.DeleteRoutine(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "DeleteRoutine", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) EnableRoutine(ctx context.Context, name string) error {
+	err := a.underlying.EnableRoutine(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "EnableRoutine", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) DisableRoutine(ctx context.Context, name string) error {
+	err := a.underlying.DisableRoutine(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "DisableRoutine", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) AddStorage(ctx context.Context, name string, storage *dto.Storage) error {
+	err := a.underlying.AddStorage(ctx, name, storage)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "AddStorage", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) UpdateStorage(ctx context.Context, name string, storage *dto.Storage) error {
+	err := a.underlying.UpdateStorage(ctx, name, storage)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "UpdateStorage", status, slog.String("resource", name))
+	return err
+}
+
+func (a *auditConfigManager) DeleteStorage(ctx context.Context, name string) error {
+	err := a.underlying.DeleteStorage(ctx, name)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "DeleteStorage", status, slog.String("resource", name))
 	return err
 }
 

--- a/pkg/audit/config_manager.go
+++ b/pkg/audit/config_manager.go
@@ -39,11 +39,7 @@ func (a *auditConfigManager) AddAerospikeCluster(
 	ctx context.Context, name string, cluster *dto.AerospikeCluster,
 ) error {
 	err := a.underlying.AddAerospikeCluster(ctx, name, cluster)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "AddAerospikeCluster", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "AddAerospikeCluster", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
@@ -51,21 +47,13 @@ func (a *auditConfigManager) UpdateAerospikeCluster(
 	ctx context.Context, name string, cluster *dto.AerospikeCluster,
 ) error {
 	err := a.underlying.UpdateAerospikeCluster(ctx, name, cluster)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "UpdateAerospikeCluster", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "UpdateAerospikeCluster", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) DeleteAerospikeCluster(ctx context.Context, name string) error {
 	err := a.underlying.DeleteAerospikeCluster(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "DeleteAerospikeCluster", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "DeleteAerospikeCluster", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
@@ -79,31 +67,19 @@ func (a *auditConfigManager) ReadPolicy(ctx context.Context, name string) (*dto.
 
 func (a *auditConfigManager) AddPolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error {
 	err := a.underlying.AddPolicy(ctx, name, policy)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "AddPolicy", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "AddPolicy", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) UpdatePolicy(ctx context.Context, name string, policy *dto.BackupPolicy) error {
 	err := a.underlying.UpdatePolicy(ctx, name, policy)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "UpdatePolicy", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "UpdatePolicy", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) DeletePolicy(ctx context.Context, name string) error {
 	err := a.underlying.DeletePolicy(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "DeletePolicy", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "DeletePolicy", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
@@ -117,51 +93,31 @@ func (a *auditConfigManager) ReadRoutine(ctx context.Context, name string) (*dto
 
 func (a *auditConfigManager) AddRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error {
 	err := a.underlying.AddRoutine(ctx, name, routine)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "AddRoutine", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "AddRoutine", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) UpdateRoutine(ctx context.Context, name string, routine *dto.BackupRoutine) error {
 	err := a.underlying.UpdateRoutine(ctx, name, routine)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "UpdateRoutine", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "UpdateRoutine", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) DeleteRoutine(ctx context.Context, name string) error {
 	err := a.underlying.DeleteRoutine(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "DeleteRoutine", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "DeleteRoutine", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) EnableRoutine(ctx context.Context, name string) error {
 	err := a.underlying.EnableRoutine(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "EnableRoutine", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "EnableRoutine", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) DisableRoutine(ctx context.Context, name string) error {
 	err := a.underlying.DisableRoutine(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "DisableRoutine", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "DisableRoutine", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
@@ -175,31 +131,19 @@ func (a *auditConfigManager) ReadStorage(ctx context.Context, name string) (*dto
 
 func (a *auditConfigManager) AddStorage(ctx context.Context, name string, storage *dto.Storage) error {
 	err := a.underlying.AddStorage(ctx, name, storage)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "AddStorage", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "AddStorage", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) UpdateStorage(ctx context.Context, name string, storage *dto.Storage) error {
 	err := a.underlying.UpdateStorage(ctx, name, storage)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "UpdateStorage", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "UpdateStorage", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 
 func (a *auditConfigManager) DeleteStorage(ctx context.Context, name string) error {
 	err := a.underlying.DeleteStorage(ctx, name)
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "DeleteStorage", status, slog.String("resource", name))
+	a.auditor.WriteEvent(ctx, "DeleteStorage", EventStatusFromError(err), slog.String("resource", name))
 	return err
 }
 

--- a/pkg/audit/config_manager.go
+++ b/pkg/audit/config_manager.go
@@ -1,0 +1,64 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+)
+
+type auditConfigManager struct {
+	underlying handlers.ConfigManager
+	auditor    Auditor
+}
+
+var _ handlers.ConfigManager = (*auditConfigManager)(nil)
+
+// NewAuditConfigManager wraps an existing ConfigManager with audit logging.
+func NewAuditConfigManager(underlying handlers.ConfigManager, auditor Auditor) handlers.ConfigManager {
+	return &auditConfigManager{
+		underlying: underlying,
+		auditor:    auditor,
+	}
+}
+
+// ChangeBackupConfig delegates to the underlying manager and audits the operation.
+func (a *auditConfigManager) ChangeBackupConfig(
+	ctx context.Context,
+	action string,
+	resourceID string,
+	mutate func(*dto.Config) ([]string, error),
+	opts ...func(*handlers.BackupConfigChangeOptions),
+) error {
+	err := a.underlying.ChangeBackupConfig(ctx, action, resourceID, mutate, opts...)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+
+	a.auditor.WriteEvent(ctx, action, status, slog.String("resource", resourceID))
+
+	return err
+}
+
+func (a *auditConfigManager) UpdateConfig(ctx context.Context, newConfig *dto.Config) error {
+	err := a.underlying.UpdateConfig(ctx, newConfig)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "UpdateConfig", status)
+	return err
+}
+
+func (a *auditConfigManager) ApplyConfig(ctx context.Context) error {
+	err := a.underlying.ApplyConfig(ctx)
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "ApplyConfig", status)
+	return err
+}

--- a/pkg/audit/config_retriever.go
+++ b/pkg/audit/config_retriever.go
@@ -1,0 +1,30 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
+)
+
+type auditConfigRetriever struct {
+	underlying service.ConfigRetriever
+}
+
+var _ service.ConfigRetriever = (*auditConfigRetriever)(nil)
+
+// NewAuditConfigRetriever wraps an existing ConfigRetriever to allow future security/RBAC additions.
+func NewAuditConfigRetriever(underlying service.ConfigRetriever) service.ConfigRetriever {
+	return &auditConfigRetriever{
+		underlying: underlying,
+	}
+}
+
+func (a *auditConfigRetriever) RetrieveConfiguration(
+	ctx context.Context,
+	routine *model.BackupRoutine,
+	timestamp time.Time,
+) ([]byte, error) {
+	return a.underlying.RetrieveConfiguration(ctx, routine, timestamp)
+}

--- a/pkg/audit/restore_manager.go
+++ b/pkg/audit/restore_manager.go
@@ -48,7 +48,12 @@ func (a *auditRestoreManager) JobStatus(jobID model.RestoreJobID) (*model.Restor
 func (a *auditRestoreManager) CancelRestore(jobID model.RestoreJobID) error {
 	err := a.underlying.CancelRestore(jobID)
 
-	a.auditor.WriteEvent(context.Background(), "CancelRestore", EventStatusFromError(err), slog.Int64("jobId", int64(jobID)))
+	a.auditor.WriteEvent(
+		context.Background(),
+		"CancelRestore",
+		EventStatusFromError(err),
+		slog.Int64("jobId", int64(jobID)),
+	)
 
 	return err
 }

--- a/pkg/audit/restore_manager.go
+++ b/pkg/audit/restore_manager.go
@@ -1,0 +1,73 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service"
+)
+
+type auditRestoreManager struct {
+	underlying service.RestoreManager
+	auditor    Auditor
+}
+
+var _ service.RestoreManager = (*auditRestoreManager)(nil)
+
+// NewAuditRestoreManager wraps an existing RestoreManager with audit logging.
+func NewAuditRestoreManager(underlying service.RestoreManager, auditor Auditor) service.RestoreManager {
+	return &auditRestoreManager{
+		underlying: underlying,
+		auditor:    auditor,
+	}
+}
+
+func (a *auditRestoreManager) Restore(ctx context.Context, request *model.RestoreRequest) (model.RestoreJobID, error) {
+	jobID, err := a.underlying.Restore(ctx, request)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "RestoreStarted", status, slog.Int64("jobId", int64(jobID)))
+
+	return jobID, err
+}
+
+func (a *auditRestoreManager) RestoreByTime(
+	ctx context.Context, request *model.RestoreTimestampRequest,
+) (model.RestoreJobID, error) {
+	jobID, err := a.underlying.RestoreByTime(ctx, request)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(ctx, "RestoreByTimeStarted", status, slog.Int64("jobId", int64(jobID)))
+
+	return jobID, err
+}
+
+func (a *auditRestoreManager) JobStatus(jobID model.RestoreJobID) (*model.RestoreJobStatus, error) {
+	return a.underlying.JobStatus(jobID)
+}
+
+func (a *auditRestoreManager) CancelRestore(jobID model.RestoreJobID) error {
+	err := a.underlying.CancelRestore(jobID)
+
+	status := StatusSuccess
+	if err != nil {
+		status = StatusFailed
+	}
+	a.auditor.WriteEvent(context.Background(), "CancelRestore", status, slog.Int64("jobId", int64(jobID)))
+
+	return err
+}
+
+func (a *auditRestoreManager) GetFilteredJobs(
+	timeBounds model.TimeBounds,
+	statusFilter model.StatusFilter,
+) map[model.RestoreJobID]*model.RestoreJobStatus {
+	return a.underlying.GetFilteredJobs(timeBounds, statusFilter)
+}

--- a/pkg/audit/restore_manager.go
+++ b/pkg/audit/restore_manager.go
@@ -26,11 +26,7 @@ func NewAuditRestoreManager(underlying service.RestoreManager, auditor Auditor) 
 func (a *auditRestoreManager) Restore(ctx context.Context, request *model.RestoreRequest) (model.RestoreJobID, error) {
 	jobID, err := a.underlying.Restore(ctx, request)
 
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "RestoreStarted", status, slog.Int64("jobId", int64(jobID)))
+	a.auditor.WriteEvent(ctx, "RestoreStarted", EventStatusFromError(err), slog.Int64("jobId", int64(jobID)))
 
 	return jobID, err
 }
@@ -40,11 +36,7 @@ func (a *auditRestoreManager) RestoreByTime(
 ) (model.RestoreJobID, error) {
 	jobID, err := a.underlying.RestoreByTime(ctx, request)
 
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(ctx, "RestoreByTimeStarted", status, slog.Int64("jobId", int64(jobID)))
+	a.auditor.WriteEvent(ctx, "RestoreByTimeStarted", EventStatusFromError(err), slog.Int64("jobId", int64(jobID)))
 
 	return jobID, err
 }
@@ -56,11 +48,7 @@ func (a *auditRestoreManager) JobStatus(jobID model.RestoreJobID) (*model.Restor
 func (a *auditRestoreManager) CancelRestore(jobID model.RestoreJobID) error {
 	err := a.underlying.CancelRestore(jobID)
 
-	status := StatusSuccess
-	if err != nil {
-		status = StatusFailed
-	}
-	a.auditor.WriteEvent(context.Background(), "CancelRestore", status, slog.Int64("jobId", int64(jobID)))
+	a.auditor.WriteEvent(context.Background(), "CancelRestore", EventStatusFromError(err), slog.Int64("jobId", int64(jobID)))
 
 	return err
 }

--- a/pkg/audit/running_backups_registry.go
+++ b/pkg/audit/running_backups_registry.go
@@ -1,0 +1,41 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aerospike/aerospike-backup-service/v3/internal/server/handlers"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+)
+
+type auditRunningBackupsRegistry struct {
+	underlying handlers.RunningBackupsRegistry
+	auditor    Auditor
+}
+
+var _ handlers.RunningBackupsRegistry = (*auditRunningBackupsRegistry)(nil)
+
+// NewAuditRunningBackupsRegistry wraps an existing RunningBackupsRegistry to allow future security/RBAC additions
+// and emit audit logs for mutations like Cancel.
+func NewAuditRunningBackupsRegistry(
+	underlying handlers.RunningBackupsRegistry, auditor Auditor,
+) handlers.RunningBackupsRegistry {
+	return &auditRunningBackupsRegistry{
+		underlying: underlying,
+		auditor:    auditor,
+	}
+}
+
+func (a *auditRunningBackupsRegistry) GetRoutineState(routine *model.BackupRoutine) model.RoutineState {
+	return a.underlying.GetRoutineState(routine)
+}
+
+func (a *auditRunningBackupsRegistry) GetRunningState() map[string]model.RoutineState {
+	return a.underlying.GetRunningState()
+}
+
+func (a *auditRunningBackupsRegistry) Cancel(routineName string) {
+	a.underlying.Cancel(routineName)
+	// Currently Cancel() in registry doesn't return error.
+	a.auditor.WriteEvent(context.Background(), "CancelBackup", StatusSuccess, slog.String("routine", routineName))
+}

--- a/pkg/audit/server.go
+++ b/pkg/audit/server.go
@@ -1,0 +1,32 @@
+package audit
+
+import (
+	"context"
+
+	"github.com/aerospike/aerospike-backup-service/v3/internal/server"
+)
+
+type auditServer struct {
+	underlying server.Server
+	auditor    Auditor
+}
+
+var _ server.Server = (*auditServer)(nil)
+
+// NewAuditServer wraps a server.Server with audit logging.
+func NewAuditServer(underlying server.Server, auditor Auditor) server.Server {
+	return &auditServer{
+		underlying: underlying,
+		auditor:    auditor,
+	}
+}
+
+func (a *auditServer) Start() error {
+	return a.underlying.Start()
+}
+
+func (a *auditServer) Shutdown() error {
+	err := a.underlying.Shutdown()
+	a.auditor.WriteEvent(context.Background(), "ServerShutdown", EventStatusFromError(err))
+	return err
+}

--- a/test/integration/fixture.go
+++ b/test/integration/fixture.go
@@ -41,7 +41,7 @@ func (s *Suite) setupEnv(customize ...func(*dto.Config)) *env {
 	configPath := filepath.Join(t.TempDir(), "config.yml")
 	s.Require().NoError(os.WriteFile(configPath, configYAML, 0o600))
 
-	scheduler, svc, err := app.InitComponents(ctx, configPath, false)
+	scheduler, svc, _, err := app.InitComponents(ctx, configPath, false)
 	s.Require().NoError(err)
 
 	scheduler.Start(ctx)


### PR DESCRIPTION
## Summary
- Introduces `pkg/audit` with an idiomatic `Auditor` interface using `slog.Attr`
- Refactors state mutation (`changeBackupConfig`) out of the HTTP layer and into a dedicated `ConfigManager` interface
- Implements the Decorator Pattern to wrap `ConfigManager`, `RestoreManager`, and `AdHocScheduler` with Audit logging
- Ensures a strict architectural boundary so that future HTTP endpoints cannot bypass the audit layer
- Lays the foundation for intercepting business logic for future RBAC

## Test plan
- Verified `go test ./...` passes
- Verified `golangci-lint run ./...` passes
- Architecture confirms no double-parsing of HTTP JSON bodies

Made with [Cursor](https://cursor.com)