### PR TITLE
Feature/password log masking

### DIFF
--- a/build/readme/readme_generator.go
+++ b/build/readme/readme_generator.go
@@ -82,8 +82,8 @@ var cluster = dto.AerospikeCluster{
 		HostName: "host.docker.internal", Port: 3000},
 	},
 	Credentials: &dto.Credentials{
-		User:     ptr.Of("user"),
-		Password: ptr.Of("password"),
+		User:     "user",
+		Password: "password",
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.0
-	github.com/aws/smithy-go v1.27.4
 	github.com/go-logr/logr v1.4.4
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
@@ -68,6 +67,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.0 // indirect
+	github.com/aws/smithy-go v1.27.4 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
+	github.com/m-mizutani/masq v0.2.2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -198,6 +198,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
+github.com/m-mizutani/gt v0.1.0 h1:HCz+dE6zmlpceb4smal4hOyZyS+WHxGtiOTUJwA9n1A=
+github.com/m-mizutani/gt v0.1.0/go.mod h1:0MPYSfGBLmYjTduzADVmIqD58ELQ5IfBFiK/f0FmB3k=
+github.com/m-mizutani/masq v0.2.2 h1:C049XdUabx1T+cUuWUiWg9gGo7onrMAgqRe71tyBi58=
+github.com/m-mizutani/masq v0.2.2/go.mod h1:tDXVSkv0TlxdxV8dfkmKj974VQozK9llZSSCHhEkcJE=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=

--- a/internal/log/log_handler.go
+++ b/internal/log/log_handler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/m-mizutani/masq"
 	"github.com/reugn/go-quartz/logger"
 	"github.com/reugn/go-quartz/quartz"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -38,8 +39,11 @@ func NewHandler(config *model.LoggerConfig) slog.Handler {
 	}
 }
 
