### PR TITLE
Test Phase 0: Enforce minimum filtered coverage in CI

### DIFF
--- a/.covignore
+++ b/.covignore
@@ -1,7 +1,7 @@
-/internal/
 /cmd/
 /docs/
 /modules/
+/build/
 /pkg/model/
 /pkg/stdio/
 /pkg/service/aerospike/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,13 @@ jobs:
           grep -v -E -f .covignore coverage.out > coverage.filtered.out
           mv coverage.filtered.out coverage.out
 
+      - name: Check coverage threshold
+        run: |
+          TOTAL=$(go tool cover -func=coverage.out | awk '/total:/ {gsub(/%/,"",$3); print $3}')
+          THRESHOLD=53
+          awk -v t="$TOTAL" -v min="$THRESHOLD" 'BEGIN { exit (t+0 >= min+0 ? 0 : 1) }' || \
+            (echo "Coverage $TOTAL% below threshold $THRESHOLD%" && exit 1)
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,16 @@ test:
 test-integration:
 	$(GOTEST) -tags=integration -count=1 -v -timeout 5m ./test/integration/...
 
+.PHONY: test-cover
+test-cover:
+	$(GOTEST) -race -tags=ci ./... -coverprofile=coverage.out -covermode=atomic
+	grep -v -E -f .covignore coverage.out > coverage.filtered.out
+	$(GO) tool cover -func=coverage.filtered.out | tail -1
+
+.PHONY: test-cover-html
+test-cover-html: test-cover
+	$(GO) tool cover -html=coverage.filtered.out -o coverage.html
+
 # mocks-generate: runs mockgen over pkg/service* interfaces and writes mockgen.go next to each
 #   package. Used by tests; committed mocks must match this output (see mocks-check).
 .PHONY: mocks-generate

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,1 @@
+confluence-export/

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,6 +41,32 @@ CI additionally runs tests with the race detector and the `ci` build tag:
 go test -race -tags=ci ./... -coverprofile=coverage.out -covermode=atomic
 ```
 
+### Coverage
+
+Run the same filtered coverage total that CI and Codecov use:
+
+```bash
+make test-cover          # prints filtered total (last line)
+make test-cover-html     # also writes coverage.html from the filtered profile
+```
+
+[`.covignore`](../.covignore) removes lines from the uploaded profile before the total is computed. It excludes
+generated mocks, entrypoints, and packages that are thin wrappers or hard to unit-test in isolation:
+
+| Excluded path | Reason |
+|---------------|--------|
+| `/cmd/` | CLI entrypoint |
+| `/docs/`, `/modules/` | Non-Go assets |
+| `/pkg/model/` | Data structs with no logic |
+| `/pkg/stdio/` | I/O wrapper |
+| `/pkg/service/aerospike/` | Live Aerospike client |
+| `configuration_manager*.go`, `estimates.go` | Integration-heavy service code |
+| `/*/mockgen.go` | Generated mocks |
+
+`internal/` (HTTP handlers, server wiring) **is** measured. CI fails if filtered coverage drops below the threshold
+configured in [`.github/workflows/build.yml`](../.github/workflows/build.yml) (currently 53%, matching the
+~53.5% filtered baseline after including `internal/`). That threshold ratchets up as test coverage improves across follow-up PRs.
+
 ## Generated artifacts
 
 Three sets of files are generated from source and checked into the repository. Each has a `make <x>` target to


### PR DESCRIPTION
## What does this change do?

<!-- Summarize the change and why it's needed. Link any related issue. -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [ ] Tests were added or updated for the change.
- [ ] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

<!-- Anything else reviewers should know: alternatives considered, follow-up work, screenshots, etc. -->
