### PR TITLE
Test Phase 2: Add storage layer unit tests

### DIFF
--- a/pkg/service/storage/local_test.go
+++ b/pkg/service/storage/local_test.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/backup-go/io/storage/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLocalStorageAccessor(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, NewLocalStorageAccessor())
+}
+
+func TestLocalStorageAccessor_Supports(t *testing.T) {
+	t.Parallel()
+
+	a := NewLocalStorageAccessor()
+
+	assert.True(t, a.supports(&model.LocalStorage{Path: "/tmp"}))
+	assert.False(t, a.supports(&model.S3Storage{}))
+}
+
+func TestLocalStorageAccessor_CreateReader(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "data.asb"), []byte("hello"), 0o600))
+
+	a := NewLocalStorageAccessor()
+	reader, err := a.createReader(t.Context(), &model.LocalStorage{Path: dir}, options.WithDir(dir))
+	require.NoError(t, err)
+	require.NotNil(t, reader)
+}
+
+func TestLocalStorageAccessor_CreateWriter(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	a := NewLocalStorageAccessor()
+
+	writer, err := a.createWriter(t.Context(), &model.LocalStorage{Path: dir}, options.WithDir(dir))
+	require.NoError(t, err)
+	require.NotNil(t, writer)
+}
+
+func TestLocalStorageAccessor_CreateWriter_WithMinPartSize(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	a := NewLocalStorageAccessor()
+	minPartSize := 1024
+
+	writer, err := a.createWriter(
+		t.Context(),
+		&model.LocalStorage{Path: dir, MinPartSize: &minPartSize},
+		options.WithDir(dir),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, writer)
+}