-// handlerReplaceAttr customizes the TRACE level string representation in logs.
-var handlerReplaceAttr = func(_ []string, a slog.Attr) slog.Attr {
+var masqReplaceAttr = masq.New(masq.WithTag("secret"))
+
+// handlerReplaceAttr redacts sensitive fields and customizes the TRACE level string representation in logs.
+var handlerReplaceAttr = func(groups []string, a slog.Attr) slog.Attr {
+	a = masqReplaceAttr(groups, a)
 	if a.Key == slog.LevelKey {
 		level := a.Value.Any().(slog.Level)
 		if level == slog.Level(logger.LevelTrace) {

--- a/internal/log/log_handler.go
+++ b/internal/log/log_handler.go
@@ -21,7 +21,8 @@ func init() {
 func NewHandler(config *model.LoggerConfig) slog.Handler {
 	const addSource = true
 	writer := newRedactingWriter(logWriter(config))
-	switch strings.ToUpper(config.GetFormatOrDefault()) {
+	logFormat := config.GetFormatOrDefault()
+	switch strings.ToUpper(logFormat) {
 	case "PLAIN":
 		return slog.NewTextHandler(writer, &slog.HandlerOptions{
 			Level:       logLevel(config.GetLevelOrDefault()),
@@ -35,7 +36,7 @@ func NewHandler(config *model.LoggerConfig) slog.Handler {
 			ReplaceAttr: handlerReplaceAttr,
 		})
 	default:
-		panic("unsupported log format: " + *config.Format)
+		panic("unsupported log format: " + logFormat)
 	}
 }
 

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -16,7 +16,7 @@ import (
 //nolint:lll
 type AerospikeCluster struct {
 	// The cluster name. Optional: used only in logs and error messages.
-	ClusterLabel *string `yaml:"label,omitempty" json:"label,omitempty" example:"testCluster" extensions:"x-nullable"`
+	ClusterLabel string `yaml:"label,omitempty" json:"label,omitempty" example:"testCluster" extensions:"x-nullable"`
 	// The seed nodes details.
 	SeedNodes []SeedNode `yaml:"seed-nodes,omitempty" json:"seed-nodes,omitempty" validate:"required"`
 	// The connection timeout in milliseconds.
@@ -195,7 +195,7 @@ type Credentials struct {
 	// The file path with the password string.
 	PasswordPath string `yaml:"password-path,omitempty" json:"password-path,omitempty" example:"/path/to/pass.txt"  extensions:"x-nullable" masq:"secret"`
 	// The authentication mode string (INTERNAL, EXTERNAL, PKI).
-	AuthMode *string `yaml:"auth-mode,omitempty" json:"auth-mode,omitempty" enums:"INTERNAL,EXTERNAL,PKI" default:"INTERNAL"`
+	AuthMode string `yaml:"auth-mode,omitempty" json:"auth-mode,omitempty" enums:"INTERNAL,EXTERNAL,PKI" default:"INTERNAL"`
 }
 
 func (c *Credentials) fromModel(m *model.Credentials, config *model.BackupConfig) {

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -188,12 +188,12 @@ func (a *AerospikeCluster) seedNodesToModel() []model.SeedNode {
 type Credentials struct {
 	SecretAgentConfig `yaml:",inline"`
 	// The username for the cluster authentication.
-	User *string `yaml:"user,omitempty" json:"user,omitempty" example:"testUser"  extensions:"x-nullable"`
+	User string `yaml:"user,omitempty" json:"user,omitempty" example:"testUser"  extensions:"x-nullable"`
 	// The password for the cluster authentication.
 	// It can be either plain text or path into the secret agent.
-	Password *string `yaml:"password,omitempty" json:"password,omitempty" example:"testPswd"  extensions:"x-nullable"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty" example:"testPswd"  extensions:"x-nullable" masq:"secret"`
 	// The file path with the password string.
-	PasswordPath *string `yaml:"password-path,omitempty" json:"password-path,omitempty" example:"/path/to/pass.txt"  extensions:"x-nullable"`
+	PasswordPath string `yaml:"password-path,omitempty" json:"password-path,omitempty" example:"/path/to/pass.txt"  extensions:"x-nullable"`
 	// The authentication mode string (INTERNAL, EXTERNAL, PKI).
 	AuthMode *string `yaml:"auth-mode,omitempty" json:"auth-mode,omitempty" enums:"INTERNAL,EXTERNAL,PKI" default:"INTERNAL"`
 }
@@ -213,13 +213,13 @@ func (c *Credentials) Validate(opts ...ValidationOption) error {
 		return nil
 	}
 
-	hasAuth := c.Password != nil || c.PasswordPath != nil
+	hasAuth := c.Password != "" || c.PasswordPath != ""
 
-	if hasAuth && c.User == nil {
+	if hasAuth && c.User == "" {
 		return errors.New("username is required when using authentication")
 	}
 
-	if c.Password != nil && c.PasswordPath != nil {
+	if c.Password != "" && c.PasswordPath != "" {
 		return errValidationMutuallyExclusive("password", "password-path")
 	}
 

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -193,7 +193,7 @@ type Credentials struct {
 	// It can be either plain text or path into the secret agent.
 	Password string `yaml:"password,omitempty" json:"password,omitempty" example:"testPswd"  extensions:"x-nullable" masq:"secret"`
 	// The file path with the password string.
-	PasswordPath string `yaml:"password-path,omitempty" json:"password-path,omitempty" example:"/path/to/pass.txt"  extensions:"x-nullable"`
+	PasswordPath string `yaml:"password-path,omitempty" json:"password-path,omitempty" example:"/path/to/pass.txt"  extensions:"x-nullable" masq:"secret"`
 	// The authentication mode string (INTERNAL, EXTERNAL, PKI).
 	AuthMode *string `yaml:"auth-mode,omitempty" json:"auth-mode,omitempty" enums:"INTERNAL,EXTERNAL,PKI" default:"INTERNAL"`
 }

--- a/pkg/dto/backup_common_config.go
+++ b/pkg/dto/backup_common_config.go
@@ -16,7 +16,7 @@ type BackupCommonConfig struct {
 	// * ISO (e.g. 2006-01-02T15-04-05)
 	// * EU (e.g. 02-Jan-2006-15-04-05)
 	// * US (e.g. Jan-02-2006-15-04-05)
-	TimestampFormat *string `yaml:"timestamp-format,omitempty" json:"timestamp-format,omitempty" enums:"ISO,US,EU" extensions:"x-nullable"` //nolint:lll
+	TimestampFormat string `yaml:"timestamp-format,omitempty" json:"timestamp-format,omitempty" enums:"ISO,US,EU" extensions:"x-nullable"` //nolint:lll
 }
 
 // Validate validates the backup subsection configuration.
@@ -25,11 +25,11 @@ func (b *BackupCommonConfig) Validate() error {
 		return nil
 	}
 
-	if b.TimestampFormat != nil {
-		format := model.TimestampFormatFromString(*b.TimestampFormat)
+	if b.TimestampFormat != "" {
+		format := model.TimestampFormatFromString(b.TimestampFormat)
 		if _, ok := model.TimestampFormatPresets[format]; !ok {
 			allowed := slices.Collect(maps.Keys(model.TimestampFormatPresets))
-			return errValidationInvalidValue("timestamp-format", *b.TimestampFormat, allowed)
+			return errValidationInvalidValue("timestamp-format", b.TimestampFormat, allowed)
 		}
 	}
 
@@ -42,8 +42,8 @@ func (b *BackupCommonConfig) ToModel() *model.BackupCommonConfig {
 	}
 
 	var df *model.TimestampFormat
-	if b.TimestampFormat != nil {
-		v := model.TimestampFormatFromString(*b.TimestampFormat)
+	if b.TimestampFormat != "" {
+		v := model.TimestampFormatFromString(b.TimestampFormat)
 		df = &v
 	}
 
@@ -52,8 +52,7 @@ func (b *BackupCommonConfig) ToModel() *model.BackupCommonConfig {
 
 func (b *BackupCommonConfig) fromModel(m *model.BackupCommonConfig) {
 	if m.TimestampFormat != nil {
-		v := string(*m.TimestampFormat)
-		b.TimestampFormat = &v
+		b.TimestampFormat = string(*m.TimestampFormat)
 	}
 }
 
@@ -68,5 +67,5 @@ func (b *BackupCommonConfig) Compare(other *BackupCommonConfig) error {
 	if other == nil {
 		return errors.New("backup removed")
 	}
-	return comparePointers("TimestampFormat", b.TimestampFormat, other.TimestampFormat)
+	return compareValues("TimestampFormat", b.TimestampFormat, other.TimestampFormat)
 }

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 	as "github.com/aerospike/aerospike-client-go/v8"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/reugn/go-quartz/quartz"
 )
 
@@ -29,7 +28,7 @@ type BackupRoutine struct {
 	// The name of the corresponding storage provider configuration.
 	Storage string `yaml:"storage,omitempty" json:"storage,omitempty" validate:"required"`
 	// The name of a Secret Agent to read secrets from (optional).
-	SecretAgent *string `yaml:"secret-agent,omitempty" json:"secret-agent,omitempty" extensions:"x-nullable"`
+	SecretAgent string `yaml:"secret-agent,omitempty" json:"secret-agent,omitempty" extensions:"x-nullable"`
 	// The interval for full backup as a cron expression string.
 	// Cron expression format: https://github.com/reugn/go-quartz?tab=readme-ov-file#cron-expression-format
 	IntervalCron string `yaml:"interval-cron" json:"interval-cron" example:"0 0 * * * *" validate:"required"`
@@ -114,11 +113,6 @@ func (r *BackupRoutine) Validate() error {
 		}
 		if rack > maxRack {
 			return fmt.Errorf("rack id %d invalid, should not exceed %d", rack, maxRack)
-		}
-	}
-	if r.SecretAgent != nil {
-		if *r.SecretAgent == "" {
-			return errValidationEmptyField("secret-agent")
 		}
 	}
 	if err := validatePartitionList(r.PartitionList); err != nil {
@@ -289,10 +283,10 @@ func (r *BackupRoutine) ToModel(config *model.BackupConfig, name string) (*model
 	}
 
 	var secretAgent *model.SecretAgent
-	if r.SecretAgent != nil {
-		secretAgent, found = config.SecretAgents[*r.SecretAgent]
+	if r.SecretAgent != "" {
+		secretAgent, found = config.SecretAgents[r.SecretAgent]
 		if !found {
-			return nil, errValidationNotFound("secret agent", *r.SecretAgent)
+			return nil, errValidationNotFound("secret agent", r.SecretAgent)
 		}
 	}
 
@@ -386,7 +380,7 @@ func (r *BackupRoutine) fromModel(m *model.BackupRoutine, config *model.BackupCo
 	r.SourceCluster = findKeyByValue(config.AerospikeClusters, m.SourceCluster)
 	r.Storage = findStorageKey(config.Storage, m.Storage)
 	if m.SecretAgent != nil {
-		r.SecretAgent = ptr.String(findKeyByValue(config.SecretAgents, m.SecretAgent))
+		r.SecretAgent = findKeyByValue(config.SecretAgents, m.SecretAgent)
 	}
 	r.IntervalCron = m.IntervalCron
 	r.IncrIntervalCron = m.IncrIntervalCron

--- a/pkg/dto/backup_routine_test.go
+++ b/pkg/dto/backup_routine_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	utptr "github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +54,7 @@ func TestBackupRoutine_ToModel(t *testing.T) {
 		BackupPolicy:     "policy1",
 		SourceCluster:    "cluster1",
 		Storage:          "storage1",
-		SecretAgent:      ptr.String("agent1"),
+		SecretAgent:      "agent1",
 		IntervalCron:     "cron",
 		IncrIntervalCron: "inc_cron",
 		Namespaces:       &[]string{"ns1"},
@@ -172,7 +171,7 @@ func TestBackupRoutine_ToModel_SecretAgentNotFound(t *testing.T) {
 		BackupPolicy:  "policy1",
 		SourceCluster: "cluster1",
 		Storage:       "storage1",
-		SecretAgent:   ptr.String("agent1"),
+		SecretAgent:   "agent1",
 		Namespaces:    &[]string{"ns1"},
 	}
 

--- a/pkg/dto/backup_service_config_validate_test.go
+++ b/pkg/dto/backup_service_config_validate_test.go
@@ -3,14 +3,13 @@ package dto
 import (
 	"testing"
 
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBackupServiceConfig_Validate_Success(t *testing.T) {
 	cfg := &ServiceConfig{
-		HTTPServer: &HTTPServerConfig{ContextPath: ptr.Of("/")},
-		Logger:     &LoggerConfig{Level: ptr.Of("INFO")},
+		HTTPServer: &HTTPServerConfig{ContextPath: "/"},
+		Logger:     &LoggerConfig{Level: "INFO"},
 	}
 
 	err := cfg.Validate()
@@ -19,7 +18,7 @@ func TestBackupServiceConfig_Validate_Success(t *testing.T) {
 
 func TestBackupServiceConfig_Validate_PropagatesHTTPServerError(t *testing.T) {
 	cfg := &ServiceConfig{
-		HTTPServer: &HTTPServerConfig{ContextPath: ptr.Of("FOO")}, // missing leading slash => invalid
+		HTTPServer: &HTTPServerConfig{ContextPath: "FOO"}, // missing leading slash => invalid
 	}
 
 	err := cfg.Validate()
@@ -29,7 +28,7 @@ func TestBackupServiceConfig_Validate_PropagatesHTTPServerError(t *testing.T) {
 
 func TestBackupServiceConfig_Validate_PropagatesLoggerError(t *testing.T) {
 	cfg := &ServiceConfig{
-		Logger: &LoggerConfig{Level: ptr.Of("FOO")},
+		Logger: &LoggerConfig{Level: "FOO"},
 	}
 
 	err := cfg.Validate()
@@ -39,7 +38,7 @@ func TestBackupServiceConfig_Validate_PropagatesLoggerError(t *testing.T) {
 
 func TestBackupServiceConfig_Validate_InvalidTimestampFormat(t *testing.T) {
 	cfg := &ServiceConfig{
-		Backup: &BackupCommonConfig{TimestampFormat: ptr.Of("UK")},
+		Backup: &BackupCommonConfig{TimestampFormat: "UK"},
 	}
 
 	err := cfg.Validate()
@@ -50,7 +49,7 @@ func TestBackupServiceConfig_Validate_InvalidTimestampFormat(t *testing.T) {
 func TestBackupServiceConfig_Validate_ValidTimestampFormats(t *testing.T) {
 	for _, v := range []string{"ISO", "US", "EU", "iso", "us", "eu"} {
 		cfg := &ServiceConfig{
-			Backup: &BackupCommonConfig{TimestampFormat: &v},
+			Backup: &BackupCommonConfig{TimestampFormat: v},
 		}
 		err := cfg.Validate()
 		require.NoError(t, err)

--- a/pkg/dto/client_tls.go
+++ b/pkg/dto/client_tls.go
@@ -13,13 +13,13 @@ import (
 //nolint:lll
 type ClientTLS struct {
 	// Path to a trusted CA certificate file in PEM format.
-	CAFile *string `yaml:"ca-file,omitempty" json:"ca-file,omitempty" example:"/path/to/ca.pem" extensions:"x-nullable"`
+	CAFile string `yaml:"ca-file,omitempty" json:"ca-file,omitempty" example:"/path/to/ca.pem" extensions:"x-nullable"`
 	// TLSName used for server certificate verification (ServerName for SNI).
-	Name *string `yaml:"name,omitempty" json:"name,omitempty" example:"example.com" extensions:"x-nullable"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty" example:"example.com" extensions:"x-nullable"`
 	// Path to a client certificate file for mutual TLS authentication.
-	Certfile *string `yaml:"cert-file,omitempty" json:"cert-file,omitempty" example:"/path/to/cert.pem" extensions:"x-nullable"`
+	Certfile string `yaml:"cert-file,omitempty" json:"cert-file,omitempty" example:"/path/to/cert.pem" extensions:"x-nullable"`
 	// Path to a client private key file for mutual TLS authentication.
-	Keyfile *string `yaml:"key-file,omitempty" json:"key-file,omitempty" example:"/path/to/key.pem" extensions:"x-nullable"`
+	Keyfile string `yaml:"key-file,omitempty" json:"key-file,omitempty" example:"/path/to/key.pem" extensions:"x-nullable"`
 }
 
 // Validate validates the ClientTLS configuration.
@@ -34,29 +34,29 @@ func (c *ClientTLS) Validate(opts ...ValidationOption) error {
 		}
 	}
 
-	if c.Certfile != nil {
-		if c.Keyfile == nil {
+	if c.Certfile != "" {
+		if c.Keyfile == "" {
 			return errValidationRequires("cert-file", "key-file")
 		}
-		if c.Name == nil {
+		if c.Name == "" {
 			return errValidationRequires("cert-file", "name")
 		}
 	}
 
-	if c.Keyfile != nil {
-		if c.Certfile == nil {
+	if c.Keyfile != "" {
+		if c.Certfile == "" {
 			return errValidationRequires("key-file", "cert-file")
 		}
-		if c.Name == nil {
+		if c.Name == "" {
 			return errValidationRequires("key-file", "name")
 		}
 	}
 
-	if c.Name != nil {
-		if c.Certfile == nil {
+	if c.Name != "" {
+		if c.Certfile == "" {
 			return errValidationRequires("name", "cert-file")
 		}
-		if c.Keyfile == nil {
+		if c.Keyfile == "" {
 			return errValidationRequires("name", "key-file")
 		}
 	}
@@ -78,21 +78,21 @@ func (c *ClientTLS) ToModel() model.ClientTLS {
 }
 
 func verifyFilesExist(c *ClientTLS) error {
-	if c.CAFile != nil {
-		if _, err := os.Stat(*c.CAFile); err != nil {
-			return errValidationNotFound("ca-file", *c.CAFile)
+	if c.CAFile != "" {
+		if _, err := os.Stat(c.CAFile); err != nil {
+			return errValidationNotFound("ca-file", c.CAFile)
 		}
 	}
 
-	if c.Certfile != nil {
-		if _, err := os.Stat(*c.Certfile); err != nil {
-			return errValidationNotFound("cert-file", *c.Certfile)
+	if c.Certfile != "" {
+		if _, err := os.Stat(c.Certfile); err != nil {
+			return errValidationNotFound("cert-file", c.Certfile)
 		}
 	}
 
-	if c.Keyfile != nil {
-		if _, err := os.Stat(*c.Keyfile); err != nil {
-			return errValidationNotFound("key-file", *c.Keyfile)
+	if c.Keyfile != "" {
+		if _, err := os.Stat(c.Keyfile); err != nil {
+			return errValidationNotFound("key-file", c.Keyfile)
 		}
 	}
 

--- a/pkg/dto/compare_test.go
+++ b/pkg/dto/compare_test.go
@@ -20,22 +20,22 @@ func TestBackupServiceConfig_Compare(t *testing.T) {
 			name: "identical configs",
 			current: ServiceConfig{
 				HTTPServer: &HTTPServerConfig{
-					Address: ptr.Of("localhost"),
+					Address: "localhost",
 					Port:    ptr.Of(Port(8080)),
 				},
 				Logger: &LoggerConfig{
-					Level:  ptr.Of("INFO"),
-					Format: ptr.Of("JSON"),
+					Level:  "INFO",
+					Format: "JSON",
 				},
 			},
 			other: ServiceConfig{
 				HTTPServer: &HTTPServerConfig{
-					Address: ptr.Of("localhost"),
+					Address: "localhost",
 					Port:    ptr.Of(Port(8080)),
 				},
 				Logger: &LoggerConfig{
-					Level:  ptr.Of("INFO"),
-					Format: ptr.Of("JSON"),
+					Level:  "INFO",
+					Format: "JSON",
 				},
 			},
 			errors: nil,
@@ -44,13 +44,13 @@ func TestBackupServiceConfig_Compare(t *testing.T) {
 			name: "changed http server config",
 			current: ServiceConfig{
 				HTTPServer: &HTTPServerConfig{
-					Address: ptr.Of("localhost"),
+					Address: "localhost",
 					Port:    ptr.Of(Port(8080)),
 				},
 			},
 			other: ServiceConfig{
 				HTTPServer: &HTTPServerConfig{
-					Address: ptr.Of("0.0.0.0"),
+					Address: "0.0.0.0",
 					Port:    ptr.Of(Port(9090)),
 				},
 			},
@@ -63,15 +63,15 @@ func TestBackupServiceConfig_Compare(t *testing.T) {
 			name: "changed logger config",
 			current: ServiceConfig{
 				Logger: &LoggerConfig{
-					Level:        ptr.Of("INFO"),
-					Format:       ptr.Of("JSON"),
+					Level:        "INFO",
+					Format:       "JSON",
 					StdoutWriter: ptr.Of(true),
 				},
 			},
 			other: ServiceConfig{
 				Logger: &LoggerConfig{
-					Level:        ptr.Of("DEBUG"),
-					Format:       ptr.Of("PLAIN"),
+					Level:        "DEBUG",
+					Format:       "PLAIN",
 					StdoutWriter: ptr.Of(false),
 				},
 			},
@@ -248,15 +248,15 @@ func TestHTTPServerConfig_Compare(t *testing.T) {
 		{
 			name: "identical configs",
 			current: &HTTPServerConfig{
-				Address:     ptr.Of("localhost"),
+				Address:     "localhost",
 				Port:        ptr.Of(Port(8080)),
-				ContextPath: ptr.Of("/api"),
+				ContextPath: "/api",
 				Timeout:     ptr.Of(int64(5000)),
 			},
 			other: &HTTPServerConfig{
-				Address:     ptr.Of("localhost"),
+				Address:     "localhost",
 				Port:        ptr.Of(Port(8080)),
-				ContextPath: ptr.Of("/api"),
+				ContextPath: "/api",
 				Timeout:     ptr.Of(int64(5000)),
 			},
 			errors: nil,
@@ -264,15 +264,15 @@ func TestHTTPServerConfig_Compare(t *testing.T) {
 		{
 			name: "all fields changed",
 			current: &HTTPServerConfig{
-				Address:     ptr.Of("localhost"),
+				Address:     "localhost",
 				Port:        ptr.Of(Port(8080)),
-				ContextPath: ptr.Of("/api"),
+				ContextPath: "/api",
 				Timeout:     ptr.Of(int64(5000)),
 			},
 			other: &HTTPServerConfig{
-				Address:     ptr.Of("0.0.0.0"),
+				Address:     "0.0.0.0",
 				Port:        ptr.Of(Port(9090)),
-				ContextPath: ptr.Of("/v1/api"),
+				ContextPath: "/v1/api",
 				Timeout:     ptr.Of(int64(10000)),
 			},
 			errors: []string{
@@ -315,8 +315,8 @@ func TestLoggerConfig_Compare(t *testing.T) {
 		{
 			name: "identical configs",
 			current: &LoggerConfig{
-				Level:        ptr.Of("INFO"),
-				Format:       ptr.Of("JSON"),
+				Level:        "INFO",
+				Format:       "JSON",
 				StdoutWriter: ptr.Of(true),
 				FileWriter: &FileLoggerConfig{
 					Filename: "app.log",
@@ -324,8 +324,8 @@ func TestLoggerConfig_Compare(t *testing.T) {
 				},
 			},
 			other: &LoggerConfig{
-				Level:        ptr.Of("INFO"),
-				Format:       ptr.Of("JSON"),
+				Level:        "INFO",
+				Format:       "JSON",
 				StdoutWriter: ptr.Of(true),
 				FileWriter: &FileLoggerConfig{
 					Filename: "app.log",
@@ -337,16 +337,16 @@ func TestLoggerConfig_Compare(t *testing.T) {
 		{
 			name: "all fields changed",
 			current: &LoggerConfig{
-				Level:        ptr.Of("INFO"),
-				Format:       ptr.Of("JSON"),
+				Level:        "INFO",
+				Format:       "JSON",
 				StdoutWriter: ptr.Of(true),
 				FileWriter: &FileLoggerConfig{
 					Filename: "app.log",
 				},
 			},
 			other: &LoggerConfig{
-				Level:        ptr.Of("DEBUG"),
-				Format:       ptr.Of("PLAIN"),
+				Level:        "DEBUG",
+				Format:       "PLAIN",
 				StdoutWriter: ptr.Of(false),
 				FileWriter: &FileLoggerConfig{
 					Filename: "new.log",

--- a/pkg/dto/compare_utils.go
+++ b/pkg/dto/compare_utils.go
@@ -43,7 +43,3 @@ func compareSlices[T comparable](fieldName string, oldSlice []T, newSlice []T) e
 
 	return err
 }
-
-func hasText(s *string) bool {
-	return s != nil && *s != ""
-}

--- a/pkg/dto/config_test.go
+++ b/pkg/dto/config_test.go
@@ -46,7 +46,7 @@ func validConfig() *Config {
 func NewLocalAerospikeCluster() *AerospikeCluster {
 	return &AerospikeCluster{
 		SeedNodes:   []SeedNode{{HostName: "localhost", Port: 3000}},
-		Credentials: &Credentials{User: ptr.Of("tester"), Password: ptr.Of("psw")},
+		Credentials: &Credentials{User: "tester", Password: "psw"},
 	}
 }
 

--- a/pkg/dto/config_test.go
+++ b/pkg/dto/config_test.go
@@ -111,10 +111,10 @@ func TestInvalidTlsFile(t *testing.T) {
 	cluster.SeedNodes[0].TLSName = "tls name"
 	cluster.TLS = &TLS{
 		ClientTLS: ClientTLS{
-			Name:     ptr.Of("tls name"),
-			Keyfile:  ptr.Of("path to key file"),
-			Certfile: ptr.Of("path to cert file"),
-			CAFile:   ptr.Of("path to ca file"),
+			Name:     "tls name",
+			Keyfile:  "path to key file",
+			Certfile: "path to cert file",
+			CAFile:   "path to ca file",
 		},
 	}
 

--- a/pkg/dto/convert_test.go
+++ b/pkg/dto/convert_test.go
@@ -57,16 +57,16 @@ var originalConfig = &Config{
 			S3Storage: &S3Storage{
 				Bucket:          "bucket",
 				S3Region:        "region",
-				AccessKeyID:     ptr.Of("id"),
-				SecretAccessKey: ptr.Of("key"),
+				AccessKeyID:     "id",
+				SecretAccessKey: "key",
 			},
 		},
 		"aws 1": { // secret agent by name
 			S3Storage: &S3Storage{
 				Bucket:            "bucket",
 				S3Region:          "region",
-				AccessKeyID:       ptr.Of("id"),
-				SecretAccessKey:   ptr.Of("key"),
+				AccessKeyID:       "id",
+				SecretAccessKey:   "key",
 				SecretAgentConfig: secretAgentConfig,
 			},
 		},
@@ -74,8 +74,8 @@ var originalConfig = &Config{
 			S3Storage: &S3Storage{
 				Bucket:          "bucket2",
 				S3Region:        "region2",
-				AccessKeyID:     ptr.Of("id2"),
-				SecretAccessKey: ptr.Of("key2"),
+				AccessKeyID:     "id2",
+				SecretAccessKey: "key2",
 				SecretAgentConfig: SecretAgentConfig{
 					SecretAgent: &SecretAgent{
 						Address:        "host3",

--- a/pkg/dto/convert_test.go
+++ b/pkg/dto/convert_test.go
@@ -16,10 +16,10 @@ var secretAgentConfig = SecretAgentConfig{
 var originalConfig = &Config{
 	ServiceConfig: ServiceConfig{
 		HTTPServer: &HTTPServerConfig{
-			Address: ptr.Of("localhost"),
+			Address: "localhost",
 		},
 		Logger: &LoggerConfig{
-			Level: ptr.Of("INFO"),
+			Level: "INFO",
 			FileWriter: &FileLoggerConfig{
 				Filename: "log",
 			},
@@ -48,7 +48,7 @@ var originalConfig = &Config{
 			},
 		},
 		"cluster3": {
-			ClusterLabel: ptr.Of("No credentials"),
+			ClusterLabel: "No credentials",
 			SeedNodes:    []SeedNode{{HostName: "host", Port: 80}},
 		},
 	},

--- a/pkg/dto/convert_test.go
+++ b/pkg/dto/convert_test.go
@@ -29,16 +29,16 @@ var originalConfig = &Config{
 		"cluster1": {
 			SeedNodes: []SeedNode{{HostName: "host", Port: 80}},
 			Credentials: &Credentials{
-				User:              ptr.Of("tester"),
-				Password:          ptr.Of("psw"),
+				User:              "tester",
+				Password:          "psw",
 				SecretAgentConfig: secretAgentConfig,
 			},
 		},
 		"cluster2": {
 			SeedNodes: []SeedNode{{HostName: "host", Port: 80}},
 			Credentials: &Credentials{
-				User:     ptr.Of("tester"),
-				Password: ptr.Of("psw"),
+				User:     "tester",
+				Password: "psw",
 				SecretAgentConfig: SecretAgentConfig{
 					SecretAgent: &SecretAgent{
 						Address:        "host2",

--- a/pkg/dto/encryption_policy.go
+++ b/pkg/dto/encryption_policy.go
@@ -17,11 +17,11 @@ type EncryptionPolicy struct {
 	// The encryption mode to be used (NONE, AES128, AES256)
 	Mode string `yaml:"mode,omitempty" json:"mode,omitempty" default:"NONE" enums:"NONE,AES128,AES256"`
 	// The path to the file containing the encryption key.
-	KeyFile *string `yaml:"key-file,omitempty" json:"key-file,omitempty" extensions:"x-nullable"`
+	KeyFile string `yaml:"key-file,omitempty" json:"key-file,omitempty" extensions:"x-nullable" masq:"secret"`
 	// The name of the environment variable containing the encryption key.
-	KeyEnv *string `yaml:"key-env,omitempty" json:"key-env,omitempty" extensions:"x-nullable"`
+	KeyEnv string `yaml:"key-env,omitempty" json:"key-env,omitempty" extensions:"x-nullable" masq:"secret"`
 	// The secret keyword in Aerospike Secret Agent containing the encryption key.
-	KeySecret *string `yaml:"key-secret,omitempty" json:"key-secret,omitempty" extensions:"x-nullable"`
+	KeySecret string `yaml:"key-secret,omitempty" json:"key-secret,omitempty" extensions:"x-nullable" masq:"secret"`
 }
 
 // Validate validates the encryption policy.
@@ -37,31 +37,31 @@ func (p *EncryptionPolicy) Validate() error {
 	}
 
 	if p.Mode == EncryptNone {
-		if p.KeyFile != nil {
+		if p.KeyFile != "" {
 			return errValidationMutuallyExclusive("key-file", "mode = NONE")
 		}
-		if p.KeyEnv != nil {
+		if p.KeyEnv != "" {
 			return errValidationMutuallyExclusive("key-env", "mode = NONE")
 		}
-		if p.KeySecret != nil {
+		if p.KeySecret != "" {
 			return errValidationMutuallyExclusive("key-secret", "mode = NONE")
 		}
 
 		return nil // no more validation for mode = NONE
 	}
 
-	if p.KeyFile == nil && p.KeyEnv == nil && p.KeySecret == nil {
+	if p.KeyFile == "" && p.KeyEnv == "" && p.KeySecret == "" {
 		return errValidationRequiredEither("key-file", "key-env", "key-secret")
 	}
 
 	// Only one parameter allowed to be set.
-	if p.KeyFile != nil && p.KeyEnv != nil {
+	if p.KeyFile != "" && p.KeyEnv != "" {
 		return errValidationMutuallyExclusive("key-file", "key-env")
 	}
-	if p.KeyFile != nil && p.KeySecret != nil {
+	if p.KeyFile != "" && p.KeySecret != "" {
 		return errValidationMutuallyExclusive("key-file", "key-secret")
 	}
-	if p.KeyEnv != nil && p.KeySecret != nil {
+	if p.KeyEnv != "" && p.KeySecret != "" {
 		return errValidationMutuallyExclusive("key-env", "key-secret")
 	}
 

--- a/pkg/dto/encryption_policy_test.go
+++ b/pkg/dto/encryption_policy_test.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"testing"
 
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,15 +13,15 @@ func TestEncryptionPolicy_Validate_Success(t *testing.T) {
 		},
 		"AES128 with key file": {
 			Mode:    EncryptAES128,
-			KeyFile: ptr.Of("path"),
+			KeyFile: "path",
 		},
 		"AES256 with key env": {
 			Mode:   EncryptAES256,
-			KeyEnv: ptr.Of("path"),
+			KeyEnv: "path",
 		},
 		"AES256 with key secret": {
 			Mode:      EncryptAES256,
-			KeySecret: ptr.Of("path"),
+			KeySecret: "path",
 		},
 	}
 
@@ -53,7 +52,7 @@ func TestEncryptionPolicy_Validate_Invalid(t *testing.T) {
 		"NONE with a key set": {
 			policy: EncryptionPolicy{
 				Mode:    EncryptNone,
-				KeyFile: ptr.Of("path"),
+				KeyFile: "path",
 			},
 			wantIsErr: errMutuallyExclusive,
 		},
@@ -64,17 +63,17 @@ func TestEncryptionPolicy_Validate_Invalid(t *testing.T) {
 		"AES256 with two keys set": {
 			policy: EncryptionPolicy{
 				Mode:      EncryptAES256,
-				KeyEnv:    ptr.Of("path"),
-				KeySecret: ptr.Of("path"),
+				KeyEnv:    "path",
+				KeySecret: "path",
 			},
 			wantIsErr: errMutuallyExclusive,
 		},
 		"AES256 with three keys set": {
 			policy: EncryptionPolicy{
 				Mode:      EncryptAES256,
-				KeyEnv:    ptr.Of("path"),
-				KeyFile:   ptr.Of("path"),
-				KeySecret: ptr.Of("path"),
+				KeyEnv:    "path",
+				KeyFile:   "path",
+				KeySecret: "path",
 			},
 			wantIsErr: errMutuallyExclusive,
 		},

--- a/pkg/dto/http_server_config.go
+++ b/pkg/dto/http_server_config.go
@@ -13,13 +13,13 @@ import (
 // @Description HTTPServerConfig represents the service's HTTP server configuration.
 type HTTPServerConfig struct {
 	// The address to listen on.
-	Address *string `yaml:"address,omitempty" json:"address,omitempty" default:"0.0.0.0" example:"0.0.0.0"`
+	Address string `yaml:"address,omitempty" json:"address,omitempty" default:"0.0.0.0" example:"0.0.0.0"`
 	// The port to listen on.
 	Port *Port `yaml:"port,omitempty" json:"port,omitempty" default:"8080" example:"8080"`
 	// HTTP rate limiter configuration.
 	Rate *RateLimiterConfig `yaml:"rate,omitempty" json:"rate,omitempty"`
 	// ContextPath customizes path for the API endpoints.
-	ContextPath *string `yaml:"context-path,omitempty" json:"context-path,omitempty" default:"/"`
+	ContextPath string `yaml:"context-path,omitempty" json:"context-path,omitempty" default:"/"`
 	// Timeout for http server operations in milliseconds.
 	Timeout *int64 `yaml:"timeout,omitempty" json:"timeout,omitempty" default:"5000"`
 }
@@ -30,8 +30,8 @@ func (s *HTTPServerConfig) Validate() error {
 		return nil
 	}
 
-	if s.ContextPath != nil && !strings.HasPrefix(*s.ContextPath, "/") {
-		return fmt.Errorf("context-path must start with a slash: %s", *s.ContextPath)
+	if s.ContextPath != "" && !strings.HasPrefix(s.ContextPath, "/") {
+		return fmt.Errorf("context-path must start with a slash: %s", s.ContextPath)
 	}
 	if s.Timeout != nil && *s.Timeout < 0 {
 		return errValidationNegative("timeout", *s.Timeout)
@@ -85,9 +85,9 @@ func (s *HTTPServerConfig) Compare(other *HTTPServerConfig) error {
 	}
 
 	var err = errors.Join(
-		comparePointers("Address", s.Address, other.Address),
+		compareValues("Address", s.Address, other.Address),
 		comparePointers("Port", s.Port, other.Port),
-		comparePointers("ContextPath", s.ContextPath, other.ContextPath),
+		compareValues("ContextPath", s.ContextPath, other.ContextPath),
 		comparePointers("Timeout", s.Timeout, other.Timeout),
 	)
 

--- a/pkg/dto/logger_config.go
+++ b/pkg/dto/logger_config.go
@@ -10,19 +10,18 @@ import (
 
 // LoggerConfig represents the backup service logger configuration.
 // @Description LoggerConfig represents the backup service logger configuration.
-//
-//nolint:lll
 type LoggerConfig struct {
 	// Level is the logger level.
-	Level *string `yaml:"level,omitempty" json:"level,omitempty" default:"INFO" enums:"TRACE,DEBUG,INFO,WARN,WARNING,ERROR"`
+	Level string `yaml:"level,omitempty" json:"level,omitempty" default:"INFO" enums:"TRACE,DEBUG,INFO,WARN,WARNING,ERROR"`
 	// Format is the logger format (PLAIN, JSON).
-	Format *string `yaml:"format,omitempty" json:"format,omitempty" default:"PLAIN" enums:"PLAIN,JSON"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" default:"PLAIN" enums:"PLAIN,JSON"`
 	// Whether to enable logging to the standard output.
 	StdoutWriter *bool `yaml:"stdout-writer,omitempty" json:"stdout-writer,omitempty" default:"true"`
 	// File writer logging configuration.
 	FileWriter *FileLoggerConfig `yaml:"file-writer,omitempty" json:"file-writer,omitempty" default:""`
 }
 
+//nolint:goconst
 var (
 	validLoggerLevels      = []string{"TRACE", "DEBUG", "INFO", "WARN", "WARNING", "ERROR"}
 	supportedLoggerFormats = []string{"PLAIN", "JSON"}
@@ -33,11 +32,11 @@ func (l *LoggerConfig) Validate() error {
 	if l == nil {
 		return nil
 	}
-	if l.Level != nil && !slices.Contains(validLoggerLevels, *l.Level) {
-		return fmt.Errorf("invalid logger level: %s", *l.Level)
+	if l.Level != "" && !slices.Contains(validLoggerLevels, l.Level) {
+		return fmt.Errorf("invalid logger level: %s", l.Level)
 	}
-	if l.Format != nil && !slices.Contains(supportedLoggerFormats, *l.Format) {
-		return fmt.Errorf("invalid logger format: %s", *l.Format)
+	if l.Format != "" && !slices.Contains(supportedLoggerFormats, l.Format) {
+		return fmt.Errorf("invalid logger format: %s", l.Format)
 	}
 	if err := l.FileWriter.Validate(); err != nil {
 		return err
@@ -82,8 +81,8 @@ func (l *LoggerConfig) Compare(other *LoggerConfig) error {
 	}
 
 	var err = errors.Join(
-		comparePointers("Level", l.Level, other.Level),
-		comparePointers("Format", l.Format, other.Format),
+		compareValues("Level", l.Level, other.Level),
+		compareValues("Format", l.Format, other.Format),
 		comparePointers("StdoutWriter", l.StdoutWriter, other.StdoutWriter),
 	)
 

--- a/pkg/dto/masking_test.go
+++ b/pkg/dto/masking_test.go
@@ -1,0 +1,75 @@
+package dto
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/m-mizutani/masq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// redactForJSON reuses masq's slog ReplaceAttr function to produce a redacted
+// deep copy of v that is safe to pass to json.Marshal, without depending on a
+// separate JSON-specific masking library.
+func redactForJSON(tag string, v any) any {
+	redact := masq.New(masq.WithTag(tag))
+	return redact(nil, slog.Any("v", v)).Value.Any()
+}
+
+func TestPasswordMasking(t *testing.T) {
+	creds := &Credentials{
+		User:     "testUser",
+		Password: "superSecretPassword",
+	}
+
+	t.Run("without masq", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&buf, nil))
+		logger.Info("cluster credentials", slog.Any("credentials", creds))
+
+		assert.Contains(t, buf.String(), "superSecretPassword")
+	})
+
+	t.Run("with masq", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+			ReplaceAttr: masq.New(masq.WithTag("secret")),
+		}))
+
+		logger.Info("cluster credentials", slog.Any("credentials", Config{
+			AerospikeClusters: map[string]*AerospikeCluster{
+				"cluster1": {
+					Credentials: creds,
+				},
+			},
+		}))
+
+		output := buf.String()
+		assert.Contains(t, output, `"user":"testUser"`)
+		assert.Contains(t, output, `"password":"`+masq.DefaultRedactMessage+`"`)
+		assert.NotContains(t, output, "superSecretPassword")
+	})
+
+	t.Run("redact for JSON response", func(t *testing.T) {
+		config := Config{
+			AerospikeClusters: map[string]*AerospikeCluster{
+				"cluster1": {
+					Credentials: creds,
+				},
+			},
+		}
+
+		redacted := redactForJSON("secret", &config)
+
+		data, err := json.Marshal(redacted)
+		require.NoError(t, err)
+
+		output := string(data)
+		assert.Contains(t, output, `"user":"testUser"`)
+		assert.Contains(t, output, `"password":"`+masq.DefaultRedactMessage+`"`)
+		assert.NotContains(t, output, "superSecretPassword")
+	})
+}

--- a/pkg/dto/restore_namespace.go
+++ b/pkg/dto/restore_namespace.go
@@ -12,18 +12,18 @@ import (
 type RestoreNamespace struct {
 	// Original namespace name.
 	// This field is required as a safeguard to ensure intentional namespace remapping.
-	Source *string `json:"source,omitempty" example:"source-ns" validate:"required"`
+	Source string `json:"source,omitempty" example:"source-ns" validate:"required"`
 	// Name of the destination namespace to restore data into.
-	Destination *string `json:"destination,omitempty" example:"destination-ns" validate:"required"`
+	Destination string `json:"destination,omitempty" example:"destination-ns" validate:"required"`
 }
 
 // Validate validates the restore namespace.
 func (n *RestoreNamespace) Validate() error {
-	if n.Source == nil || *n.Source == "" {
+	if n.Source == "" {
 		return errValidationEmptyField("source")
 	}
 
-	if n.Destination == nil || *n.Destination == "" {
+	if n.Destination == "" {
 		return errValidationEmptyField("destination")
 	}
 

--- a/pkg/dto/restore_request_test.go
+++ b/pkg/dto/restore_request_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -135,11 +134,11 @@ func TestDestinationClusterConfig_ToModel(t *testing.T) {
 			name: "convert from cluster config",
 			dstCluster: DestinationClusterConfig{
 				Cluster: &AerospikeCluster{
-					ClusterLabel: ptr.Of("new cluster"),
+					ClusterLabel: "new cluster",
 				},
 			},
 			want: &model.AerospikeCluster{
-				ClusterLabel: ptr.Of("new cluster"),
+				ClusterLabel: "new cluster",
 			},
 		},
 		{
@@ -442,7 +441,7 @@ func TestRestoreTimestampRequest_Validate(t *testing.T) {
 func TestRestoreRequest_ToModel(t *testing.T) {
 	config := model.NewConfig()
 	cluster := &model.AerospikeCluster{
-		ClusterLabel: ptr.Of("new cluster"),
+		ClusterLabel: "new cluster",
 	}
 	storage := &model.LocalStorage{Path: "test-path"}
 	secretAgent := &model.SecretAgent{
@@ -548,7 +547,7 @@ func TestRestoreTimestampRequest_ToModel(t *testing.T) {
 	config := model.NewConfig()
 	cluster := &model.AerospikeCluster{}
 	_ = config.AddCluster("test-cluster", cluster)
-	routineCluster := &model.AerospikeCluster{ClusterLabel: ptr.Of("routine-cluster")}
+	routineCluster := &model.AerospikeCluster{ClusterLabel: "routine-cluster"}
 	routineStorage := &model.LocalStorage{Path: "routine-path"}
 	routine := &model.BackupRoutine{
 		Name:          "daily",

--- a/pkg/dto/secret_agent_test.go
+++ b/pkg/dto/secret_agent_test.go
@@ -3,7 +3,6 @@ package dto
 import (
 	"testing"
 
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,7 +117,7 @@ func TestInvalidCertFile(t *testing.T) {
 		Address:        "localhost",
 		ConnectionType: "tcp",
 		ClientTLS: ClientTLS{
-			CAFile: ptr.Of("invalid-cert-file"),
+			CAFile: "invalid-cert-file",
 		},
 	}
 

--- a/pkg/dto/storage_azure.go
+++ b/pkg/dto/storage_azure.go
@@ -23,14 +23,14 @@ type AzureStorage struct {
 	AccountName string `yaml:"account-name,omitempty" json:"account-name,omitempty" extensions:"x-nullable"`
 	// AccountKey is the Azure storage account key for Shared Key authentication.
 	// This is sensitive information. Can be a path in secret agent or an actual value.
-	AccountKey string `yaml:"account-key,omitempty" json:"account-key,omitempty" extensions:"x-nullable"`
+	AccountKey string `yaml:"account-key,omitempty" json:"account-key,omitempty" extensions:"x-nullable" masq:"secret"`
 	// TenantID is the Azure Active Directory tenant ID for AAD authentication.
 	TenantID string `yaml:"tenant-id,omitempty" json:"tenant-id,omitempty" extensions:"x-nullable"`
 	// ClientID is the Azure Active Directory client ID for AAD authentication.
 	ClientID string `yaml:"client-id,omitempty" json:"client-id,omitempty" extensions:"x-nullable"`
 	// ClientSecret is the Azure Active Directory client secret for AAD authentication.
 	// This is sensitive information. Can be a path in secret agent or an actual value.
-	ClientSecret string `yaml:"client-secret,omitempty" json:"client-secret,omitempty" extensions:"x-nullable"`
+	ClientSecret string `yaml:"client-secret,omitempty" json:"client-secret,omitempty" extensions:"x-nullable" masq:"secret"` //nolint:lll
 	// The minimum size in bytes of individual Azure Blob chunks.
 	MinPartSize *int `yaml:"min-part-size,omitempty" json:"min-part-size,omitempty" default:"52428800" minimum:"1048576"`
 	// StorageClass defines the storage tier for data and metadata objects.

--- a/pkg/dto/storage_gcp.go
+++ b/pkg/dto/storage_gcp.go
@@ -16,7 +16,7 @@ type GcpStorage struct {
 	KeyFile string `yaml:"key-file-path,omitempty" json:"key-file-path,omitempty" extensions:"x-nullable"`
 	// Key is the service account key in JSON format.
 	// This is sensitive information. Can be a path in secret agent or an actual value.
-	Key string `yaml:"key,omitempty" json:"key,omitempty" extensions:"x-nullable"`
+	Key string `yaml:"key,omitempty" json:"key,omitempty" extensions:"x-nullable" masq:"secret"`
 	// GCP storage bucket name.
 	BucketName string `yaml:"bucket-name" json:"bucket-name" validate:"required"`
 	// The root path for the backup repository. If not specified, backups will be saved in the bucket's root.

--- a/pkg/dto/storage_s3.go
+++ b/pkg/dto/storage_s3.go
@@ -24,9 +24,9 @@ type S3Storage struct {
 	// The S3 profile name (AWS S3 optional).
 	S3Profile string `yaml:"s3-profile,omitempty" json:"s3-profile,omitempty" example:"default" extensions:"x-nullable"`
 	// An alternative endpoint for the S3 SDK to communicate (AWS S3 optional).
-	S3EndpointOverride *string `yaml:"s3-endpoint-override,omitempty" json:"s3-endpoint-override,omitempty" example:"http://host.docker.internal:9000" extensions:"x-nullable"`
+	S3EndpointOverride string `yaml:"s3-endpoint-override,omitempty" json:"s3-endpoint-override,omitempty" example:"http://host.docker.internal:9000" extensions:"x-nullable"`
 	// The log level of the AWS S3 SDK (AWS S3 optional).
-	S3LogLevel *string `yaml:"s3-log-level,omitempty" json:"s3-log-level,omitempty" default:"FATAL" enums:"OFF,FATAL,ERROR,WARN,INFO,DEBUG,TRACE"`
+	S3LogLevel string `yaml:"s3-log-level,omitempty" json:"s3-log-level,omitempty" default:"FATAL" enums:"OFF,FATAL,ERROR,WARN,INFO,DEBUG,TRACE"`
 	// The minimum size in bytes of individual S3 UploadParts.
 	MinPartSize *int `yaml:"min-part-size,omitempty" json:"min-part-size,omitempty" default:"52428800" extensions:"x-nullable" minimum:"5242880"`
 	// The maximum number of simultaneous requests from S3.

--- a/pkg/dto/storage_s3.go
+++ b/pkg/dto/storage_s3.go
@@ -33,10 +33,10 @@ type S3Storage struct {
 	MaxConnsPerHost *int `yaml:"max-async-connections,omitempty" json:"max-async-connections,omitempty" example:"16" extensions:"x-nullable"`
 	// Access Key ID for authentication with S3 StaticCredentialsProvider.
 	// This is sensitive information. Can be a path in secret agent or an actual value.
-	AccessKeyID *string `yaml:"access-key-id,omitempty" json:"access-key-id,omitempty" extensions:"x-nullable"`
+	AccessKeyID string `yaml:"access-key-id,omitempty" json:"access-key-id,omitempty" extensions:"x-nullable" masq:"secret"`
 	// Secret Access Key for authentication with S3 StaticCredentialsProvider.
 	// This is sensitive information. Can be a path in secret agent or an actual value.
-	SecretAccessKey *string `yaml:"secret-access-key,omitempty" json:"secret-access-key,omitempty" extensions:"x-nullable"`
+	SecretAccessKey string `yaml:"secret-access-key,omitempty" json:"secret-access-key,omitempty" extensions:"x-nullable" masq:"secret"`
 	// StorageClass defines the storage class for data and metadata objects.
 	StorageClass *S3StorageClass `yaml:"storage-class,omitempty" json:"storage-class,omitempty"`
 }
@@ -56,10 +56,10 @@ func (s *S3Storage) Validate(opts ...ValidationOption) error {
 		return err
 	}
 
-	if s.AccessKeyID != nil && s.SecretAccessKey == nil {
+	if s.AccessKeyID != "" && s.SecretAccessKey == "" {
 		return errors.New("access-key-id is set but secret-access-key is missing")
 	}
-	if s.AccessKeyID == nil && s.SecretAccessKey != nil {
+	if s.AccessKeyID == "" && s.SecretAccessKey != "" {
 		return errors.New("secret-access-key is set but access-key-id is missing")
 	}
 	if s.MinPartSize != nil && *s.MinPartSize < s3MinUploadPartSize {
@@ -77,7 +77,7 @@ func (s *S3Storage) Validate(opts ...ValidationOption) error {
 
 func (s *S3Storage) toModel(config *model.Config) (*model.S3Storage, error) {
 	var auth *model.S3Authentication
-	if s.AccessKeyID != nil {
+	if s.AccessKeyID != "" {
 		//nolint:staticcheck // We want to call embedded methods with embedded struct name.
 		agent, err := s.SecretAgentConfig.ToModel(config)
 		if err != nil {
@@ -85,8 +85,8 @@ func (s *S3Storage) toModel(config *model.Config) (*model.S3Storage, error) {
 		}
 
 		auth = &model.S3Authentication{
-			KeyIDSecret:     *s.AccessKeyID,
-			AccessKeySecret: *s.SecretAccessKey,
+			KeyIDSecret:     s.AccessKeyID,
+			AccessKeySecret: s.SecretAccessKey,
 			SecretAgent:     agent,
 		}
 	}
@@ -119,8 +119,8 @@ func newS3StorageFromModel(s *model.S3Storage, config *model.BackupConfig) *S3St
 	}
 	if s.Auth != nil {
 		result.SecretAgentConfig = ResolveSecretAgentFromModel(s.Auth.SecretAgent, config)
-		result.AccessKeyID = &s.Auth.KeyIDSecret
-		result.SecretAccessKey = &s.Auth.AccessKeySecret
+		result.AccessKeyID = s.Auth.KeyIDSecret
+		result.SecretAccessKey = s.Auth.AccessKeySecret
 	}
 
 	return result

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -15,11 +15,11 @@ import (
 type TLS struct {
 	ClientTLS `yaml:",inline"`
 	// Path to a directory of trusted CA certificates.
-	CAPath *string `yaml:"ca-path,omitempty" json:"ca-path,omitempty" example:"/path/to/ca" extensions:"x-nullable"`
+	CAPath string `yaml:"ca-path,omitempty" json:"ca-path,omitempty" example:"/path/to/ca" extensions:"x-nullable"`
 	// TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.
-	Protocols *string `yaml:"protocols,omitempty" json:"protocols,omitempty" default:"TLSv1.2"`
+	Protocols string `yaml:"protocols,omitempty" json:"protocols,omitempty" default:"TLSv1.2"`
 	// TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format.
-	CipherSuite *string `yaml:"cipher-suite,omitempty" json:"cipher-suite,omitempty" example:"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" extensions:"x-nullable"`
+	CipherSuite string `yaml:"cipher-suite,omitempty" json:"cipher-suite,omitempty" example:"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" extensions:"x-nullable"`
 
 	// Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).
 	KeyfilePassword string `yaml:"key-file-password,omitempty" json:"key-file-password,omitempty" example:"file:/path/to/password" extensions:"x-nullable" masq:"secret"`
@@ -47,7 +47,7 @@ func (t *TLS) Validate(opts ...ValidationOption) error {
 
 // validateCACertificates ensures CA file and path are mutually exclusive.
 func (t *TLS) validateCACertificates() error {
-	if hasText(t.CAFile) && hasText(t.CAPath) {
+	if t.CAFile != "" && t.CAPath != "" {
 		return errValidationMutuallyExclusive("ca-file", "ca-path")
 	}
 
@@ -56,7 +56,7 @@ func (t *TLS) validateCACertificates() error {
 
 // validateKeyfilePassword ensures keyfile password is only set when keyfile is present.
 func (t *TLS) validateKeyfilePassword() error {
-	if t.KeyfilePassword != "" && !hasText(t.Keyfile) {
+	if t.KeyfilePassword != "" && (t.Keyfile == "") {
 		return errValidationRequires("key-file-password", "key-file")
 	}
 

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -22,7 +22,7 @@ type TLS struct {
 	CipherSuite *string `yaml:"cipher-suite,omitempty" json:"cipher-suite,omitempty" example:"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" extensions:"x-nullable"`
 
 	// Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).
-	KeyfilePassword *string `yaml:"key-file-password,omitempty" json:"key-file-password,omitempty" example:"file:/path/to/password" extensions:"x-nullable"`
+	KeyfilePassword string `yaml:"key-file-password,omitempty" json:"key-file-password,omitempty" example:"file:/path/to/password" extensions:"x-nullable" masq:"secret"`
 }
 
 func (t *TLS) Validate(opts ...ValidationOption) error {
@@ -56,7 +56,7 @@ func (t *TLS) validateCACertificates() error {
 
 // validateKeyfilePassword ensures keyfile password is only set when keyfile is present.
 func (t *TLS) validateKeyfilePassword() error {
-	if hasText(t.KeyfilePassword) && !hasText(t.Keyfile) {
+	if t.KeyfilePassword != "" && !hasText(t.Keyfile) {
 		return errValidationRequires("key-file-password", "key-file")
 	}
 

--- a/pkg/dto/tls_test.go
+++ b/pkg/dto/tls_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -143,7 +142,7 @@ func TestTLS_Validate(t *testing.T) {
 			name: "valid TLS with CAFile only",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile: &certs.caFile,
+					CAFile: certs.caFile,
 				},
 			},
 			wantErr: false,
@@ -151,7 +150,7 @@ func TestTLS_Validate(t *testing.T) {
 		{
 			name: "valid TLS with CAPath only",
 			tls: &TLS{
-				CAPath: &certs.caDir,
+				CAPath: certs.caDir,
 			},
 			wantErr: false,
 		},
@@ -159,9 +158,9 @@ func TestTLS_Validate(t *testing.T) {
 			name: "CAFile and CAPath are mutually exclusive",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile: &certs.caFile,
+					CAFile: certs.caFile,
 				},
-				CAPath: &certs.caDir,
+				CAPath: certs.caDir,
 			},
 			wantErr: true,
 			errType: errMutuallyExclusive,
@@ -170,9 +169,9 @@ func TestTLS_Validate(t *testing.T) {
 			name: "valid complete mTLS configuration",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name:     ptr.Of("tls-name"),
-					Keyfile:  &certs.keyFile,
-					Certfile: &certs.certFile,
+					Name:     "tls-name",
+					Keyfile:  certs.keyFile,
+					Certfile: certs.certFile,
 				},
 			},
 			wantErr: false,
@@ -181,10 +180,10 @@ func TestTLS_Validate(t *testing.T) {
 			name: "valid mTLS with CA and password",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile:   &certs.caFile,
-					Name:     ptr.Of("tls-name"),
-					Keyfile:  &certs.keyFile,
-					Certfile: &certs.certFile,
+					CAFile:   certs.caFile,
+					Name:     "tls-name",
+					Keyfile:  certs.keyFile,
+					Certfile: certs.certFile,
 				},
 				KeyfilePassword: "", // Empty password for unencrypted key
 			},
@@ -194,8 +193,8 @@ func TestTLS_Validate(t *testing.T) {
 			name: "mTLS missing name",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Keyfile:  &certs.keyFile,
-					Certfile: &certs.certFile,
+					Keyfile:  certs.keyFile,
+					Certfile: certs.certFile,
 				},
 			},
 			wantErr: true,
@@ -205,8 +204,8 @@ func TestTLS_Validate(t *testing.T) {
 			name: "mTLS missing keyfile",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name:     ptr.Of("tls-name"),
-					Certfile: &certs.certFile,
+					Name:     "tls-name",
+					Certfile: certs.certFile,
 				},
 			},
 			wantErr: true,
@@ -216,8 +215,8 @@ func TestTLS_Validate(t *testing.T) {
 			name: "mTLS missing certfile",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name:    ptr.Of("tls-name"),
-					Keyfile: &certs.keyFile,
+					Name:    "tls-name",
+					Keyfile: certs.keyFile,
 				},
 			},
 			wantErr: true,
@@ -235,7 +234,7 @@ func TestTLS_Validate(t *testing.T) {
 			name: "only name set should fail",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name: ptr.Of("tls-name"),
+					Name: "tls-name",
 				},
 			},
 			wantErr: true,
@@ -245,7 +244,7 @@ func TestTLS_Validate(t *testing.T) {
 			name: "only keyfile set should fail",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Keyfile: &certs.keyFile,
+					Keyfile: certs.keyFile,
 				},
 			},
 			wantErr: true,
@@ -255,7 +254,7 @@ func TestTLS_Validate(t *testing.T) {
 			name: "only certfile set should fail",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Certfile: &certs.certFile,
+					Certfile: certs.certFile,
 				},
 			},
 			wantErr: true,
@@ -264,8 +263,8 @@ func TestTLS_Validate(t *testing.T) {
 		{
 			name: "valid TLS with protocols and cipher suite",
 			tls: &TLS{
-				Protocols:   ptr.Of("TLSv1.2"),
-				CipherSuite: ptr.Of("TLS_AES_128_GCM_SHA256"),
+				Protocols:   "TLSv1.2",
+				CipherSuite: "TLS_AES_128_GCM_SHA256",
 			},
 			wantErr: false,
 		},
@@ -273,13 +272,13 @@ func TestTLS_Validate(t *testing.T) {
 			name: "complex valid configuration",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile:   &certs.caFile,
-					Name:     ptr.Of("tls-name"),
-					Keyfile:  &certs.keyFile,
-					Certfile: &certs.certFile,
+					CAFile:   certs.caFile,
+					Name:     "tls-name",
+					Keyfile:  certs.keyFile,
+					Certfile: certs.certFile,
 				},
-				Protocols:   ptr.Of("TLSv1.2"),
-				CipherSuite: ptr.Of("TLS_AES_128_GCM_SHA256"),
+				Protocols:   "TLSv1.2",
+				CipherSuite: "TLS_AES_128_GCM_SHA256",
 			},
 			wantErr: false,
 		},
@@ -287,7 +286,7 @@ func TestTLS_Validate(t *testing.T) {
 			name: "invalid CA file path",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile: ptr.Of("/nonexistent/path/ca.pem"),
+					CAFile: "/nonexistent/path/ca.pem",
 				},
 			},
 			wantErr: true,
@@ -296,9 +295,9 @@ func TestTLS_Validate(t *testing.T) {
 			name: "invalid key file path",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name:     ptr.Of("tls-name"),
-					Keyfile:  ptr.Of("/nonexistent/path/key.pem"),
-					Certfile: &certs.certFile,
+					Name:     "tls-name",
+					Keyfile:  "/nonexistent/path/key.pem",
+					Certfile: certs.certFile,
 				},
 			},
 			wantErr: true,
@@ -307,9 +306,9 @@ func TestTLS_Validate(t *testing.T) {
 			name: "invalid cert file path",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					Name:     ptr.Of("tls-name"),
-					Keyfile:  &certs.keyFile,
-					Certfile: ptr.Of("/nonexistent/path/cert.pem"),
+					Name:     "tls-name",
+					Keyfile:  certs.keyFile,
+					Certfile: "/nonexistent/path/cert.pem",
 				},
 			},
 			wantErr: true,
@@ -350,7 +349,7 @@ func TestTLS_validateCACertificates(t *testing.T) {
 			name: "only CAFile",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile: &certs.caFile,
+					CAFile: certs.caFile,
 				},
 			},
 			wantErr: false,
@@ -358,7 +357,7 @@ func TestTLS_validateCACertificates(t *testing.T) {
 		{
 			name: "only CAPath",
 			tls: &TLS{
-				CAPath: &certs.caDir,
+				CAPath: certs.caDir,
 			},
 			wantErr: false,
 		},
@@ -366,9 +365,9 @@ func TestTLS_validateCACertificates(t *testing.T) {
 			name: "both CAFile and CAPath",
 			tls: &TLS{
 				ClientTLS: ClientTLS{
-					CAFile: &certs.caFile,
+					CAFile: certs.caFile,
 				},
-				CAPath: &certs.caDir,
+				CAPath: certs.caDir,
 			},
 			wantErr: true,
 		},

--- a/pkg/dto/tls_test.go
+++ b/pkg/dto/tls_test.go
@@ -186,7 +186,7 @@ func TestTLS_Validate(t *testing.T) {
 					Keyfile:  &certs.keyFile,
 					Certfile: &certs.certFile,
 				},
-				KeyfilePassword: ptr.Of(""), // Empty password for unencrypted key
+				KeyfilePassword: "", // Empty password for unencrypted key
 			},
 			wantErr: false,
 		},
@@ -226,7 +226,7 @@ func TestTLS_Validate(t *testing.T) {
 		{
 			name: "keyfile password without keyfile",
 			tls: &TLS{
-				KeyfilePassword: ptr.Of("password"),
+				KeyfilePassword: "password",
 			},
 			wantErr: true,
 			errType: errMissingDependency,

--- a/pkg/model/aerospike_cluster.go
+++ b/pkg/model/aerospike_cluster.go
@@ -1,13 +1,9 @@
 package model
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
-
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 )
 
 // AerospikeCluster represents the configuration for an Aerospike cluster for backup.
@@ -48,53 +44,28 @@ func (c *AerospikeCluster) GetPassword() string {
 	return c.Credentials.Password
 }
 
-// Hash returns a unique string identifier for the AerospikeCluster.
-func (c *AerospikeCluster) Hash() string {
-	nodeStrings := make([]string, len(c.SeedNodes))
-	for i, node := range c.SeedNodes {
-		nodeStrings[i] = node.String()
-	}
-	sort.Strings(nodeStrings)
-
-	// Build a slice of all fields to be hashed.
-	hashData := []any{
-		c.ClusterLabel,
-		nodeStrings,
-		ptr.ValueOrZero(c.ConnTimeout).String(),
-		ptr.ValueOrZero(c.UseServicesAlternate),
-		c.Credentials.String(),
-		c.TLS.String(),
-		ptr.ValueOrZero(c.MaxParallelScans),
-		c.PreferRacks,
-	}
-
-	hasher := sha256.New()
-	_, _ = fmt.Fprintf(hasher, "%v", hashData)
-
-	return hex.EncodeToString(hasher.Sum(nil))
-}
-
-// ToString returns a user-friendly cluster identifier.
-// It prefers ClusterLabel; if missing, it uses a stable first seed node string.
-func (c *AerospikeCluster) ToString() string {
+// Hash returns a unique identifier for the AerospikeCluster.
+func (c *AerospikeCluster) Hash() uint64 {
 	if c == nil {
-		return ""
+		return 0
 	}
 
-	if label := c.ClusterLabel; label != "" {
-		return label
+	nodeHashes := make([]uint64, len(c.SeedNodes))
+	for i, node := range c.SeedNodes {
+		nodeHashes[i] = node.Hash()
 	}
+	slices.Sort(nodeHashes)
 
-	if len(c.SeedNodes) > 0 {
-		nodeStrings := make([]string, len(c.SeedNodes))
-		for i, node := range c.SeedNodes {
-			nodeStrings[i] = node.String()
-		}
-		sort.Strings(nodeStrings)
-		return nodeStrings[0]
-	}
-
-	return ""
+	return hashValues(
+		c.ClusterLabel,
+		nodeHashes,
+		c.ConnTimeout,
+		c.UseServicesAlternate,
+		c.Credentials.Hash(),
+		c.TLS.Hash(),
+		c.MaxParallelScans,
+		c.PreferRacks,
+	)
 }
 
 // Credentials represents authentication details to the Aerospike cluster.
@@ -121,17 +92,19 @@ func (c *Credentials) AuthModeOrDefault() AuthMode {
 	return *c.AuthMode
 }
 
-// String returns a string representation of the Credentials.
-func (c *Credentials) String() string {
+// Hash returns a unique identifier for the Credentials.
+func (c *Credentials) Hash() uint64 {
 	if c == nil {
-		return ""
+		return 0
 	}
-	return fmt.Sprintf("%v:%v:%v:%v:%v",
+
+	return hashValues(
 		c.User,
 		c.Password,
 		c.PasswordPath,
-		c.AuthModeOrDefault(),
-		c.SecretAgent.String())
+		c.AuthMode,
+		c.SecretAgent.Hash(),
+	)
 }
 
 // SeedNode represents details of a node in the Aerospike cluster.
@@ -142,6 +115,11 @@ type SeedNode struct {
 	Port Port
 	// TLS certificate name used for secure connections (if enabled).
 	TLSName string
+}
+
+// Hash returns a unique identifier for the SeedNode.
+func (s SeedNode) Hash() uint64 {
+	return hashValues(s.HostName, s.TLSName, s.Port)
 }
 
 // String returns a string representation of the SeedNode.

--- a/pkg/model/aerospike_cluster.go
+++ b/pkg/model/aerospike_cluster.go
@@ -13,7 +13,7 @@ import (
 // AerospikeCluster represents the configuration for an Aerospike cluster for backup.
 type AerospikeCluster struct {
 	// The cluster name.
-	ClusterLabel *string
+	ClusterLabel string
 	// The seed nodes details.
 	SeedNodes []SeedNode
 	// The connection timeout.
@@ -58,7 +58,7 @@ func (c *AerospikeCluster) Hash() string {
 
 	// Build a slice of all fields to be hashed.
 	hashData := []any{
-		ptr.ValueOrZero(c.ClusterLabel),
+		c.ClusterLabel,
 		nodeStrings,
 		ptr.ValueOrZero(c.ConnTimeout).String(),
 		ptr.ValueOrZero(c.UseServicesAlternate),
@@ -81,7 +81,7 @@ func (c *AerospikeCluster) ToString() string {
 		return ""
 	}
 
-	if label := ptr.ValueOrZero(c.ClusterLabel); label != "" {
+	if label := c.ClusterLabel; label != "" {
 		return label
 	}
 

--- a/pkg/model/aerospike_cluster.go
+++ b/pkg/model/aerospike_cluster.go
@@ -31,19 +31,19 @@ type AerospikeCluster struct {
 }
 
 // GetUser safely returns the username.
-func (c *AerospikeCluster) GetUser() *string {
+func (c *AerospikeCluster) GetUser() string {
 	if c.Credentials != nil {
 		return c.Credentials.User
 	}
-	return nil
+	return ""
 }
 
 // GetPassword returns the configured password.
 // Note: This returns the raw password configuration. If using Secret Agent or file path,
 // this needs to be resolved by the service layer.
-func (c *AerospikeCluster) GetPassword() *string {
+func (c *AerospikeCluster) GetPassword() string {
 	if c.Credentials == nil {
-		return nil
+		return ""
 	}
 	return c.Credentials.Password
 }
@@ -100,12 +100,12 @@ func (c *AerospikeCluster) ToString() string {
 // Credentials represents authentication details to the Aerospike cluster.
 type Credentials struct {
 	// The username for the cluster authentication.
-	User *string
+	User string
 	// The password for the cluster authentication.
 	// It can be either plain text or path into the secret agent.
-	Password *string
+	Password string
 	// The file path with the password string, will take precedence over the password field.
-	PasswordPath *string
+	PasswordPath string
 	// The authentication mode (INTERNAL, EXTERNAL, PKI). Nil means unset.
 	AuthMode *AuthMode
 	// The name of the configured Secret Agent to use for authentication.
@@ -127,9 +127,9 @@ func (c *Credentials) String() string {
 		return ""
 	}
 	return fmt.Sprintf("%v:%v:%v:%v:%v",
-		ptr.ValueOrZero(c.User),
-		ptr.ValueOrZero(c.Password),
-		ptr.ValueOrZero(c.PasswordPath),
+		c.User,
+		c.Password,
+		c.PasswordPath,
 		c.AuthModeOrDefault(),
 		c.SecretAgent.String())
 }

--- a/pkg/model/aerospike_cluster_hash_test.go
+++ b/pkg/model/aerospike_cluster_hash_test.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAerospikeCluster_Hash(t *testing.T) {
+	t.Parallel()
+
+	base := &AerospikeCluster{
+		ClusterLabel: "cluster-a",
+		SeedNodes: []SeedNode{
+			{HostName: "host-b", Port: 3000},
+			{HostName: "host-a", Port: 3000},
+		},
+		ConnTimeout:          ptr.Of(5 * time.Second),
+		UseServicesAlternate: ptr.Of(true),
+		Credentials: &Credentials{
+			User:     "user",
+			Password: "password",
+		},
+		TLS: &TLS{
+			CAPath:          "/etc/certs",
+			KeyfilePassword: "tls-password",
+		},
+		MaxParallelScans: ptr.Of(10),
+		PreferRacks:      []int{1, 2},
+	}
+
+	t.Run("stable for identical config", func(t *testing.T) {
+		t.Parallel()
+
+		other := *base
+		other.SeedNodes = []SeedNode{
+			{HostName: "host-a", Port: 3000},
+			{HostName: "host-b", Port: 3000},
+		}
+
+		require.Equal(t, base.Hash(), other.Hash())
+	})
+
+	t.Run("different password produces different hash", func(t *testing.T) {
+		t.Parallel()
+
+		other := *base
+		other.Credentials = &Credentials{
+			User:     base.Credentials.User,
+			Password: "other-password",
+		}
+
+		require.NotEqual(t, base.Hash(), other.Hash())
+	})
+
+	t.Run("nil cluster", func(t *testing.T) {
+		t.Parallel()
+
+		var cluster *AerospikeCluster
+		require.Zero(t, cluster.Hash())
+	})
+}
+
+func TestCredentials_Hash(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil credentials", func(t *testing.T) {
+		t.Parallel()
+
+		var creds *Credentials
+		require.Zero(t, creds.Hash())
+	})
+
+	t.Run("nil auth mode differs from explicit", func(t *testing.T) {
+		t.Parallel()
+
+		withDefault := (&Credentials{User: "user"}).Hash()
+		withInternal := (&Credentials{User: "user", AuthMode: ptr.Of(AuthModeInternal)}).Hash()
+
+		require.NotEqual(t, withDefault, withInternal)
+	})
+}

--- a/pkg/model/auth_mode.go
+++ b/pkg/model/auth_mode.go
@@ -19,25 +19,23 @@ const (
 	AuthModePKI AuthMode = "PKI"
 )
 
-// String returns a string representation of AuthMode. A nil receiver yields nil.
-func (m *AuthMode) String() *string {
+// String returns a string representation of AuthMode. A nil receiver yields empty string.
+func (m *AuthMode) String() string {
 	if m == nil {
-		return nil
+		return ""
 	}
 
-	s := string(*m)
-
-	return &s
+	return string(*m)
 }
 
 // ParseAuthMode parses a configured auth-mode value.
-// A nil value is valid and yields a nil auth mode.
-func ParseAuthMode(value *string) (*AuthMode, error) {
-	if value == nil {
+// An empty value is valid and yields a nil auth mode.
+func ParseAuthMode(value string) (*AuthMode, error) {
+	if value == "" {
 		return nil, nil
 	}
 
-	switch strings.ToUpper(strings.TrimSpace(*value)) {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
 	case string(AuthModeInternal):
 		return ptr.Of(AuthModeInternal), nil
 	case string(AuthModeExternal):
@@ -47,7 +45,7 @@ func ParseAuthMode(value *string) (*AuthMode, error) {
 	default:
 		return nil, fmt.Errorf(
 			"auth-mode %q incorrect, should be one of: %s,%s,%s",
-			*value,
+			value,
 			AuthModeInternal,
 			AuthModeExternal,
 			AuthModePKI,

--- a/pkg/model/auth_mode_test.go
+++ b/pkg/model/auth_mode_test.go
@@ -21,23 +21,23 @@ func TestCredentialsAuthModeOrDefault(t *testing.T) {
 
 func TestAuthModeString(t *testing.T) {
 	var unset *AuthMode
-	assert.Nil(t, unset.String())
-	assert.Equal(t, ptr.Of("PKI"), ptr.Of(AuthModePKI).String())
+	assert.Empty(t, unset.String())
+	assert.Equal(t, "PKI", ptr.Of(AuthModePKI).String())
 }
 
 func TestParseAuthMode(t *testing.T) {
 	tests := []struct {
 		name        string
-		value       *string
+		value       string
 		expected    *AuthMode
 		expectError bool
 	}{
-		{name: "nil", value: nil, expected: nil},
-		{name: "internal", value: ptr.Of("INTERNAL"), expected: ptr.Of(AuthModeInternal)},
-		{name: "internal lowercase", value: ptr.Of("internal"), expected: ptr.Of(AuthModeInternal)},
-		{name: "external", value: ptr.Of("EXTERNAL"), expected: ptr.Of(AuthModeExternal)},
-		{name: "pki", value: ptr.Of("PKI"), expected: ptr.Of(AuthModePKI)},
-		{name: "invalid", value: ptr.Of("LDAP"), expectError: true},
+		{name: "empty", value: "", expected: nil},
+		{name: "internal", value: "INTERNAL", expected: ptr.Of(AuthModeInternal)},
+		{name: "internal lowercase", value: "internal", expected: ptr.Of(AuthModeInternal)},
+		{name: "external", value: "EXTERNAL", expected: ptr.Of(AuthModeExternal)},
+		{name: "pki", value: "PKI", expected: ptr.Of(AuthModePKI)},
+		{name: "invalid", value: "LDAP", expectError: true},
 	}
 
 	for _, test := range tests {

--- a/pkg/model/client_tls.go
+++ b/pkg/model/client_tls.go
@@ -1,7 +1,5 @@
 package model
 
-import "fmt"
-
 // ClientTLS represents the TLS configuration options relevant for client-side connections.
 type ClientTLS struct {
 	// Path to a trusted CA certificate file in PEM format.
@@ -14,16 +12,7 @@ type ClientTLS struct {
 	Keyfile string
 }
 
-// String returns a string representation of the ClientTLS.
-func (c *ClientTLS) String() string {
-	if c == nil {
-		return ""
-	}
-	return fmt.Sprintf(
-		"%s:%s:%s:%s",
-		c.CAFile,
-		c.Name,
-		c.Certfile,
-		c.Keyfile,
-	)
+// Hash returns a unique identifier for the ClientTLS configuration.
+func (c ClientTLS) Hash() uint64 {
+	return hashValues(c.CAFile, c.Name, c.Certfile, c.Keyfile)
 }

--- a/pkg/model/client_tls.go
+++ b/pkg/model/client_tls.go
@@ -1,21 +1,17 @@
 package model
 
-import (
-	"fmt"
-
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
-)
+import "fmt"
 
 // ClientTLS represents the TLS configuration options relevant for client-side connections.
 type ClientTLS struct {
 	// Path to a trusted CA certificate file in PEM format.
-	CAFile *string
+	CAFile string
 	// TLSName used for server certificate verification (ServerName for SNI).
-	Name *string
+	Name string
 	// Path to a client certificate file for mutual TLS authentication.
-	Certfile *string
+	Certfile string
 	// Path to a client private key file for mutual TLS authentication.
-	Keyfile *string
+	Keyfile string
 }
 
 // String returns a string representation of the ClientTLS.
@@ -24,10 +20,10 @@ func (c *ClientTLS) String() string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"%v:%v:%v:%v",
-		ptr.ValueOrZero(c.CAFile),
-		ptr.ValueOrZero(c.Name),
-		ptr.ValueOrZero(c.Certfile),
-		ptr.ValueOrZero(c.Keyfile),
+		"%s:%s:%s:%s",
+		c.CAFile,
+		c.Name,
+		c.Certfile,
+		c.Keyfile,
 	)
 }

--- a/pkg/model/config_default.go
+++ b/pkg/model/config_default.go
@@ -23,19 +23,19 @@ var defaultConfig = struct {
 	credentials   Credentials
 }{
 	http: HTTPServerConfig{
-		Address: ptr.Of("0.0.0.0"),
+		Address: "0.0.0.0",
 		Port:    NewPort(8080),
 		Rate: &RateLimiterConfig{
 			Tps:       ptr.Of(1024),
 			Size:      ptr.Of(1024),
 			WhiteList: []string{},
 		},
-		ContextPath: ptr.Of("/"),
+		ContextPath: "/",
 		Timeout:     ptr.Of(5 * time.Second),
 	},
 	logger: LoggerConfig{
-		Level:        ptr.Of("INFO"),
-		Format:       ptr.Of("PLAIN"),
+		Level:        "INFO",
+		Format:       "PLAIN",
 		StdoutWriter: ptr.Of(true),
 		FileWriter: &FileLoggerConfig{
 			MaxSize:    100,

--- a/pkg/model/encryption_policy.go
+++ b/pkg/model/encryption_policy.go
@@ -5,9 +5,9 @@ type EncryptionPolicy struct {
 	// The encryption mode to be used (NONE, AES128, AES256)
 	Mode string
 	// The path to the file containing the encryption key.
-	KeyFile *string
+	KeyFile string
 	// The name of the environment variable containing the encryption key.
-	KeyEnv *string
+	KeyEnv string
 	// The secret keyword in Aerospike Secret Agent containing the encryption key.
-	KeySecret *string
+	KeySecret string
 }

--- a/pkg/model/hash.go
+++ b/pkg/model/hash.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"fmt"
+	"hash/fnv"
+)
+
+func hashValues(values ...any) uint64 {
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%v", values)
+
+	return h.Sum64()
+}

--- a/pkg/model/http_server_config.go
+++ b/pkg/model/http_server_config.go
@@ -5,13 +5,13 @@ import "time"
 // HTTPServerConfig represents the service's HTTP server configuration.
 type HTTPServerConfig struct {
 	// The address to listen on.
-	Address *string
+	Address string
 	// The port to listen on.
 	Port *Port
 	// HTTP rate limiter configuration.
 	Rate *RateLimiterConfig
 	// ContextPath customizes path for the API endpoints.
-	ContextPath *string
+	ContextPath string
 	// Timeout for http server operations.
 	Timeout *time.Duration
 }
@@ -19,10 +19,10 @@ type HTTPServerConfig struct {
 // GetAddressOrDefault returns the value of the Address property.
 // If the property is not set, it returns the default value.
 func (s *HTTPServerConfig) GetAddressOrDefault() string {
-	if s.Address != nil {
-		return *s.Address
+	if s.Address != "" {
+		return s.Address
 	}
-	return *defaultConfig.http.Address
+	return defaultConfig.http.Address
 }
 
 // GetPortOrDefault returns the value of the Port property.
@@ -55,10 +55,10 @@ func (s *HTTPServerConfig) GetRateOrDefault() *RateLimiterConfig {
 // GetContextPathOrDefault returns the value of the ContextPath property.
 // If the property is not set, it returns the default value.
 func (s *HTTPServerConfig) GetContextPathOrDefault() string {
-	if s.ContextPath != nil {
-		return *s.ContextPath
+	if s.ContextPath != "" {
+		return s.ContextPath
 	}
-	return *defaultConfig.http.ContextPath
+	return defaultConfig.http.ContextPath
 }
 
 // RateLimiterConfig represents the service's HTTP server rate limiter configuration.

--- a/pkg/model/logger_config.go
+++ b/pkg/model/logger_config.go
@@ -3,9 +3,9 @@ package model
 // LoggerConfig represents the backup service logger configuration.
 type LoggerConfig struct {
 	// Level is the logger level.
-	Level *string
+	Level string
 	// Format is the logger format (PLAIN, JSON).
-	Format *string
+	Format string
 	// Whether to enable logging to the standard output.
 	StdoutWriter *bool
 	// File writer logging configuration.
@@ -15,19 +15,19 @@ type LoggerConfig struct {
 // GetLevelOrDefault returns the value of the Level property.
 // If the property is not set, it returns the default value.
 func (l *LoggerConfig) GetLevelOrDefault() string {
-	if l.Level != nil {
-		return *l.Level
+	if l.Level != "" {
+		return l.Level
 	}
-	return *defaultConfig.logger.Level
+	return defaultConfig.logger.Level
 }
 
 // GetFormatOrDefault returns the value of the Format property.
 // If the property is not set, it returns the default value.
 func (l *LoggerConfig) GetFormatOrDefault() string {
-	if l.Format != nil {
-		return *l.Format
+	if l.Format != "" {
+		return l.Format
 	}
-	return *defaultConfig.logger.Format
+	return defaultConfig.logger.Format
 }
 
 // GetStdoutWriterOrDefault returns the value of the StdoutWriter property.

--- a/pkg/model/restore_namespace.go
+++ b/pkg/model/restore_namespace.go
@@ -5,7 +5,7 @@ package model
 // the namespace name to which the backup data is to be restored.
 type RestoreNamespace struct {
 	// Original namespace name.
-	Source *string
+	Source string
 	// Destination namespace name.
-	Destination *string
+	Destination string
 }

--- a/pkg/model/secret_agent.go
+++ b/pkg/model/secret_agent.go
@@ -35,10 +35,10 @@ func (s *SecretAgent) ToSecretAgentConfig() *backup.SecretAgentConfig {
 		Address:            &s.Address,
 		Port:               (*int)(s.Port),
 		TimeoutMillisecond: s.Timeout,
-		CaFile:             s.CAFile,
-		TLSName:            s.Name,
-		CertFile:           s.Certfile,
-		KeyFile:            s.Keyfile,
+		CaFile:             ptr.StringOrNil(s.CAFile),
+		TLSName:            ptr.StringOrNil(s.Name),
+		CertFile:           ptr.StringOrNil(s.Certfile),
+		KeyFile:            ptr.StringOrNil(s.Keyfile),
 		IsBase64:           s.IsBase64,
 	}
 }

--- a/pkg/model/secret_agent.go
+++ b/pkg/model/secret_agent.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"fmt"
-
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/aerospike/backup-go"
 )
@@ -43,16 +41,18 @@ func (s *SecretAgent) ToSecretAgentConfig() *backup.SecretAgentConfig {
 	}
 }
 
-// String returns a string representation of the SecretAgent.
-func (s *SecretAgent) String() string {
+// Hash returns a unique identifier for the SecretAgent configuration.
+func (s *SecretAgent) Hash() uint64 {
 	if s == nil {
-		return ""
+		return 0
 	}
-	return fmt.Sprintf("%v:%v:%v:%v:%v:%v",
+
+	return hashValues(
 		s.ConnectionType,
 		s.Address,
-		ptr.ValueOrZero(s.Port),
-		ptr.ValueOrZero(s.Timeout),
-		s.ClientTLS.String(),
-		ptr.ValueOrZero(s.IsBase64))
+		s.Port,
+		s.Timeout,
+		s.ClientTLS.Hash(),
+		s.IsBase64,
+	)
 }

--- a/pkg/model/storage_s3.go
+++ b/pkg/model/storage_s3.go
@@ -1,8 +1,6 @@
 package model
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type S3Storage struct {
 	// Path is the root directory within the S3 bucket where backups will be stored.
@@ -15,10 +13,10 @@ type S3Storage struct {
 	// S3Profile is the name of the AWS credentials profile to use.
 	S3Profile string
 	// S3EndpointOverride is used to specify a custom S3 endpoint.
-	S3EndpointOverride *string
+	S3EndpointOverride string
 	// S3LogLevel controls the verbosity of the AWS SDK logging.
 	// Valid values are: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE.
-	S3LogLevel *string
+	S3LogLevel string
 	// MinPartSize is the minimum size in bytes for multipart upload parts.
 	MinPartSize *int
 	// MaxConnsPerHost limits the number of concurrent connections to S3.

--- a/pkg/model/tls.go
+++ b/pkg/model/tls.go
@@ -1,20 +1,16 @@
 package model
 
-import (
-	"fmt"
-
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
-)
+import "fmt"
 
 // TLS represents the Aerospike cluster TLS configuration options.
 type TLS struct {
 	ClientTLS
 	// Path to a directory of trusted CA certificates.
-	CAPath *string
+	CAPath string
 	// TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.
-	Protocols *string
+	Protocols string
 	// TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format.
-	CipherSuite *string
+	CipherSuite string
 	// Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).
 	KeyfilePassword string
 }
@@ -25,11 +21,11 @@ func (tls *TLS) String() string {
 		return ""
 	}
 	return fmt.Sprintf(
-		"%s:%v:%v:%v:%v",
+		"%s:%s:%s:%s:%s",
 		tls.ClientTLS.String(),
-		ptr.ValueOrZero(tls.CAPath),
-		ptr.ValueOrZero(tls.Protocols),
-		ptr.ValueOrZero(tls.CipherSuite),
+		tls.CAPath,
+		tls.Protocols,
+		tls.CipherSuite,
 		tls.KeyfilePassword,
 	)
 }

--- a/pkg/model/tls.go
+++ b/pkg/model/tls.go
@@ -1,7 +1,5 @@
 package model
 
-import "fmt"
-
 // TLS represents the Aerospike cluster TLS configuration options.
 type TLS struct {
 	ClientTLS
@@ -15,14 +13,14 @@ type TLS struct {
 	KeyfilePassword string
 }
 
-// String returns a string representation of the TLS.
-func (tls *TLS) String() string {
+// Hash returns a unique identifier for the TLS configuration.
+func (tls *TLS) Hash() uint64 {
 	if tls == nil {
-		return ""
+		return 0
 	}
-	return fmt.Sprintf(
-		"%s:%s:%s:%s:%s",
-		tls.ClientTLS.String(),
+
+	return hashValues(
+		tls.ClientTLS.Hash(),
 		tls.CAPath,
 		tls.Protocols,
 		tls.CipherSuite,

--- a/pkg/model/tls.go
+++ b/pkg/model/tls.go
@@ -16,7 +16,7 @@ type TLS struct {
 	// TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format.
 	CipherSuite *string
 	// Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).
-	KeyfilePassword *string
+	KeyfilePassword string
 }
 
 // String returns a string representation of the TLS.
@@ -30,6 +30,6 @@ func (tls *TLS) String() string {
 		ptr.ValueOrZero(tls.CAPath),
 		ptr.ValueOrZero(tls.Protocols),
 		ptr.ValueOrZero(tls.CipherSuite),
-		ptr.ValueOrZero(tls.KeyfilePassword),
+		tls.KeyfilePassword,
 	)
 }

--- a/pkg/service/aerospike/client_factory.go
+++ b/pkg/service/aerospike/client_factory.go
@@ -132,7 +132,7 @@ func setTLSConfig(c *model.AerospikeCluster, policy *as.ClientPolicy) {
 	if !anySeedNodeHasTLSName(c) {
 		if c.TLS != nil {
 			slog.Warn("A TLS configuration is provided, but no seed nodes have TLS names. Ignoring TLS settings.",
-				slog.String("cluster", ptr.ValueOrZero(c.ClusterLabel)))
+				slog.String("cluster", c.ClusterLabel))
 		}
 
 		return // no TLS configuration needed for this cluster
@@ -149,7 +149,7 @@ func setTLSConfig(c *model.AerospikeCluster, policy *as.ClientPolicy) {
 	policy.TlsConfig, err = NewTLSConfig(tlsToApply)
 	if err != nil {
 		slog.Error("Failed to initialize TLS config",
-			slog.String("cluster", ptr.ValueOrZero(c.ClusterLabel)),
+			slog.String("cluster", c.ClusterLabel),
 			attr.Error(err))
 	}
 }

--- a/pkg/service/aerospike/client_factory.go
+++ b/pkg/service/aerospike/client_factory.go
@@ -67,7 +67,7 @@ func clientHosts(c *model.AerospikeCluster) []*as.Host {
 func (f *DefaultClientFactory) clientPolicy(ctx context.Context, c *model.AerospikeCluster) (*as.ClientPolicy, error) {
 	policy := as.NewClientPolicy()
 	if c.Credentials != nil {
-		policy.User = ptr.ValueOrZero(c.GetUser())
+		policy.User = c.GetUser()
 		password, err := f.resolveClusterPassword(ctx, c.Credentials)
 		if err != nil {
 			return nil, err

--- a/pkg/service/aerospike/client_manager.go
+++ b/pkg/service/aerospike/client_manager.go
@@ -43,7 +43,7 @@ type Cluster interface {
 // the client is actually closed when the counter reaches zero.
 type ClientManagerImpl struct {
 	// clients holds the state for each cluster.
-	clients       *collections.SafeMap[string, *clientInfo]
+	clients       *collections.SafeMap[uint64, *clientInfo]
 	clientFactory ClientFactory
 	closeDelay    time.Duration
 }
@@ -66,7 +66,7 @@ type clientInfo struct {
 // closeDelay specifies how long to wait before actually closing the client after the last user releases it.
 func NewClientManager(aerospikeClientFactory ClientFactory, closeDelay time.Duration) *ClientManagerImpl {
 	return &ClientManagerImpl{
-		clients:       collections.NewSafeMap[string, *clientInfo](),
+		clients:       collections.NewSafeMap[uint64, *clientInfo](),
 		clientFactory: aerospikeClientFactory,
 		closeDelay:    closeDelay,
 	}
@@ -164,13 +164,13 @@ func (cm *ClientManagerImpl) createBackupClient(
 func (cm *ClientManagerImpl) Close(client Client) {
 	var (
 		targetInfo *clientInfo
-		targetKey  string
+		targetKey  uint64
 	)
 
 	// We need to find which info struct owns this client.
 	// Since Client interface wraps the underlying AerospikeClient, we compare pointers.
 	found := false
-	cm.clients.Iterate(func(key string, info *clientInfo) {
+	cm.clients.Iterate(func(key uint64, info *clientInfo) {
 		if found {
 			return // Optimization: stop if already found
 		}
@@ -197,7 +197,7 @@ func (cm *ClientManagerImpl) Close(client Client) {
 }
 
 // decrementRef decreases the reference count and schedules closing if count reaches zero.
-func (cm *ClientManagerImpl) decrementRef(info *clientInfo, clusterKey string) {
+func (cm *ClientManagerImpl) decrementRef(info *clientInfo, clusterKey uint64) {
 	info.mu.Lock()
 	defer info.mu.Unlock()
 
@@ -212,7 +212,7 @@ func (cm *ClientManagerImpl) decrementRef(info *clientInfo, clusterKey string) {
 }
 
 // scheduleClosing schedules client closing after the configured delay.
-func (cm *ClientManagerImpl) scheduleClosing(clusterKey string) *time.Timer {
+func (cm *ClientManagerImpl) scheduleClosing(clusterKey uint64) *time.Timer {
 	return time.AfterFunc(cm.closeDelay, func() {
 		// 1. Retrieve the info struct
 		info, exists := cm.clients.Load(clusterKey)

--- a/pkg/service/aerospike/client_manager_test.go
+++ b/pkg/service/aerospike/client_manager_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aerospike/aerospike-client-go/v8"
 	"github.com/aerospike/backup-go"
 	"github.com/aerospike/backup-go/mocks"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -19,11 +18,11 @@ import (
 )
 
 var cluster = &model.AerospikeCluster{
-	ClusterLabel: ptr.String("test"),
+	ClusterLabel: "test",
 }
 
 var cluster2 = &model.AerospikeCluster{
-	ClusterLabel: ptr.String("test2"),
+	ClusterLabel: "test2",
 }
 
 func Test_GetClient(t *testing.T) {

--- a/pkg/service/aerospike/namespace_validator_test.go
+++ b/pkg/service/aerospike/namespace_validator_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/backup-go/mocks"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -131,8 +130,8 @@ func TestFindMissingByRoutine_TwoClusters_OK(t *testing.T) {
 	defer ctrl.Finish()
 
 	mgr := NewMockClientManager(ctrl)
-	a := &model.AerospikeCluster{ClusterLabel: ptr.String("A")}
-	b := &model.AerospikeCluster{ClusterLabel: ptr.String("B")}
+	a := &model.AerospikeCluster{ClusterLabel: "A"}
+	b := &model.AerospikeCluster{ClusterLabel: "B"}
 
 	routines := map[string]*model.BackupRoutine{
 		"r1": {SourceCluster: a, Namespaces: []string{"ns1"}},
@@ -153,8 +152,8 @@ func TestFindMissingByRoutine_TwoClusters_Fail(t *testing.T) {
 	defer ctrl.Finish()
 
 	mgr := NewMockClientManager(ctrl)
-	a := &model.AerospikeCluster{ClusterLabel: ptr.String("A")}
-	b := &model.AerospikeCluster{ClusterLabel: ptr.String("B")}
+	a := &model.AerospikeCluster{ClusterLabel: "A"}
+	b := &model.AerospikeCluster{ClusterLabel: "B"}
 
 	routines := map[string]*model.BackupRoutine{
 		"r1": {SourceCluster: a, Namespaces: []string{"ns2"}},

--- a/pkg/service/aerospike/tls.go
+++ b/pkg/service/aerospike/tls.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 )
 
 var protocolMap = map[string]uint16{
@@ -64,7 +63,7 @@ func NewTLSConfig(t *model.TLS) (*tls.Config, error) {
 	}
 
 	tlsConfig := &tls.Config{
-		ServerName:   ptr.ValueOrZero(t.Name),
+		ServerName:   t.Name,
 		Certificates: clientCerts,
 		RootCAs:      rootCAs,
 		MinVersion:   minVersion,
@@ -76,7 +75,7 @@ func NewTLSConfig(t *model.TLS) (*tls.Config, error) {
 }
 
 // loadCertPool creates a new x509.CertPool and populates it from a file and a directory.
-func loadCertPool(caFile, caPath *string) (*x509.CertPool, error) {
+func loadCertPool(caFile, caPath string) (*x509.CertPool, error) {
 	// Try to load system CA certs, otherwise just make an empty pool
 	pool, err := x509.SystemCertPool()
 	if pool == nil || err != nil {
@@ -85,21 +84,21 @@ func loadCertPool(caFile, caPath *string) (*x509.CertPool, error) {
 	}
 
 	// Load from CAFile if provided.
-	if caFile != nil && *caFile != "" {
-		if err := appendCertFile(pool, *caFile); err != nil {
+	if caFile != "" {
+		if err := appendCertFile(pool, caFile); err != nil {
 			return nil, err
 		}
 	}
 
 	// Load from CAPath if provided.
-	if caPath != nil && *caPath != "" {
-		files, err := os.ReadDir(*caPath)
+	if caPath != "" {
+		files, err := os.ReadDir(caPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read CA path directory %s: %w", *caPath, err)
+			return nil, fmt.Errorf("failed to read CA path directory %s: %w", caPath, err)
 		}
 
 		for _, file := range files {
-			path := filepath.Join(*caPath, file.Name())
+			path := filepath.Join(caPath, file.Name())
 			fileInfo, err := os.Stat(path)
 			if err != nil {
 				slog.Warn("Failed to stat file, skipping",
@@ -135,8 +134,8 @@ func appendCertFile(pool *x509.CertPool, path string) error {
 
 // loadClientCerts loads the client certificate and key.
 func loadClientCerts(t *model.TLS) ([]tls.Certificate, error) {
-	certFile := ptr.ValueOrZero(t.Certfile)
-	keyFile := ptr.ValueOrZero(t.Keyfile)
+	certFile := t.Certfile
+	keyFile := t.Keyfile
 
 	if certFile == "" || keyFile == "" {
 		return nil, nil // Not an error, just no client certs provided.
@@ -182,18 +181,18 @@ func loadClientCerts(t *model.TLS) ([]tls.Certificate, error) {
 }
 
 // parseProtocols parses a space-separated string of TLS protocol versions.
-func parseProtocols(protocols *string) (minVersion, maxVersion uint16, err error) {
+func parseProtocols(protocols string) (minVersion, maxVersion uint16, err error) {
 	// Default to TLS 1.2 as the minimum if nothing is specified.
 	// A maxVersion of 0 means "use the highest supported version".
 	minVersion, maxVersion = tls.VersionTLS12, 0
-	if protocols == nil || *protocols == "" {
+	if protocols == "" {
 		return minVersion, maxVersion, nil
 	}
 
 	minVersion = 0xFFFF // Set to maxVersion value to find the true minimum.
 	maxVersion = 0
 
-	versionStrs := strings.Fields(*protocols)
+	versionStrs := strings.Fields(protocols)
 	if len(versionStrs) == 0 {
 		return tls.VersionTLS12, 0, nil
 	}
@@ -220,12 +219,12 @@ func parseProtocols(protocols *string) (minVersion, maxVersion uint16, err error
 }
 
 // parseCipherSuites parses a colon-separated string of IANA cipher suite names.
-func parseCipherSuites(cipherSuiteStr *string) ([]uint16, error) {
-	if cipherSuiteStr == nil || *cipherSuiteStr == "" {
+func parseCipherSuites(cipherSuiteStr string) ([]uint16, error) {
+	if cipherSuiteStr == "" {
 		return nil, nil // Use default cipher suites.
 	}
 
-	names := strings.Split(*cipherSuiteStr, ":")
+	names := strings.Split(cipherSuiteStr, ":")
 	suites := make([]uint16, 0, len(names))
 
 	for _, name := range names {

--- a/pkg/service/aerospike/tls.go
+++ b/pkg/service/aerospike/tls.go
@@ -162,8 +162,8 @@ func loadClientCerts(t *model.TLS) ([]tls.Certificate, error) {
 
 	// Check and Decrypt the Key Block using passphrase
 	//noinspection GoDeprecation
-	if t.KeyfilePassword != nil && x509.IsEncryptedPEMBlock(keyBlock) { //nolint:staticcheck
-		decryptedDERBytes, err := x509.DecryptPEMBlock(keyBlock, []byte(*t.KeyfilePassword)) //nolint:staticcheck
+	if t.KeyfilePassword != "" && x509.IsEncryptedPEMBlock(keyBlock) { //nolint:staticcheck
+		decryptedDERBytes, err := x509.DecryptPEMBlock(keyBlock, []byte(t.KeyfilePassword)) //nolint:staticcheck
 		if err != nil {
 			return nil, fmt.Errorf("failed to decrypt client key file %s: %w", keyFile, err)
 		}

--- a/pkg/service/aerospike/tls_test.go
+++ b/pkg/service/aerospike/tls_test.go
@@ -196,7 +196,7 @@ func TestNewTLSConfig(t *testing.T) {
 					Certfile: &serverCertFile,
 					Keyfile:  &encKeyFile,
 				},
-				KeyfilePassword: &encKeyPassword,
+				KeyfilePassword: encKeyPassword,
 			})
 			require.NoError(t, err)
 			assert.Len(t, cfg.Certificates, 1, "Certificate should be loaded with correct password")
@@ -209,7 +209,7 @@ func TestNewTLSConfig(t *testing.T) {
 					Certfile: &serverCertFile,
 					Keyfile:  &encKeyFile,
 				},
-				KeyfilePassword: &wrongPass,
+				KeyfilePassword: wrongPass,
 			})
 			require.Error(t, err, "Should fail with wrong password")
 		})

--- a/pkg/service/aerospike/tls_test.go
+++ b/pkg/service/aerospike/tls_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,7 +113,7 @@ func TestNewTLSConfig(t *testing.T) {
 
 	t.Run("With Server Name", func(t *testing.T) {
 		serverName := "my.test.server"
-		cfg, err := NewTLSConfig(&model.TLS{ClientTLS: model.ClientTLS{Name: &serverName}})
+		cfg, err := NewTLSConfig(&model.TLS{ClientTLS: model.ClientTLS{Name: serverName}})
 		require.NoError(t, err)
 		assert.Equal(t, serverName, cfg.ServerName)
 	})
@@ -125,8 +124,8 @@ func TestNewTLSConfig(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(caSubDir, "ca.crt"), caCertPEM, 0600))
 
 		cfg, err := NewTLSConfig(&model.TLS{
-			ClientTLS: model.ClientTLS{CAFile: &caCertFile},
-			CAPath:    &caSubDir,
+			ClientTLS: model.ClientTLS{CAFile: caCertFile},
+			CAPath:    caSubDir,
 		})
 		require.NoError(t, err)
 		//noinspection GoDeprecation
@@ -165,7 +164,7 @@ func TestNewTLSConfig(t *testing.T) {
 		// - `..2025_10_27_12_34_56_789` (dir, skipped)
 		// - `..data` (symlink to dir, skipped)
 		// - `cert1.pem` (symlink to file, loaded)
-		cfg, err := NewTLSConfig(&model.TLS{CAPath: &caPathK8s})
+		cfg, err := NewTLSConfig(&model.TLS{CAPath: caPathK8s})
 		require.NoError(t, err)
 		require.NotNil(t, cfg.RootCAs, "RootCAs should be populated")
 
@@ -181,8 +180,8 @@ func TestNewTLSConfig(t *testing.T) {
 	t.Run("With Client Certs", func(t *testing.T) {
 		cfg, err := NewTLSConfig(&model.TLS{
 			ClientTLS: model.ClientTLS{
-				Certfile: &serverCertFile,
-				Keyfile:  &serverKeyFile,
+				Certfile: serverCertFile,
+				Keyfile:  serverKeyFile,
 			},
 		})
 		require.NoError(t, err)
@@ -193,8 +192,8 @@ func TestNewTLSConfig(t *testing.T) {
 		t.Run("Correct Password", func(t *testing.T) {
 			cfg, err := NewTLSConfig(&model.TLS{
 				ClientTLS: model.ClientTLS{
-					Certfile: &serverCertFile,
-					Keyfile:  &encKeyFile,
+					Certfile: serverCertFile,
+					Keyfile:  encKeyFile,
 				},
 				KeyfilePassword: encKeyPassword,
 			})
@@ -206,8 +205,8 @@ func TestNewTLSConfig(t *testing.T) {
 			wrongPass := "wrong"
 			_, err := NewTLSConfig(&model.TLS{
 				ClientTLS: model.ClientTLS{
-					Certfile: &serverCertFile,
-					Keyfile:  &encKeyFile,
+					Certfile: serverCertFile,
+					Keyfile:  encKeyFile,
 				},
 				KeyfilePassword: wrongPass,
 			})
@@ -217,8 +216,8 @@ func TestNewTLSConfig(t *testing.T) {
 		t.Run("No Password", func(t *testing.T) {
 			_, err := NewTLSConfig(&model.TLS{
 				ClientTLS: model.ClientTLS{
-					Certfile: &serverCertFile,
-					Keyfile:  &encKeyFile,
+					Certfile: serverCertFile,
+					Keyfile:  encKeyFile,
 				},
 			})
 			require.Error(t, err, "Should fail when no password is provided for an encrypted key")
@@ -230,16 +229,15 @@ func TestNewTLSConfig(t *testing.T) {
 func TestParseProtocols(t *testing.T) {
 	testCases := []struct {
 		name        string
-		protocolStr *string
+		protocolStr string
 		wantMin     uint16
 		wantMax     uint16
 		expectErr   bool
 	}{
-		{"NilInput", nil, tls.VersionTLS12, 0, false},
-		{"EmptyInput", ptr.Of(""), tls.VersionTLS12, 0, false},
-		{"WithSpaces", ptr.Of("  TLSv1.2  "), tls.VersionTLS12, tls.VersionTLS12, false},
-		{"InvalidVersion", ptr.Of("TLSv1.9"), 0, 0, true},
-		{"MixedValidity", ptr.Of("TLSv1.2 BOGUS"), 0, 0, true},
+		{"EmptyInput", "", tls.VersionTLS12, 0, false},
+		{"WithSpaces", "  TLSv1.2  ", tls.VersionTLS12, tls.VersionTLS12, false},
+		{"InvalidVersion", "TLSv1.9", 0, 0, true},
+		{"MixedValidity", "TLSv1.2 BOGUS", 0, 0, true},
 	}
 
 	for _, tc := range testCases {
@@ -265,24 +263,23 @@ func TestParseCipherSuites(t *testing.T) {
 
 	testCases := []struct {
 		name       string
-		ciphersStr *string
+		ciphersStr string
 		wantSuites []uint16
 		expectErr  bool
 	}{
-		{"NilInput", nil, nil, false},
-		{"EmptyInput", ptr.Of(""), nil, false},
-		{"SingleSuite", ptr.Of(validSuite1), []uint16{validSuiteID1}, false},
+		{"EmptyInput", "", nil, false},
+		{"SingleSuite", validSuite1, []uint16{validSuiteID1}, false},
 		{"MultipleSuites",
-			ptr.Of(fmt.Sprintf("%s:%s", validSuite1, validSuite2)),
+			fmt.Sprintf("%s:%s", validSuite1, validSuite2),
 			[]uint16{validSuiteID1, validSuiteID2}, false},
 		{"WithWhitespace",
-			ptr.Of(fmt.Sprintf(" %s : %s ", validSuite1, validSuite2)),
+			fmt.Sprintf(" %s : %s ", validSuite1, validSuite2),
 			[]uint16{validSuiteID1, validSuiteID2}, false},
-		{"InvalidSuiteName", ptr.Of("TLS_BOGUS_SUITE"), nil, true},
+		{"InvalidSuiteName", "TLS_BOGUS_SUITE", nil, true},
 		{"MixedValidity",
-			ptr.Of(validSuite1 + ":TLS_BOGUS_SUITE"), nil, true},
+			validSuite1 + ":TLS_BOGUS_SUITE", nil, true},
 		{"EmptyStringBetweenColons",
-			ptr.Of(fmt.Sprintf("%s::%s", validSuite1, validSuite2)),
+			fmt.Sprintf("%s::%s", validSuite1, validSuite2),
 			[]uint16{validSuiteID1, validSuiteID2}, false},
 	}
 

--- a/pkg/service/backupexecutor/scan.go
+++ b/pkg/service/backupexecutor/scan.go
@@ -148,8 +148,8 @@ func makeEncryptionPolicy(policy *model.BackupPolicy) *backup.EncryptionPolicy {
 
 	return &backup.EncryptionPolicy{
 		Mode:      policy.EncryptionPolicy.Mode,
-		KeyFile:   policy.EncryptionPolicy.KeyFile,
-		KeySecret: policy.EncryptionPolicy.KeySecret,
-		KeyEnv:    policy.EncryptionPolicy.KeyEnv,
+		KeyFile:   ptr.StringOrNil(policy.EncryptionPolicy.KeyFile),
+		KeySecret: ptr.StringOrNil(policy.EncryptionPolicy.KeySecret),
+		KeyEnv:    ptr.StringOrNil(policy.EncryptionPolicy.KeyEnv),
 	}
 }

--- a/pkg/service/backupexecutor/scan_test.go
+++ b/pkg/service/backupexecutor/scan_test.go
@@ -46,7 +46,7 @@ func TestMakeBackupConfigWithFullBackup(t *testing.T) {
 			Address:        "localhost",
 			Port:           ptr.Of(model.Port(9000)),
 			Timeout:        ptr.Of(1000),
-			ClientTLS:      model.ClientTLS{CAFile: ptr.Of("ca-string")},
+			ClientTLS:      model.ClientTLS{CAFile: "ca-string"},
 			IsBase64:       ptr.Of(true),
 		},
 		SourceCluster: &model.AerospikeCluster{},

--- a/pkg/service/backupexecutor/scan_test.go
+++ b/pkg/service/backupexecutor/scan_test.go
@@ -30,9 +30,9 @@ func TestMakeBackupConfigWithFullBackup(t *testing.T) {
 			},
 			EncryptionPolicy: &model.EncryptionPolicy{
 				Mode:      "aes-256",
-				KeyFile:   ptr.Of("path/to/key"),
-				KeySecret: ptr.Of("secret-name"),
-				KeyEnv:    ptr.Of("ENV_VAR"),
+				KeyFile:   "path/to/key",
+				KeySecret: "secret-name",
+				KeyEnv:    "ENV_VAR",
 			},
 			Compact: ptr.Of(true),
 		},

--- a/pkg/service/restore_path_runner_test.go
+++ b/pkg/service/restore_path_runner_test.go
@@ -161,7 +161,7 @@ func TestRestoreFailsWithInvalidNamespace(t *testing.T) {
 	destinationNS := "test-ns"
 	policy := model.RestorePolicy{
 		Namespace: &model.RestoreNamespace{
-			Destination: &destinationNS,
+			Destination: destinationNS,
 		},
 	}
 	storage := &model.LocalStorage{Path: "/backup/path"}

--- a/pkg/service/restore_time_runner.go
+++ b/pkg/service/restore_time_runner.go
@@ -173,7 +173,7 @@ func (r *timeRestoreRunner) restoreByTimeSync(
 	client, err := r.clientManager.GetClient(ctx, &request.DestinationCluster, nil, logger)
 	if err != nil {
 		return fmt.Errorf("failed to get client for cluster %s: %w",
-			ptr.ValueOrZero(request.DestinationCluster.ClusterLabel), err)
+			request.DestinationCluster.ClusterLabel, err)
 	}
 	defer r.clientManager.Close(client)
 

--- a/pkg/service/restore_time_runner_test.go
+++ b/pkg/service/restore_time_runner_test.go
@@ -201,7 +201,7 @@ func TestRestoreByTime_CompressionAndEncryptionHandling(t *testing.T) {
 			policy: model.RestorePolicy{
 				EncryptionPolicy: &model.EncryptionPolicy{
 					Mode:   "AES128",
-					KeyEnv: ptr.Of("AES_KEY"),
+					KeyEnv: "AES_KEY",
 				},
 			},
 			backupEncryption: "AES128",

--- a/pkg/service/restore_validator.go
+++ b/pkg/service/restore_validator.go
@@ -203,8 +203,8 @@ func validateBackupsEncryption(backups []model.BackupDetails, policy *model.Encr
 
 // destinationNamespacesForRestore resolves effective destination namespaces for a restore request.
 func destinationNamespacesForRestore(remapping *model.RestoreNamespace, sourceNamespaces []string) []string {
-	if remapping != nil && remapping.Destination != nil {
-		return []string{*remapping.Destination}
+	if remapping != nil && remapping.Destination != "" {
+		return []string{remapping.Destination}
 	}
 
 	return sourceNamespaces

--- a/pkg/service/restore_validator.go
+++ b/pkg/service/restore_validator.go
@@ -190,9 +190,9 @@ func validateBackupsEncryption(backups []model.BackupDetails, policy *model.Encr
 			return fmt.Errorf("backup is encrypted with mode '%s', "+
 				"but the provided encryption policy specifies mode '%s'", b.Encryption, policy.Mode)
 		}
-		if policy.KeyFile == nil &&
-			policy.KeyEnv == nil &&
-			policy.KeySecret == nil {
+		if policy.KeyFile == "" &&
+			policy.KeyEnv == "" &&
+			policy.KeySecret == "" {
 			return errors.New("backup is encrypted, " +
 				"but no encryption key (KeyFile, KeyEnv, or KeySecret) was provided in the encryption policy")
 		}

--- a/pkg/service/restore_validator.go
+++ b/pkg/service/restore_validator.go
@@ -130,8 +130,13 @@ func (r *restoreValidatorImpl) checkRunningBackupsConflict(
 		// Block if there is any overlap between the destination namespaces of the restore
 		// and the source namespaces of the running backup.
 		if overlappingNS := namespacesOverlap(destinationNamespaces, routine.Namespaces); overlappingNS != "" {
+			clusterLabel := cluster.ClusterLabel
+			if clusterLabel == "" && len(cluster.SeedNodes) > 0 {
+				clusterLabel = cluster.SeedNodes[0].String()
+			}
+
 			return fmt.Errorf("restore not allowed during backups on routine %s (cluster %s, namespace %q). "+
-				"Please cancel existing backups jobs to perform restore", routine.Name, cluster.ToString(), overlappingNS)
+				"Please cancel existing backups jobs to perform restore", routine.Name, clusterLabel, overlappingNS)
 		}
 	}
 

--- a/pkg/service/restore_validator_test.go
+++ b/pkg/service/restore_validator_test.go
@@ -26,7 +26,7 @@ func TestRestoreValidator_BlocksPathRestoreOnSameClusterNamespace(t *testing.T) 
 	config := NewMockroutineProvider(ctrl)
 
 	clusterLabel := "cluster-a"
-	cluster := &model.AerospikeCluster{ClusterLabel: &clusterLabel}
+	cluster := &model.AerospikeCluster{ClusterLabel: clusterLabel}
 	routines := map[string]*model.BackupRoutine{
 		"routine-1": {
 			Name:          "routine-1",
@@ -67,7 +67,7 @@ func TestRestoreValidator_BlocksTimeRestoreOnSameClusterNamespace(t *testing.T) 
 	config := NewMockroutineProvider(ctrl)
 
 	clusterLabel := "cluster-a"
-	cluster := &model.AerospikeCluster{ClusterLabel: &clusterLabel}
+	cluster := &model.AerospikeCluster{ClusterLabel: clusterLabel}
 	routines := map[string]*model.BackupRoutine{
 		"routine-1": {
 			Name:          "routine-1",
@@ -108,7 +108,7 @@ func TestRestoreValidator_BlocksPathRestoreOnPendingBackupStart(t *testing.T) {
 	config := NewMockroutineProvider(ctrl)
 
 	clusterLabel := "cluster-a"
-	cluster := &model.AerospikeCluster{ClusterLabel: &clusterLabel}
+	cluster := &model.AerospikeCluster{ClusterLabel: clusterLabel}
 	routines := map[string]*model.BackupRoutine{
 		"routine-1": {
 			Name:          "routine-1",
@@ -147,7 +147,7 @@ func TestRestoreValidator_BlocksTimeRestoreOnPendingBackupStart(t *testing.T) {
 	config := NewMockroutineProvider(ctrl)
 
 	clusterLabel := "cluster-a"
-	cluster := &model.AerospikeCluster{ClusterLabel: &clusterLabel}
+	cluster := &model.AerospikeCluster{ClusterLabel: clusterLabel}
 	routines := map[string]*model.BackupRoutine{
 		"routine-1": {
 			Name:          "routine-1",

--- a/pkg/service/restoreexecutor/scan.go
+++ b/pkg/service/restoreexecutor/scan.go
@@ -56,8 +56,8 @@ func makeRestoreConfig(restoreRequest *model.RestoreRequest,
 
 	if restoreRequest.Policy.Namespace != nil {
 		config.Namespace = &backup.RestoreNamespaceConfig{
-			Source:      restoreRequest.Policy.Namespace.Source,
-			Destination: restoreRequest.Policy.Namespace.Destination,
+			Source:      ptr.StringOrNil(restoreRequest.Policy.Namespace.Source),
+			Destination: ptr.StringOrNil(restoreRequest.Policy.Namespace.Destination),
 		}
 	}
 

--- a/pkg/service/restoreexecutor/scan.go
+++ b/pkg/service/restoreexecutor/scan.go
@@ -77,9 +77,9 @@ func makeRestoreConfig(restoreRequest *model.RestoreRequest,
 	if restoreRequest.Policy.EncryptionPolicy != nil {
 		config.EncryptionPolicy = &backup.EncryptionPolicy{
 			Mode:      restoreRequest.Policy.EncryptionPolicy.Mode,
-			KeyFile:   restoreRequest.Policy.EncryptionPolicy.KeyFile,
-			KeySecret: restoreRequest.Policy.EncryptionPolicy.KeySecret,
-			KeyEnv:    restoreRequest.Policy.EncryptionPolicy.KeyEnv,
+			KeyFile:   ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeyFile),
+			KeySecret: ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeySecret),
+			KeyEnv:    ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeyEnv),
 		}
 	}
 

--- a/pkg/service/restoreexecutor/scan_test.go
+++ b/pkg/service/restoreexecutor/scan_test.go
@@ -27,8 +27,8 @@ func TestMakeRestoreConfig(t *testing.T) {
 			DisableBatchWrites: ptr.Of(true),
 
 			Namespace: &model.RestoreNamespace{
-				Source:      ptr.Of("ns_source"),
-				Destination: ptr.Of("ns_dest"),
+				Source:      "ns_source",
+				Destination: "ns_dest",
 			},
 
 			CompressionPolicy: &model.CompressionPolicy{
@@ -48,7 +48,7 @@ func TestMakeRestoreConfig(t *testing.T) {
 			Address:        "127.0.0.1",
 			Port:           ptr.Of(model.Port(1234)),
 			Timeout:        ptr.Of(2000),
-			ClientTLS:      model.ClientTLS{CAFile: ptr.Of("ca-cert")},
+			ClientTLS:      model.ClientTLS{CAFile: "ca-cert"},
 			IsBase64:       ptr.Of(true),
 		},
 	}

--- a/pkg/service/restoreexecutor/scan_test.go
+++ b/pkg/service/restoreexecutor/scan_test.go
@@ -38,9 +38,9 @@ func TestMakeRestoreConfig(t *testing.T) {
 
 			EncryptionPolicy: &model.EncryptionPolicy{
 				Mode:      "aes-128",
-				KeyFile:   ptr.Of("key/file/path"),
-				KeySecret: ptr.Of("key-secret"),
-				KeyEnv:    ptr.Of("KEY_ENV_VAR"),
+				KeyFile:   "key/file/path",
+				KeySecret: "key-secret",
+				KeyEnv:    "KEY_ENV_VAR",
 			},
 		},
 		SecretAgent: &model.SecretAgent{

--- a/pkg/service/restoreexecutor/xdr.go
+++ b/pkg/service/restoreexecutor/xdr.go
@@ -72,9 +72,9 @@ func makeXdrRestoreConfig(restoreRequest *model.RestoreRequest,
 	if restoreRequest.Policy.EncryptionPolicy != nil {
 		config.EncryptionPolicy = &backup.EncryptionPolicy{
 			Mode:      restoreRequest.Policy.EncryptionPolicy.Mode,
-			KeyFile:   restoreRequest.Policy.EncryptionPolicy.KeyFile,
-			KeySecret: restoreRequest.Policy.EncryptionPolicy.KeySecret,
-			KeyEnv:    restoreRequest.Policy.EncryptionPolicy.KeyEnv,
+			KeyFile:   ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeyFile),
+			KeySecret: ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeySecret),
+			KeyEnv:    ptr.StringOrNil(restoreRequest.Policy.EncryptionPolicy.KeyEnv),
 		}
 	}
 

--- a/pkg/service/restoreexecutor/xdr.go
+++ b/pkg/service/restoreexecutor/xdr.go
@@ -52,8 +52,8 @@ func makeXdrRestoreConfig(restoreRequest *model.RestoreRequest,
 
 	if restoreRequest.Policy.Namespace != nil {
 		config.Namespace = &backup.RestoreNamespaceConfig{
-			Source:      restoreRequest.Policy.Namespace.Source,
-			Destination: restoreRequest.Policy.Namespace.Destination,
+			Source:      ptr.StringOrNil(restoreRequest.Policy.Namespace.Source),
+			Destination: ptr.StringOrNil(restoreRequest.Policy.Namespace.Destination),
 		}
 	}
 

--- a/pkg/service/secret/password.go
+++ b/pkg/service/secret/password.go
@@ -37,12 +37,12 @@ func (r passwordResolverImpl) Resolve(ctx context.Context, creds *model.Credenti
 	}
 
 	// 1) Resolve Path (file)
-	if creds.PasswordPath != nil {
-		data, err := os.ReadFile(*creds.PasswordPath)
+	if creds.PasswordPath != "" {
+		data, err := os.ReadFile(creds.PasswordPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read password from password-path %s: %w", *creds.PasswordPath, err)
+			return nil, fmt.Errorf("failed to read password from password-path %s: %w", creds.PasswordPath, err)
 		}
-		slog.Debug("Successfully read password", slog.String("path", *creds.PasswordPath))
+		slog.Debug("Successfully read password", slog.String("path", creds.PasswordPath))
 
 		// Strip only line-ending characters to preserve meaningful spaces.
 		password := strings.TrimRight(string(data), "\r\n")
@@ -51,8 +51,8 @@ func (r passwordResolverImpl) Resolve(ctx context.Context, creds *model.Credenti
 	}
 
 	// 2) Resolve (literal or secret-agent reference)
-	if creds.Password != nil {
-		password, err := r.resolver.Resolve(ctx, creds.SecretAgent, *creds.Password)
+	if creds.Password != "" {
+		password, err := r.resolver.Resolve(ctx, creds.SecretAgent, creds.Password)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read password from secret agent: %w", err)
 		}

--- a/pkg/service/secret/password_test.go
+++ b/pkg/service/secret/password_test.go
@@ -29,8 +29,7 @@ func TestResolve(t *testing.T) {
 			name:      "ValidPasswordPath",
 			setupMock: func() { createFile("password") },
 			credentials: &model.Credentials{
-				User:         nil,
-				PasswordPath: ptr.Of(passwordPath),
+				PasswordPath: passwordPath,
 			},
 			expectedPassword: ptr.Of("password"),
 			expectedErr:      false,
@@ -39,8 +38,7 @@ func TestResolve(t *testing.T) {
 			name:      "ValidPasswordPathWithLF",
 			setupMock: func() { createFile("password\n") },
 			credentials: &model.Credentials{
-				User:         nil,
-				PasswordPath: ptr.Of(passwordPath),
+				PasswordPath: passwordPath,
 			},
 			expectedPassword: ptr.Of("password"),
 			expectedErr:      false,
@@ -49,8 +47,7 @@ func TestResolve(t *testing.T) {
 			name:      "ValidPasswordPathWithCRLF",
 			setupMock: func() { createFile("password\r\n") },
 			credentials: &model.Credentials{
-				User:         nil,
-				PasswordPath: ptr.Of(passwordPath),
+				PasswordPath: passwordPath,
 			},
 			expectedPassword: ptr.Of("password"),
 			expectedErr:      false,
@@ -59,8 +56,7 @@ func TestResolve(t *testing.T) {
 			name:      "InvalidPasswordPath",
 			setupMock: func() {},
 			credentials: &model.Credentials{
-				User:         nil,
-				PasswordPath: ptr.Of("not-existing.txt"),
+				PasswordPath: "not-existing.txt",
 			},
 			expectedPassword: nil,
 			expectedErr:      true,
@@ -82,7 +78,7 @@ func TestResolve(t *testing.T) {
 			name:      "PlainPassword",
 			setupMock: func() {},
 			credentials: &model.Credentials{
-				Password: ptr.Of("plain"),
+				Password: "plain",
 			},
 			expectedPassword: ptr.Of("plain"),
 			expectedErr:      false,

--- a/pkg/service/storage/s3.go
+++ b/pkg/service/storage/s3.go
@@ -106,8 +106,8 @@ func (a *S3StorageAccessor) getS3Client(ctx context.Context, s *model.S3Storage)
 	}
 
 	client := awsS3.NewFromConfig(cfg, func(o *awsS3.Options) {
-		if s.S3EndpointOverride != nil && *s.S3EndpointOverride != "" {
-			o.BaseEndpoint = s.S3EndpointOverride
+		if s.S3EndpointOverride != "" {
+			o.BaseEndpoint = aws.String(s.S3EndpointOverride)
 		}
 
 		o.UsePathStyle = true

--- a/pkg/service/storage/s3_test.go
+++ b/pkg/service/storage/s3_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	secrets "github.com/aerospike/aerospike-backup-service/v3/pkg/service/secret"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +26,7 @@ func TestS3Storage_ConnectivitySuccess(t *testing.T) {
 	s3Config := &model.S3Storage{
 		Bucket:             "test-bucket",
 		S3Region:           "us-east-1",
-		S3EndpointOverride: ptr.Of(ts.URL),
+		S3EndpointOverride: ts.URL,
 		Auth: &model.S3Authentication{
 			KeyIDSecret:     "key",
 			AccessKeySecret: "secret",
@@ -53,7 +52,7 @@ func TestS3Storage_ConnectivityReadOnly(t *testing.T) {
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",
 		S3Region:           "us-east-1",
-		S3EndpointOverride: ptr.Of(ts.URL),
+		S3EndpointOverride: ts.URL,
 		Auth: &model.S3Authentication{
 			KeyIDSecret:     "key",
 			AccessKeySecret: "secret",
@@ -76,7 +75,7 @@ func TestS3Storage_ConnectivityFailure(t *testing.T) {
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{
 		Bucket:             "test-bucket",
 		S3Region:           "us-east-1",
-		S3EndpointOverride: ptr.Of(ts.URL),
+		S3EndpointOverride: ts.URL,
 		Auth: &model.S3Authentication{
 			KeyIDSecret:     "key",
 			AccessKeySecret: "secret",

--- a/pkg/util/ptr/ptr.go
+++ b/pkg/util/ptr/ptr.go
@@ -14,3 +14,11 @@ func ValueOrZero[T any](p *T) T {
 	var zero T
 	return zero
 }
+
+// StringOrNil returns nil when s is empty, otherwise a pointer to s.
+func StringOrNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return Of(s)
+}

--- a/pkg/validation/config_validation_test.go
+++ b/pkg/validation/config_validation_test.go
@@ -22,10 +22,10 @@ func TestValidateConfiguration(t *testing.T) {
 				},
 				TLS: &dto.TLS{ // validation will pass even with non-existent files
 					ClientTLS: dto.ClientTLS{
-						Name:     ptr.Of("name"),
-						CAFile:   ptr.Of("/tmp/non-existent-ca-file"),
-						Keyfile:  ptr.Of("/tmp/non-existent-key-file"),
-						Certfile: ptr.Of("/tmp/non-existent-cert-file"),
+						Name:     "name",
+						CAFile:   "/tmp/non-existent-ca-file",
+						Keyfile:  "/tmp/non-existent-key-file",
+						Certfile: "/tmp/non-existent-cert-file",
 					},
 				},
 			},
@@ -51,10 +51,10 @@ func TestValidateRestoreRequest(t *testing.T) {
 				},
 				TLS: &dto.TLS{ // validation will pass even with non-existent files
 					ClientTLS: dto.ClientTLS{
-						Name:     ptr.Of("name"),
-						CAFile:   ptr.Of("/tmp/non-existent-ca-file"),
-						Keyfile:  ptr.Of("/tmp/non-existent-key-file"),
-						Certfile: ptr.Of("/tmp/non-existent-cert-file"),
+						Name:     "name",
+						CAFile:   "/tmp/non-existent-ca-file",
+						Keyfile:  "/tmp/non-existent-key-file",
+						Certfile: "/tmp/non-existent-cert-file",
 					},
 				},
 			},
@@ -118,10 +118,10 @@ func TestValidateRestoreTimestampRequest(t *testing.T) {
 			},
 			TLS: &dto.TLS{ // validation will pass even with non-existent files
 				ClientTLS: dto.ClientTLS{
-					Name:     ptr.Of("name"),
-					CAFile:   ptr.Of("/tmp/non-existent-ca-file"),
-					Keyfile:  ptr.Of("/tmp/non-existent-key-file"),
-					Certfile: ptr.Of("/tmp/non-existent-cert-file"),
+					Name:     "name",
+					CAFile:   "/tmp/non-existent-ca-file",
+					Keyfile:  "/tmp/non-existent-key-file",
+					Certfile: "/tmp/non-existent-cert-file",
 				},
 			},
 		},

--- a/test/integration/fixture.go
+++ b/test/integration/fixture.go
@@ -61,7 +61,7 @@ func (s *Suite) setupEnv(customize ...func(*dto.Config)) *env {
 func (s *Suite) baseConfig(backupDir string) *dto.Config {
 	return &dto.Config{
 		ServiceConfig: dto.ServiceConfig{
-			Logger: &dto.LoggerConfig{Level: ptr.Of("ERROR")},
+			Logger: &dto.LoggerConfig{Level: "ERROR"},
 		},
 		AerospikeClusters: map[string]*dto.AerospikeCluster{
 			clusterName: {


### PR DESCRIPTION
## What does this change do?

<!-- Summarize the change and why it's needed. Link any related issue. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [ ] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [ ] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [ ] Tests were added or updated for the change.
- [ ] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

<!-- Anything else reviewers should know: alternatives considered, follow-up work, screenshots, etc. -->
