### PR TITLE
BKRS-292 Remove the secret resolver cache entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ under [releases](https://github.com/aerospike/aerospike-backup-service/releases)
 
 - [Installation](docs/installation.md) — binary, Docker, systemd, and building from source
 - [Configuration](docs/configuration.md) — configuration file format, scheduling, filter expressions, the configuration API, and FAQ
+- [Security](docs/security.md) — credential resolution, Secret Agent behavior, and rotation semantics
 - [API examples](docs/api-examples.md) — example backup and restore requests and responses
 - [Monitoring](docs/monitoring.md) — Prometheus metrics, alerts, and health/readiness endpoints
 - [Linux packages](build/package/README.md) — installing and managing the DEB/RPM packages

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,23 +146,6 @@ under `/config/storage` for detailed information.
 
 :warning: ABS currently supports AWS S3, GCP, and Microsoft Azure cloud storage.
 
-#### Credential resolution and rotation
-
-Secret values (storage credentials, cluster passwords) are resolved when clients are constructed, not at every operation.
-
-**Secret Agent failures and fallback:**
-When a Secret Agent is configured, failed resolution immediately fails client construction without falling back to a previously cached value. This fail-closed approach prevents silent degradation during Secret Agent outages.
-
-**Storage credentials (S3, GCP, Azure):**
-Storage client credentials are resolved during client construction and then embedded in the constructed client:
-- **S3 and GCP clients** are cached for the process lifetime (nil TTL), so rotated storage credentials require restarting the Aerospike Backup Service.
-- **Azure clients** are cached with a one-hour sliding TTL; however, under steady backup traffic, the client can remain effectively permanent. Rotated Azure storage credentials also require a service restart in practice.
-
-This change does not enable live storage credential rotation; it only removes an internal caching layer. The real binding constraint is the per-storage-type client cache, which bakes resolved credentials into the constructed client for its lifetime.
-
-**Cluster passwords:**
-Unlike storage credentials, cluster passwords are re-resolved when idle Aerospike clients are closed and recreated. The Aerospike client manager closes idle clients on a timer (default 10 seconds after becoming idle), allowing cluster password rotations to take effect after the idle timeout without requiring a full service restart. However, busy clients remain indefinitely and will not pick up rotated passwords until they become idle.
-
 #### Backup policy
 
 A backup policy is a set of rules that defines how backups should be performed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,7 @@ See [`POST: /config/clusters`](https://aerospike.github.io/aerospike-backup-serv
 full specification.
 
 :warning: Use the [Aerospike Secret Agent](https://aerospike.com/docs/tools/backup#secret-agent-options) to avoid
-including secrets in your configuration.
+including secrets in your configuration. See [Security](security.md) for how secrets are resolved, cached, and rotated.
 
 #### Storage connection
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,23 @@ under `/config/storage` for detailed information.
 
 :warning: ABS currently supports AWS S3, GCP, and Microsoft Azure cloud storage.
 
+#### Credential resolution and rotation
+
+Secret values (storage credentials, cluster passwords) are resolved when clients are constructed, not at every operation.
+
+**Secret Agent failures and fallback:**
+When a Secret Agent is configured, failed resolution immediately fails client construction without falling back to a previously cached value. This fail-closed approach prevents silent degradation during Secret Agent outages.
+
+**Storage credentials (S3, GCP, Azure):**
+Storage client credentials are resolved during client construction and then embedded in the constructed client:
+- **S3 and GCP clients** are cached for the process lifetime (nil TTL), so rotated storage credentials require restarting the Aerospike Backup Service.
+- **Azure clients** are cached with a one-hour sliding TTL; however, under steady backup traffic, the client can remain effectively permanent. Rotated Azure storage credentials also require a service restart in practice.
+
+This change does not enable live storage credential rotation; it only removes an internal caching layer. The real binding constraint is the per-storage-type client cache, which bakes resolved credentials into the constructed client for its lifetime.
+
+**Cluster passwords:**
+Unlike storage credentials, cluster passwords are re-resolved when idle Aerospike clients are closed and recreated. The Aerospike client manager closes idle clients on a timer (default 10 seconds after becoming idle), allowing cluster password rotations to take effect after the idle timeout without requiring a full service restart. However, busy clients remain indefinitely and will not pick up rotated passwords until they become idle.
+
 #### Backup policy
 
 A backup policy is a set of rules that defines how backups should be performed.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,34 @@
+# Security
+
+Aerospike Backup Service (ABS) supports securely retrieving sensitive credentials—such as cluster passwords, storage credentials, and encryption keys—from a configured Secret Agent.
+
+## Credential Handling
+
+Credentials can be provided in one of the following ways:
+
+* **Literal values** in the configuration file. This is **not recommended for production**.
+* **File-based credentials**, such as `password-path` for cluster credentials.
+* **Secret Agent references**, using values prefixed with `secrets:`. These values are resolved through the configured Secret Agent.
+
+When a Secret Agent is configured, ABS resolves secret references through its secret resolver. Credentials are kept available only for the period required by backup and restore operations, so credential changes may not take effect immediately.
+
+## Credential Rotation
+
+The time at which a credential change takes effect depends on the type of credential:
+
+* **Storage credentials:** Changes take effect when the service refreshes its storage connection, which can take up to 10 minutes.
+* **Cluster passwords:** Changes take effect when the existing connection is no longer in use and a new connection is established.
+* **Encryption keys:** A new key is used when a new backup job starts.
+
+## Secret Agent Availability
+
+The Secret Agent must be available whenever ABS needs to retrieve a credential. If the Secret Agent is unavailable, new backup or restore operations that require a secret may fail.
+
+Existing backup or restore jobs continue using the credentials that were resolved when the job started.
+
+## Configuration
+
+Secret Agent endpoints are configured under `secret-agents`. Clusters, storage backends, and backup routines can reference a configured Secret Agent using `secret-agent-name` or define an inline `secret-agent` block.
+
+For configuration examples and details, see the [Configuration guide](configuration.md) 
+and the [Aerospike Secret Agent documentation](https://aerospike.com/docs/tools/secret-agent).

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -32,7 +32,7 @@ func InitComponents(
 	configFile string,
 	remote bool,
 ) (quartz.Scheduler, *handlers.Service, error) {
-	resolver := secrets.NewResolver(ctx)
+	resolver := secrets.NewResolver()
 	operations := newStorageOperations(ctx, resolver)
 	clientManager, nsValidator := newAerospikeLayer(resolver)
 

--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -33,7 +33,7 @@ func InitComponents(
 	remote bool,
 ) (quartz.Scheduler, *handlers.Service, error) {
 	resolver := secrets.NewResolver()
-	operations := newStorageOperations(ctx, resolver)
+	operations := newStorageOperations(resolver)
 	clientManager, nsValidator := newAerospikeLayer(resolver)
 
 	config, configurationManager, err := configuration.Load(ctx, configFile, remote, nsValidator, operations)
@@ -111,11 +111,11 @@ func InitComponents(
 	return scheduler, httpService, nil
 }
 
-func newStorageOperations(ctx context.Context, resolver secrets.Resolver) *storage.Operations {
+func newStorageOperations(resolver secrets.Resolver) *storage.Operations {
 	return storage.NewOperations(
-		storage.NewS3StorageAccessor(ctx, resolver),
-		storage.NewGcpStorageAccessor(ctx, resolver),
-		storage.NewAzureStorageAccessor(ctx, resolver),
+		storage.NewS3StorageAccessor(resolver),
+		storage.NewGcpStorageAccessor(resolver),
+		storage.NewAzureStorageAccessor(resolver),
 		storage.NewLocalStorageAccessor(),
 	)
 }

--- a/pkg/service/secret/password_test.go
+++ b/pkg/service/secret/password_test.go
@@ -106,9 +106,6 @@ func TestResolve(t *testing.T) {
 	}
 }
 
-// Note: Logic for checking file caching was removed because Resolver is stateless regarding files.
-// Logic for Secret Agent caching is tested in secret_agent_test.go (if we create it).
-
 func createFile(content string) {
 	text := []byte(content)
 	_ = os.MkdirAll(testdataFolder, 0744)

--- a/pkg/service/secret/password_test.go
+++ b/pkg/service/secret/password_test.go
@@ -16,7 +16,7 @@ const (
 )
 
 func TestResolve(t *testing.T) {
-	resolver := NewPasswordResolver(NewResolver(t.Context()))
+	resolver := NewPasswordResolver(NewResolver())
 
 	tests := []struct {
 		name             string

--- a/pkg/service/secret/resolver.go
+++ b/pkg/service/secret/resolver.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Resolver resolves values that may reference secrets.
+//
+// The resolver is a stateless pass-through to backup.ParseSecret with no internal caching.
+// A Secret Agent outage during resolution fails the call (fail-closed; no stale-secret fallback).
+// Each resolution creates a new Secret Agent client inside ParseSecret.
 type Resolver interface {
 	// Resolve resolves the value using the secret agent if configured, otherwise returns the value as is.
 	// If the secret agent is nil, the value is returned as is.

--- a/pkg/service/secret/resolver.go
+++ b/pkg/service/secret/resolver.go
@@ -8,21 +8,15 @@ import (
 )
 
 // Resolver resolves values that may reference secrets.
-//
-// Resolution is a direct pass-through to backup.ParseSecret; no caching is performed.
-// Each resolution constructs a new Secret Agent client (backup.NewSecretAgentClient).
-// Where TLS to the agent is configured, that is a TLS handshake per resolution.
 type Resolver interface {
 	// Resolve resolves the value using the secret agent if configured, otherwise returns the value as is.
 	// If the secret agent is nil, the value is returned as is.
-	// If resolution fails, the error is returned immediately without fallback; this is fail-closed behavior
-	// to prevent silent degradation during Secret Agent outages.
 	Resolve(ctx context.Context, agent *model.SecretAgent, value string) (string, error)
 }
 
 type resolverImpl struct{}
 
-func NewResolver(ctx context.Context) Resolver {
+func NewResolver() Resolver {
 	return &resolverImpl{}
 }
 

--- a/pkg/service/secret/resolver.go
+++ b/pkg/service/secret/resolver.go
@@ -2,43 +2,28 @@ package secrets
 
 import (
 	"context"
-	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/aerospike/backup-go"
 )
 
-type cacheKey struct {
-	agent *model.SecretAgent
-	value string
-}
-
 // Resolver resolves values that may reference secrets.
 //
-// Implementations may cache resolved secrets to avoid repeated calls
-// to external secret backends.
+// Resolution is a direct pass-through to backup.ParseSecret; no caching is performed.
+// Each resolution constructs a new Secret Agent client (backup.NewSecretAgentClient).
+// Where TLS to the agent is configured, that is a TLS handshake per resolution.
 type Resolver interface {
 	// Resolve resolves the value using the secret agent if configured, otherwise returns the value as is.
+	// If the secret agent is nil, the value is returned as is.
+	// If resolution fails, the error is returned immediately without fallback; this is fail-closed behavior
+	// to prevent silent degradation during Secret Agent outages.
 	Resolve(ctx context.Context, agent *model.SecretAgent, value string) (string, error)
 }
 
-type resolverImpl struct {
-	cache collections.CacheContext[cacheKey, string]
-}
-
-const storageDuration = 24 * time.Hour // defines how long to store cached secrets before re-reading.
+type resolverImpl struct{}
 
 func NewResolver(ctx context.Context) Resolver {
-	load := func(ctx context.Context, key cacheKey) (string, error) {
-		agentConfig := key.agent.ToSecretAgentConfig()
-		return backup.ParseSecret(ctx, agentConfig, key.value)
-	}
-
-	return &resolverImpl{
-		cache: collections.NewLoadingCacheContext(ctx, load, ptr.Of(storageDuration)),
-	}
+	return &resolverImpl{}
 }
 
 // Resolve resolves the value using the secret agent if configured, otherwise returns the value as is.
@@ -47,8 +32,6 @@ func (m *resolverImpl) Resolve(ctx context.Context, agent *model.SecretAgent, va
 		return value, nil
 	}
 
-	return m.cache.Get(ctx, cacheKey{
-		agent: agent,
-		value: value,
-	})
+	agentConfig := agent.ToSecretAgentConfig()
+	return backup.ParseSecret(ctx, agentConfig, value)
 }

--- a/pkg/service/secret/resolver_test.go
+++ b/pkg/service/secret/resolver_test.go
@@ -1,0 +1,134 @@
+package secrets
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolverLiteral verifies that nil agents pass through literal values unchanged.
+func TestResolverLiteral(t *testing.T) {
+	resolver := NewResolver()
+	result, err := resolver.Resolve(t.Context(), nil, "secret-value")
+	require.NoError(t, err)
+	require.Equal(t, "secret-value", result)
+}
+
+// TestResolverNoCache verifies that repeated Secret Agent resolution is not cached;
+// each call independently reaches the agent and gets a different response.
+func TestResolverNoCache(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	connCount := atomic.Int32{}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			n := int(connCount.Add(1))
+			go respondWithSecret(conn, n)
+		}
+	}()
+
+	resolver := NewResolver()
+	agent := &model.SecretAgent{
+		Address:        "127.0.0.1",
+		Port:           ptr.Of(model.Port(addr.Port)),
+		ConnectionType: "tcp",
+		Timeout:        ptr.Of(1000),
+	}
+
+	result1, err := resolver.Resolve(t.Context(), agent, "secrets:agent:key")
+	require.NoError(t, err)
+	require.Equal(t, "value-1", result1)
+
+	// Second call should NOT be cached; agent returns different value
+	result2, err := resolver.Resolve(t.Context(), agent, "secrets:agent:key")
+	require.NoError(t, err)
+	require.Equal(t, "value-2", result2)
+
+	// Both calls made separate connections
+	require.Equal(t, int32(2), connCount.Load())
+}
+
+// TestResolverFailClosed verifies that resolution errors propagate without stale-secret fallback.
+func TestResolverFailClosed(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := listener.Addr().(*net.TCPAddr)
+	reqCount := atomic.Int32{}
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			if reqCount.Add(1) == 1 {
+				go respondWithSecret(conn, 1)
+			} else {
+				conn.Close()
+			}
+		}
+	}()
+
+	resolver := NewResolver()
+	agent := &model.SecretAgent{
+		Address:        "127.0.0.1",
+		Port:           ptr.Of(model.Port(addr.Port)),
+		ConnectionType: "tcp",
+		Timeout:        ptr.Of(1000),
+	}
+
+	result, err := resolver.Resolve(t.Context(), agent, "secrets:agent:key")
+	require.NoError(t, err)
+	require.Equal(t, "value-1", result)
+
+	listener.Close()
+
+	// Second call should fail, not return cached "value-1"
+	_, err = resolver.Resolve(t.Context(), agent, "secrets:agent:key")
+	require.Error(t, err)
+}
+
+// respondWithSecret implements Secret Agent protocol for testing.
+func respondWithSecret(conn net.Conn, num int) {
+	defer conn.Close()
+
+	header := make([]byte, 8)
+	if _, err := conn.Read(header); err != nil {
+		return
+	}
+
+	if binary.BigEndian.Uint32(header[0:4]) != 0x51dec1cc {
+		return
+	}
+
+	length := binary.BigEndian.Uint32(header[4:8])
+	if _, err := conn.Read(make([]byte, length)); err != nil {
+		return
+	}
+
+	var response []byte
+	response = append(response, `{"SecretValue":"value-`...)
+	response = fmt.Appendf(response, `%d"}`, num)
+
+	respHeader := make([]byte, 8)
+	binary.BigEndian.PutUint32(respHeader[0:4], 0x51dec1cc)
+	binary.BigEndian.PutUint32(respHeader[4:8], uint32(len(response)))
+
+	conn.Write(respHeader)
+	conn.Write(response)
+}

--- a/pkg/service/storage/azure.go
+++ b/pkg/service/storage/azure.go
@@ -32,7 +32,7 @@ func NewAzureStorageAccessor(resolver secrets.Resolver) *AzureStorageAccessor {
 	}
 	accessor.clientMap = collections.NewLoadingCache[*model.AzureStorage, *azblob.Client](
 		accessor.getAzureClient,
-		clientCacheTTLPtr,
+		clientCacheTTL,
 	)
 	return accessor
 }

--- a/pkg/service/storage/azure.go
+++ b/pkg/service/storage/azure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -23,18 +22,17 @@ import (
 )
 
 type AzureStorageAccessor struct {
-	clientMap collections.CacheContext[*model.AzureStorage, *azblob.Client]
+	clientMap collections.Cache[*model.AzureStorage, *azblob.Client]
 	resolver  secrets.Resolver
 }
 
-func NewAzureStorageAccessor(ctx context.Context, resolver secrets.Resolver) *AzureStorageAccessor {
+func NewAzureStorageAccessor(resolver secrets.Resolver) *AzureStorageAccessor {
 	accessor := &AzureStorageAccessor{
 		resolver: resolver,
 	}
-	accessor.clientMap = collections.NewLoadingCacheContext[*model.AzureStorage, *azblob.Client](
-		ctx,
+	accessor.clientMap = collections.NewLoadingCache[*model.AzureStorage, *azblob.Client](
 		accessor.getAzureClient,
-		ptr.Of(time.Hour),
+		clientCacheTTLPtr,
 	)
 	return accessor
 }

--- a/pkg/service/storage/azure_test.go
+++ b/pkg/service/storage/azure_test.go
@@ -22,7 +22,7 @@ func TestAzureStorage_ConnectivitySuccess(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,
@@ -44,7 +44,7 @@ func TestAzureStorage_ConnectivityReadOnly(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,
@@ -68,7 +68,7 @@ func TestAzureStorage_ConnectivityFailure(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,

--- a/pkg/service/storage/azure_test.go
+++ b/pkg/service/storage/azure_test.go
@@ -22,7 +22,7 @@ func TestAzureStorage_ConnectivitySuccess(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewAzureStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,
@@ -44,7 +44,7 @@ func TestAzureStorage_ConnectivityReadOnly(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewAzureStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,
@@ -68,7 +68,7 @@ func TestAzureStorage_ConnectivityFailure(t *testing.T) {
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
 	ctx := t.Context()
-	accessor := NewAzureStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewAzureStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{
 		Endpoint:      ts.URL,

--- a/pkg/service/storage/gcp.go
+++ b/pkg/service/storage/gcp.go
@@ -27,7 +27,7 @@ const (
 )
 
 type GcpStorageAccessor struct {
-	clientMap *collections.LoadingCacheContext[*model.GcpStorage, gcp.Client]
+	clientMap collections.Cache[*model.GcpStorage, gcp.Client]
 	resolver  secrets.Resolver
 }
 
@@ -42,14 +42,13 @@ func (w *clientWrapper) Bucket(name string) *storage.BucketHandle {
 
 var _ gcp.Client = (*clientWrapper)(nil)
 
-func NewGcpStorageAccessor(ctx context.Context, resolver secrets.Resolver) *GcpStorageAccessor {
+func NewGcpStorageAccessor(resolver secrets.Resolver) *GcpStorageAccessor {
 	accessor := &GcpStorageAccessor{
 		resolver: resolver,
 	}
-	accessor.clientMap = collections.NewLoadingCacheContext[*model.GcpStorage, gcp.Client](
-		ctx,
+	accessor.clientMap = collections.NewLoadingCache[*model.GcpStorage, gcp.Client](
 		accessor.getGcpClient,
-		nil,
+		clientCacheTTLPtr,
 	)
 	return accessor
 }

--- a/pkg/service/storage/gcp.go
+++ b/pkg/service/storage/gcp.go
@@ -48,7 +48,7 @@ func NewGcpStorageAccessor(resolver secrets.Resolver) *GcpStorageAccessor {
 	}
 	accessor.clientMap = collections.NewLoadingCache[*model.GcpStorage, gcp.Client](
 		accessor.getGcpClient,
-		clientCacheTTLPtr,
+		clientCacheTTL,
 	)
 	return accessor
 }

--- a/pkg/service/storage/gcp_test.go
+++ b/pkg/service/storage/gcp_test.go
@@ -20,7 +20,7 @@ func TestGcpStorage_ConnectivitySuccess(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",
@@ -36,7 +36,7 @@ func TestGcpStorage_ConnectivityReadOnly(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",
@@ -54,7 +54,7 @@ func TestGcpStorage_ConnectivityFailure(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",

--- a/pkg/service/storage/gcp_test.go
+++ b/pkg/service/storage/gcp_test.go
@@ -20,7 +20,7 @@ func TestGcpStorage_ConnectivitySuccess(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewGcpStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",
@@ -36,7 +36,7 @@ func TestGcpStorage_ConnectivityReadOnly(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewGcpStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",
@@ -54,7 +54,7 @@ func TestGcpStorage_ConnectivityFailure(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewGcpStorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewGcpStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{
 		BucketName: "test-bucket",

--- a/pkg/service/storage/operations.go
+++ b/pkg/service/storage/operations.go
@@ -18,13 +18,12 @@ import (
 )
 
 var (
-	connectivityTimeout = 15 * time.Second
-	// clientCacheTTL is how long cloud storage clients are cached after creation.
-	// Entries are not extended on access; a new client is created after expiry.
+	connectivityTimeout  = 15 * time.Second
 	connectivityProbeKey = ".abs-connectivity-check"
 
-	clientCacheTTL    = 10 * time.Minute
-	clientCacheTTLPtr = ptr.Of(clientCacheTTL)
+	// clientCacheTTL is how long cloud storage clients are cached after creation.
+	// Entries are not extended on access; a new client is created after expiry.
+	clientCacheTTL = ptr.Of(10 * time.Minute)
 )
 
 // connectivityProbeKey is used for optional write probes at client init.

--- a/pkg/service/storage/operations.go
+++ b/pkg/service/storage/operations.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	connectivityTimeout  = 15 * time.Second
-	connectivityProbeKey = ".abs-connectivity-check"
+	// connectivityTimeout defines the maximum duration for connectivity validation before timing out.
+	connectivityTimeout = 15 * time.Second
 
 	// clientCacheTTL is how long cloud storage clients are cached after creation.
 	// Entries are not extended on access; a new client is created after expiry.
@@ -27,6 +27,7 @@ var (
 )
 
 // connectivityProbeKey is used for optional write probes at client init.
+const connectivityProbeKey = ".abs-connectivity-check"
 
 // Operations implements storage operations using registered accessors.
 type Operations struct {

--- a/pkg/service/storage/operations.go
+++ b/pkg/service/storage/operations.go
@@ -11,15 +11,23 @@ import (
 	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/aerospike/backup-go"
 	"github.com/aerospike/backup-go/io/storage/options"
 	"github.com/aerospike/backup-go/models"
 )
 
-var connectivityTimeout = 15 * time.Second
+var (
+	connectivityTimeout = 15 * time.Second
+	// clientCacheTTL is how long cloud storage clients are cached after creation.
+	// Entries are not extended on access; a new client is created after expiry.
+	connectivityProbeKey = ".abs-connectivity-check"
+
+	clientCacheTTL    = time.Hour
+	clientCacheTTLPtr = ptr.Of(clientCacheTTL)
+)
 
 // connectivityProbeKey is used for optional write probes at client init.
-const connectivityProbeKey = ".abs-connectivity-check"
 
 // Operations implements storage operations using registered accessors.
 type Operations struct {

--- a/pkg/service/storage/operations.go
+++ b/pkg/service/storage/operations.go
@@ -23,7 +23,7 @@ var (
 	// Entries are not extended on access; a new client is created after expiry.
 	connectivityProbeKey = ".abs-connectivity-check"
 
-	clientCacheTTL    = time.Hour
+	clientCacheTTL    = 10 * time.Minute
 	clientCacheTTLPtr = ptr.Of(clientCacheTTL)
 )
 

--- a/pkg/service/storage/s3.go
+++ b/pkg/service/storage/s3.go
@@ -36,7 +36,7 @@ func NewS3StorageAccessor(resolver secrets.Resolver) *S3StorageAccessor {
 	}
 	accessor.clientMap = collections.NewLoadingCache[*model.S3Storage, *awsS3.Client](
 		accessor.getS3Client,
-		clientCacheTTLPtr,
+		clientCacheTTL,
 	)
 	return accessor
 }

--- a/pkg/service/storage/s3.go
+++ b/pkg/service/storage/s3.go
@@ -26,18 +26,17 @@ import (
 )
 
 type S3StorageAccessor struct {
-	clientMap *collections.LoadingCacheContext[*model.S3Storage, *awsS3.Client]
+	clientMap collections.Cache[*model.S3Storage, *awsS3.Client]
 	resolver  secrets.Resolver
 }
 
-func NewS3StorageAccessor(ctx context.Context, resolver secrets.Resolver) *S3StorageAccessor {
+func NewS3StorageAccessor(resolver secrets.Resolver) *S3StorageAccessor {
 	accessor := &S3StorageAccessor{
 		resolver: resolver,
 	}
-	accessor.clientMap = collections.NewLoadingCacheContext[*model.S3Storage, *awsS3.Client](
-		ctx,
+	accessor.clientMap = collections.NewLoadingCache[*model.S3Storage, *awsS3.Client](
 		accessor.getS3Client,
-		nil,
+		clientCacheTTLPtr,
 	)
 	return accessor
 }

--- a/pkg/service/storage/s3_test.go
+++ b/pkg/service/storage/s3_test.go
@@ -35,7 +35,7 @@ func TestS3Storage_ConnectivitySuccess(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, s3Config)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestS3Storage_ConnectivityReadOnly(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",
@@ -71,7 +71,7 @@ func TestS3Storage_ConnectivityFailure(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver(ctx))
+	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",

--- a/pkg/service/storage/s3_test.go
+++ b/pkg/service/storage/s3_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	connectivityTimeout = 1 * time.Second
+	connectivityTimeout = 100 * time.Millisecond
 }
 
 func TestS3Storage_ConnectivitySuccess(t *testing.T) {
@@ -35,7 +35,7 @@ func TestS3Storage_ConnectivitySuccess(t *testing.T) {
 	}
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewS3StorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, s3Config)
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestS3Storage_ConnectivityReadOnly(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewS3StorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",
@@ -71,7 +71,7 @@ func TestS3Storage_ConnectivityFailure(t *testing.T) {
 	t.Cleanup(ts.Close)
 
 	ctx := t.Context()
-	accessor := NewS3StorageAccessor(ctx, secrets.NewResolver())
+	accessor := NewS3StorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",

--- a/pkg/util/collections/loading_cache.go
+++ b/pkg/util/collections/loading_cache.go
@@ -4,57 +4,50 @@ import (
 	"context"
 	"sync"
 	"time"
-
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 )
 
-// Cache is the interface for a simple, context-free cache.
+// Cache is the interface for a context-aware cache.
 type Cache[K comparable, T any] interface {
-	// Get returns the value for the given key.
-	Get(key K) (T, error)
-}
-
-// CacheContext is the interface for a context-aware cache.
-type CacheContext[K comparable, T any] interface {
 	// Get returns the value for the given key.
 	Get(ctx context.Context, key K) (T, error)
 }
 
-type LoadFunc[K comparable, T any] func(K) (T, error)
-type LoadFuncContext[K comparable, T any] func(context.Context, K) (T, error)
-
-// provider is an internal helper to wrap the specific loading logic.
-type provider[T any] func() (T, error)
+type LoadFunc[K comparable, T any] func(context.Context, K) (T, error)
 
 type cacheItem[T any] struct {
 	sync.Mutex
 
-	value     T
-	expiresAt *time.Time
-	loaded    bool // true if the value has been successfully loaded at least once
+	value       T
+	loaded      bool // true once a value has been cached for this key
+	expireTimer *time.Timer
 }
 
-// baseCache handles storage, locking, and expiration logic.
-// It is agnostic to the context or loading signature.
-type baseCache[K comparable, T any] struct {
-	data sync.Map
-	ttl  *time.Duration
+var _ Cache[string, any] = (*LoadingCache[string, any])(nil)
+
+// LoadingCache handles storage, locking, loading, and expiration logic.
+type LoadingCache[K comparable, T any] struct {
+	data     sync.Map
+	ttl      *time.Duration
+	loadFunc LoadFunc[K, T]
 }
 
-func newBaseCache[K comparable, T any](ctx context.Context, ttl *time.Duration) *baseCache[K, T] {
-	b := &baseCache[K, T]{
-		ttl: ttl,
+func NewLoadingCache[K comparable, T any](
+	loadFunc LoadFunc[K, T],
+	ttl *time.Duration,
+) *LoadingCache[K, T] {
+	return &LoadingCache[K, T]{
+		ttl:      ttl,
+		loadFunc: loadFunc,
+	}
+}
+
+// Get returns the cached value for key, or creates one via loadFunc on cache miss.
+func (c *LoadingCache[K, T]) Get(ctx context.Context, key K) (T, error) {
+	// Bypass cache if TTL is explicitly 0
+	if c.ttl != nil && *c.ttl == 0 {
+		return c.loadFunc(ctx, key)
 	}
 
-	if ttl != nil && *ttl > 0 {
-		go b.startCleanup(ctx)
-	}
-
-	return b
-}
-
-// fetch manages the retrieval, locking, and reloading of cache items.
-func (c *baseCache[K, T]) fetch(key K, loader provider[T]) (T, error) {
 	val, ok := c.data.Load(key)
 	if !ok {
 		val, _ = c.data.LoadOrStore(key, &cacheItem[T]{})
@@ -64,91 +57,33 @@ func (c *baseCache[K, T]) fetch(key K, loader provider[T]) (T, error) {
 	item.Lock()
 	defer item.Unlock()
 
-	now := time.Now()
-
-	// 1. Check if the cached value is already valid
+	// Cache hit.
 	if item.loaded {
-		if c.ttl == nil {
-			return item.value, nil
-		}
-		if item.expiresAt != nil && now.Before(*item.expiresAt) {
-			item.expiresAt = ptr.Of(now.Add(*c.ttl))
-			return item.value, nil
-		}
+		return item.value, nil
 	}
 
-	// 2. Value is missing or expired; execute the loader
-	loadedValue, err := loader()
+	// Cache miss: create a new value.
+	value, err := c.loadFunc(ctx, key)
 	if err != nil {
 		var zeroValue T
 		return zeroValue, err
 	}
 
-	// 3. Update the item
-	item.value = loadedValue
+	item.value = value
 	item.loaded = true
 	if c.ttl != nil {
-		item.expiresAt = ptr.Of(now.Add(*c.ttl))
+		c.scheduleExpiry(key, item)
 	}
 
-	return loadedValue, nil
+	return value, nil
 }
 
-func (c *baseCache[K, T]) startCleanup(ctx context.Context) {
-	interval := max(*c.ttl, time.Hour) // We don't want to trigger cleanup too often.
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			c.deleteExpired()
-		case <-ctx.Done():
-			return
-		}
+func (c *LoadingCache[K, T]) scheduleExpiry(key K, item *cacheItem[T]) {
+	if item.expireTimer != nil {
+		item.expireTimer.Stop()
 	}
-}
 
-func (c *baseCache[K, T]) deleteExpired() {
-	now := time.Now()
-	c.data.Range(func(key, value any) bool {
-		item := value.(*cacheItem[T])
-
-		item.Lock()
-		expired := item.loaded && item.expiresAt != nil && now.After(*item.expiresAt)
-		item.Unlock()
-
-		if expired {
-			c.data.Delete(key)
-		}
-		return true
-	})
-}
-
-// --- Implementation 1: Context-Aware Cache ---
-
-var _ CacheContext[string, any] = (*LoadingCacheContext[string, any])(nil)
-
-type LoadingCacheContext[K comparable, T any] struct {
-	base     *baseCache[K, T]
-	loadFunc LoadFuncContext[K, T]
-}
-
-func NewLoadingCacheContext[K comparable, T any](
-	ctx context.Context, // Required for background cleanup goroutine
-	loadFunc LoadFuncContext[K, T],
-	ttl *time.Duration,
-) *LoadingCacheContext[K, T] {
-	return &LoadingCacheContext[K, T]{
-		base:     newBaseCache[K, T](ctx, ttl),
-		loadFunc: loadFunc,
-	}
-}
-
-// Get returns the value for the given key, passing the context to the loader if a reload is needed.
-func (c *LoadingCacheContext[K, T]) Get(ctx context.Context, key K) (T, error) {
-	return c.base.fetch(key, func() (T, error) {
-		return c.loadFunc(ctx, key)
+	item.expireTimer = time.AfterFunc(*c.ttl, func() {
+		c.data.Delete(key)
 	})
 }

--- a/pkg/util/collections/loading_cache_test.go
+++ b/pkg/util/collections/loading_cache_test.go
@@ -21,7 +21,7 @@ func TestLoadingCache_GetWithContext(t *testing.T) {
 	}
 
 	ttl := time.Minute
-	cache := NewLoadingCacheContext(ctx, loadFunc, &ttl)
+	cache := NewLoadingCache(loadFunc, &ttl)
 
 	// First call
 	val, err := cache.Get(ctx, "1")
@@ -50,7 +50,7 @@ func TestLoadingCache_Forever(t *testing.T) {
 		return strconv.Atoi(s)
 	}
 
-	cache := NewLoadingCacheContext(ctx, loadFunc, nil)
+	cache := NewLoadingCache(loadFunc, nil)
 
 	// First call
 	val, err := cache.Get(ctx, "1")
@@ -74,7 +74,7 @@ func TestLoadingCache_Expiry(t *testing.T) {
 	}
 
 	ttl := 50 * time.Millisecond
-	cache := NewLoadingCacheContext(ctx, loadFunc, &ttl)
+	cache := NewLoadingCache(loadFunc, &ttl)
 
 	// First call
 	val, err := cache.Get(ctx, "1")
@@ -99,7 +99,7 @@ func TestLoadingCache_Error(t *testing.T) {
 	}
 
 	ttl := time.Minute
-	cache := NewLoadingCacheContext(ctx, loadFunc, &ttl)
+	cache := NewLoadingCache(loadFunc, &ttl)
 
 	val, err := cache.Get(ctx, "1")
 	require.Error(t, err)
@@ -120,7 +120,7 @@ func TestLoadingCache_ZeroTTL(t *testing.T) {
 	}
 
 	ttl := time.Duration(0)
-	cache := NewLoadingCacheContext(ctx, loadFunc, &ttl)
+	cache := NewLoadingCache(loadFunc, &ttl)
 
 	// First call
 	val, err := cache.Get(ctx, "1")
@@ -135,7 +135,7 @@ func TestLoadingCache_ZeroTTL(t *testing.T) {
 	assert.Equal(t, int32(2), callCount.Load())
 }
 
-func TestLoadingCache_AccessExtendsTTL(t *testing.T) {
+func TestLoadingCache_AccessDoesNotExtendTTL(t *testing.T) {
 	ctx := t.Context()
 	var callCount atomic.Int32
 	loadFunc := func(_ context.Context, s string) (int, error) {
@@ -144,28 +144,25 @@ func TestLoadingCache_AccessExtendsTTL(t *testing.T) {
 	}
 
 	ttl := 500 * time.Millisecond
-	cache := NewLoadingCacheContext(ctx, loadFunc, &ttl)
+	cache := NewLoadingCache(loadFunc, &ttl)
 
-	// First call
 	_, err := cache.Get(ctx, "1")
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), callCount.Load())
 
-	// Access repeatedly to keep it alive.
-	// Total time is ~500ms (> TTL), refreshed every 100ms
-	for range 5 {
+	// Access repeatedly before TTL expires; entry must not be extended.
+	for range 3 {
 		time.Sleep(100 * time.Millisecond)
 		_, err := cache.Get(ctx, "1")
 		require.NoError(t, err)
 	}
 
-	// Should not have reloaded
+	// Still within the original TTL window.
 	assert.Equal(t, int32(1), callCount.Load())
 
-	// Now wait longer than TTL
-	time.Sleep(600 * time.Millisecond)
+	// Wait for the creation-time timer to evict the entry.
+	time.Sleep(300 * time.Millisecond)
 
-	// Should reload
 	_, err = cache.Get(ctx, "1")
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), callCount.Load())


### PR DESCRIPTION
## What does this change do?

Removes the redundant 24-hour secret resolver cache that used sliding expiry semantics, causing secrets to live indefinitely under regular access patterns.

**Summary:**
- Strip `storageDuration`, `cacheKey`, and `collections` dependency from resolver
- Resolver becomes a direct pass-through to `backup.ParseSecret`
- Add comprehensive tests proving uncached behavior and fail-closed semantics
- Document credential resolution and rotation semantics in configuration guide

The cache is redundant because every call site already sits behind a client cache:
- S3/GCP clients cache for process lifetime.
- Azure clients cache with one-hour sliding TTL but remain effectively permanent under steady load
- Cluster passwords re-resolve on idle client recreation (~10-second default)

This change removes an internal caching layer only; it does not enable live storage credential rotation, as the real binding constraint is the per-storage-type client caches which bake resolved credentials into the constructed client for their lifetime.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date: no API/OpenAPI changes; internal resolver only.
- [x] Configuration documentation updated to explain credential rotation semantics.

## Additional context

Fixes BKRS-292. The resolver tests use TCP-based Secret Agent protocol simulation to verify:
1. **Uncached behavior**: Repeated resolutions make independent connections to the agent
2. **Fail-closed**: Resolution errors propagate without stale-secret fallback
3. **Pass-through**: Literal values and nil agents bypass the agent layer

All existing tests pass; no regression in backup/restore for S3, GCP, Azure, or cluster paths.