--- a/pkg/service/storage/operations_test.go
+++ b/pkg/service/storage/operations_test.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestOperations(t *testing.T) (*Operations, *model.LocalStorage) {
+	t.Helper()
+
+	return NewOperations(NewLocalStorageAccessor()), &model.LocalStorage{Path: t.TempDir()}
+}
+
+func TestNewOperations(t *testing.T) {
+	t.Parallel()
+
+	ops := NewOperations(NewLocalStorageAccessor())
+	require.NotNil(t, ops)
+	assert.Len(t, ops.accessors, 1)
+}
+
+func TestOperations_WriteDataFile_ReadFile(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+	content := []byte("hello data")
+
+	require.NoError(t, ops.WriteDataFile(ctx, s, "file.asb", content))
+
+	got, err := ops.ReadFile(ctx, s, "file.asb")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestOperations_WriteMetadataFile_ReadFile(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+	content := []byte("metadata content")
+
+	require.NoError(t, ops.WriteMetadataFile(ctx, s, "metadata.yaml", content))
+
+	got, err := ops.ReadFile(ctx, s, "metadata.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+func TestOperations_ReadFile_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+
+	_, err := ops.ReadFile(t.Context(), s, "does-not-exist.asb")
+	require.Error(t, err)
+}
+
+func TestOperations_ReadFiles(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+
+	files := map[string]string{
+		"sub/aaa.keep": "content-aaa",
+		"sub/bbb.skip": "content-bbb",
+		"sub/ccc.keep": "content-ccc",
+	}
+	for name, content := range files {
+		require.NoError(t, ops.WriteDataFile(ctx, s, name, []byte(content)))
+	}
+
+	buffers, err := ops.ReadFiles(ctx, s, "sub", ".keep")
+	require.NoError(t, err)
+	require.Len(t, buffers, 2)
+
+	contents := make([]string, len(buffers))
+	for i, b := range buffers {
+		contents[i] = b.String()
+	}
+	assert.ElementsMatch(t, []string{"content-aaa", "content-ccc"}, contents)
+}
+
+func TestOperations_ReadFiles_CreateReaderError(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+
+	_, err := ops.ReadFiles(t.Context(), s, "missing-dir", "")
+	require.Error(t, err)
+}
+
+func TestOperations_ReadFileNames(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+
+	files := map[string]string{
+		"sub/aaa.keep": "content-aaa",
+		"sub/bbb.skip": "content-bbb",
+		"sub/ccc.keep": "content-ccc",
+	}
+	for name, content := range files {
+		require.NoError(t, ops.WriteDataFile(ctx, s, name, []byte(content)))
+	}
+
+	names, err := ops.ReadFileNames(ctx, s, "sub", ".keep", nil)
+	require.NoError(t, err)
+	require.Len(t, names, 2)
+
+	expectedDir := filepath.Join(s.GetPath(), "sub")
+	assert.ElementsMatch(t, []string{
+		filepath.Join(expectedDir, "aaa.keep"),
+		filepath.Join(expectedDir, "ccc.keep"),
+	}, names)
+}
+
+func TestOperations_ReadFileNames_WithFromTime(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+
+	require.NoError(t, ops.WriteDataFile(ctx, s, "sub/aaa.keep", []byte("content-aaa")))
+
+	fromTime := time.Now()
+	names, err := ops.ReadFileNames(ctx, s, "sub", ".keep", &fromTime)
+	require.NoError(t, err)
+	assert.Len(t, names, 1)
+}
+
+func TestOperations_DeleteFolder(t *testing.T) {
+	t.Parallel()
+
+	ops, s := newTestOperations(t)
+	ctx := t.Context()
+
+	require.NoError(t, ops.WriteDataFile(ctx, s, "sub/aaa.asb", []byte("content-aaa")))
+	require.NoError(t, ops.WriteDataFile(ctx, s, "sub/bbb.asb", []byte("content-bbb")))
+
+	require.NoError(t, ops.DeleteFolder(ctx, s, "sub"))
+
+	names, err := ops.ReadFileNames(ctx, s, "sub", "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, names)
+}
+
+func TestOperations_GetAccessor_Unsupported(t *testing.T) {
+	t.Parallel()
+
+	ops := NewOperations(NewLocalStorageAccessor())
+
+	_, err := ops.getAccessor(&model.S3Storage{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported storage type")
+}
+
+func TestOperations_ReadFile_UnsupportedStorage(t *testing.T) {
+	t.Parallel()
+
+	ops := NewOperations(NewLocalStorageAccessor())
+
+	_, err := ops.ReadFile(t.Context(), &model.S3Storage{}, "file.asb")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported storage type")
+}
+
+func TestOperations_UnsupportedStorage_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ops := NewOperations(NewLocalStorageAccessor())
+	unsupported := &model.S3Storage{}
+	ctx := t.Context()
+
+	t.Run("WriteDataFile", func(t *testing.T) {
+		t.Parallel()
+		err := ops.WriteDataFile(ctx, unsupported, "file.asb", []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create writer")
+	})
+
+	t.Run("WriteMetadataFile", func(t *testing.T) {
+		t.Parallel()
+		err := ops.WriteMetadataFile(ctx, unsupported, "meta.yaml", []byte("x"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create writer")
+	})
+
+	t.Run("ReadFiles", func(t *testing.T) {
+		t.Parallel()
+		_, err := ops.ReadFiles(ctx, unsupported, "sub", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create reader")
+	})
+
+	t.Run("ReadFileNames", func(t *testing.T) {
+		t.Parallel()
+		_, err := ops.ReadFileNames(ctx, unsupported, "sub", "", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to create reader")
+	})
+
+	t.Run("DeleteFolder", func(t *testing.T) {
+		t.Parallel()
+		err := ops.DeleteFolder(ctx, unsupported, "sub")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported storage type")
+	})
+}

--- a/pkg/service/storage/validator_test.go
+++ b/pkg/service/storage/validator_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNameValidator(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, newNameValidator(""))
+
+	v := newNameValidator(".asb")
+	require.NotNil(t, v)
+	assert.Equal(t, ".asb", v.filter)
+}
+
+func TestNameValidator_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		v       *nameValidator
+		path    string
+		wantErr bool
+	}{
+		{name: "nil validator allows everything", v: nil, path: "backup/data.asb", wantErr: false},
+		{name: "empty filter allows everything", v: &nameValidator{filter: ""}, path: "backup/data.asb", wantErr: false},
+		{name: "matching suffix", v: &nameValidator{filter: ".asb"}, path: "backup/data.asb", wantErr: false},
+		{name: "non-matching suffix", v: &nameValidator{filter: ".asb"}, path: "backup/data.txt", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.v.Run(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "skipped by filter")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this change do?

Adds Phase 2 coverage unit tests for the local storage layer (`pkg/service/storage/operations.go`, `local.go`, and `validator.go`). This is cherry-picked from `realmgic/test/coverage-p2-storage`; P0/P1 coverage work is already on `dev` (#607, #608).

Storage package coverage increases from ~37% to ~64%. Cloud accessor tests remain connectivity-only (deferred to integration tests per the coverage plan).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- Source branch: https://github.com/realmgic/aerospike-backup-service/tree/test/coverage-p2-storage
- Only the Phase 2 commit was applied; earlier commits on that branch (P0/P1 infra and quick-win tests) were already merged via #607 and #608.
- Fixed order-dependent assertions in `ReadFiles` and `ReadFileNames` tests (map iteration is non-deterministic in Go).

## Test plan

- [x] `go test ./pkg/service/storage/... -count=1`
- [x] `golangci-lint run ./pkg/service/storage/... --fix`


Made with [Cursor](https://cursor.com)