### PR TITLE
Test Phase 3: Add backup and restore executor unit tests

### DIFF
--- a/pkg/service/backupexecutor/backup_executor_test.go
+++ b/pkg/service/backupexecutor/backup_executor_test.go
@@ -1,0 +1,166 @@
+package backupexecutor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/backup-go"
+	"github.com/aerospike/backup-go/io/storage/options"
+	bgmocks "github.com/aerospike/backup-go/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type mockStorageWriter struct {
+	writer backup.Writer
+	err    error
+}
+
+func (m *mockStorageWriter) CreateDirWriter(
+	_ context.Context,
+	_ model.Storage,
+	_ string,
+	_ ...options.Opt,
+) (backup.Writer, error) {
+	return m.writer, m.err
+}
+
+func TestBackupExecutor_Run_GetClientError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	clientManager := aerospike.NewMockClientManager(ctrl)
+	clientManager.EXPECT().
+		GetClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("client unavailable"))
+
+	executor := NewBackupExecutor(clientManager, &mockStorageWriter{})
+	routine := testBackupRoutine()
+
+	_, err := executor.Run(
+		t.Context(),
+		routine,
+		model.TimeBounds{},
+		"test-ns",
+		"/backup/path",
+		nil,
+		slog.Default(),
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to get backup client")
+}
+
+func TestBackupExecutor_Run_CreateWriterError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	client := aerospike.NewMockClient(ctrl)
+	clientManager := aerospike.NewMockClientManager(ctrl)
+	clientManager.EXPECT().
+		GetClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(client, nil)
+	clientManager.EXPECT().Close(client)
+
+	executor := NewBackupExecutor(clientManager, &mockStorageWriter{
+		err: errors.New("writer failed"),
+	})
+
+	_, err := executor.Run(
+		t.Context(),
+		testBackupRoutine(),
+		model.TimeBounds{},
+		"test-ns",
+		"/backup/path",
+		nil,
+		slog.Default(),
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create backup writer")
+}
+
+func TestBackupExecutor_Run_ScanBackupUsesScanPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	writer := bgmocks.NewMockWriter(t)
+	client := aerospike.NewMockClient(ctrl)
+	clientManager := aerospike.NewMockClientManager(ctrl)
+
+	clientManager.EXPECT().
+		GetClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(client, nil)
+	clientManager.EXPECT().Close(client)
+
+	client.EXPECT().
+		Backup(gomock.Any(), gomock.Any(), writer, gomock.Nil()).
+		Return(nil, errors.New("backup start failed"))
+
+	executor := NewBackupExecutor(clientManager, &mockStorageWriter{writer: writer})
+
+	_, err := executor.Run(
+		t.Context(),
+		testBackupRoutine(),
+		model.TimeBounds{},
+		"test-ns",
+		"/backup/path",
+		nil,
+		slog.Default(),
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to start scan backup")
+}
+
+func TestRunScanBackup_ConfigError(t *testing.T) {
+	client := aerospike.NewMockClient(gomock.NewController(t))
+
+	_, err := runScanBackup(
+		t.Context(),
+		client,
+		&model.BackupRoutine{
+			BackupPolicy:     &model.BackupPolicy{},
+			SourceCluster:    &model.AerospikeCluster{},
+			FilterExpression: "invalid-expression",
+		},
+		model.TimeBounds{},
+		"test-ns",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to make backup config")
+}
+
+func TestRunScanBackup_BackupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := aerospike.NewMockClient(ctrl)
+
+	client.EXPECT().
+		Backup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(nil, errors.New("backup failed"))
+
+	_, err := runScanBackup(
+		t.Context(),
+		client,
+		testBackupRoutine(),
+		model.TimeBounds{},
+		"test-ns",
+		nil,
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to start scan backup")
+}
+
+func testBackupRoutine() *model.BackupRoutine {
+	return &model.BackupRoutine{
+		BackupPolicy:  &model.BackupPolicy{},
+		IntervalCron:  "@daily",
+		SourceCluster: &model.AerospikeCluster{},
+		Storage:       &model.LocalStorage{Path: "/tmp/backups"},
+	}
+}

--- a/pkg/service/backupexecutor/backup_executor_test.go
+++ b/pkg/service/backupexecutor/backup_executor_test.go
@@ -19,6 +19,7 @@ import (
 type mockStorageWriter struct {
 	writer backup.Writer
 	err    error
+	calls  int
 }
 
 func (m *mockStorageWriter) CreateDirWriter(
@@ -27,6 +28,7 @@ func (m *mockStorageWriter) CreateDirWriter(
 	_ string,
 	_ ...options.Opt,
 ) (backup.Writer, error) {
+	m.calls++
 	return m.writer, m.err
 }
 
@@ -83,7 +85,7 @@ func TestBackupExecutor_Run_CreateWriterError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to create backup writer")
 }
 
-func TestBackupExecutor_Run_ScanBackupUsesScanPath(t *testing.T) {
+func TestBackupExecutor_Run_BackupStartError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	writer := bgmocks.NewMockWriter(t)
@@ -115,8 +117,44 @@ func TestBackupExecutor_Run_ScanBackupUsesScanPath(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to start scan backup")
 }
 
-func TestRunScanBackup_ConfigError(t *testing.T) {
-	client := aerospike.NewMockClient(gomock.NewController(t))
+func TestBackupExecutor_Run_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	writer := bgmocks.NewMockWriter(t)
+	client := aerospike.NewMockClient(ctrl)
+	clientManager := aerospike.NewMockClientManager(ctrl)
+
+	clientManager.EXPECT().
+		GetClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(client, nil)
+
+	client.EXPECT().
+		Backup(gomock.Any(), gomock.Any(), writer, gomock.Nil()).
+		Return(nil, nil)
+
+	operations := &mockStorageWriter{writer: writer}
+	executor := NewBackupExecutor(clientManager, operations)
+
+	handler, err := executor.Run(
+		t.Context(),
+		testBackupRoutine(),
+		model.TimeBounds{},
+		"test-ns",
+		"/backup/path",
+		nil,
+		slog.Default(),
+	)
+	require.NoError(t, err)
+
+	wrapped, ok := handler.(*closeOnWaitBackupHandler)
+	require.True(t, ok)
+	assert.Equal(t, client, wrapped.client)
+	assert.Equal(t, 1, operations.calls)
+}
+
+func TestRunBackup_ConfigError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := aerospike.NewMockClient(ctrl)
 
 	_, err := runScanBackup(
 		t.Context(),
@@ -135,7 +173,7 @@ func TestRunScanBackup_ConfigError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to make backup config")
 }
 
-func TestRunScanBackup_BackupError(t *testing.T) {
+func TestRunBackup_BackupStartError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := aerospike.NewMockClient(ctrl)
 

--- a/pkg/service/backupexecutor/backup_handler_test.go
+++ b/pkg/service/backupexecutor/backup_handler_test.go
@@ -1,0 +1,41 @@
+package backupexecutor
+
+import (
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/backup-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCloseOnWaitBackupHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	inner := NewMockBackupHandler(ctrl)
+	client := aerospike.NewMockClient(ctrl)
+	clientManager := aerospike.NewMockClientManager(ctrl)
+
+	stats := models.NewBackupStats()
+	metrics := models.NewMetrics(1, 2, 42, 10)
+
+	inner.EXPECT().Wait(gomock.Any()).Return(nil)
+	inner.EXPECT().GetStats().Return(stats)
+	inner.EXPECT().GetMetrics().Return(metrics)
+	clientManager.EXPECT().Close(client).Times(1)
+
+	handler := &closeOnWaitBackupHandler{
+		inner:         inner,
+		client:        client,
+		clientManager: clientManager,
+	}
+
+	require.NoError(t, handler.Wait(t.Context()))
+	assert.Equal(t, stats, handler.GetStats())
+	assert.Equal(t, metrics, handler.GetMetrics())
+
+	// Close is invoked exactly once even if Wait is called again.
+	inner.EXPECT().Wait(gomock.Any()).Return(nil)
+	require.NoError(t, handler.Wait(t.Context()))
+}

--- a/pkg/service/backupexecutor/backup_handler_test.go
+++ b/pkg/service/backupexecutor/backup_handler_test.go
@@ -1,6 +1,7 @@
 package backupexecutor
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
@@ -38,4 +39,24 @@ func TestCloseOnWaitBackupHandler(t *testing.T) {
 	// Close is invoked exactly once even if Wait is called again.
 	inner.EXPECT().Wait(gomock.Any()).Return(nil)
 	require.NoError(t, handler.Wait(t.Context()))
+}
+
+func TestCloseOnWaitBackupHandler_WaitErrorStillClosesClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	inner := NewMockBackupHandler(ctrl)
+	client := aerospike.NewMockClient(ctrl)
+	clientManager := aerospike.NewMockClientManager(ctrl)
+
+	waitErr := errors.New("backup wait failed")
+	inner.EXPECT().Wait(gomock.Any()).Return(waitErr)
+	clientManager.EXPECT().Close(client).Times(1)
+
+	handler := &closeOnWaitBackupHandler{
+		inner:         inner,
+		client:        client,
+		clientManager: clientManager,
+	}
+
+	require.ErrorIs(t, handler.Wait(t.Context()), waitErr)
 }

--- a/pkg/service/restoreexecutor/restore_executor_test.go
+++ b/pkg/service/restoreexecutor/restore_executor_test.go
@@ -1,0 +1,121 @@
+package restoreexecutor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/backup-go"
+	"github.com/aerospike/backup-go/io/storage/common"
+	"github.com/aerospike/backup-go/io/storage/options"
+	bgmocks "github.com/aerospike/backup-go/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+type mockStorageReader struct {
+	reader backup.StreamingReader
+	err    error
+	calls  int
+}
+
+func (m *mockStorageReader) CreateDirReader(
+	_ context.Context,
+	_ model.Storage,
+	_ string,
+	_ ...options.Opt,
+) (backup.StreamingReader, error) {
+	m.calls++
+	return m.reader, m.err
+}
+
+func TestRestoreExecutor_Run_ScanSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	reader := bgmocks.NewMockStreamingReader(t)
+	restoreHandler := NewMockRestoreHandler(ctrl)
+
+	client := aerospike.NewMockClient(ctrl)
+	client.EXPECT().
+		Restore(gomock.Any(), gomock.Any(), reader).
+		Return(restoreHandler, nil)
+
+	operations := &mockStorageReader{reader: reader}
+	executor := NewRestoreExecutor(operations)
+
+	handler, err := executor.Run(t.Context(), client, testRestoreRequest())
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+	assert.Equal(t, 1, operations.calls)
+}
+
+func TestRestoreExecutor_Run_FatalError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	reader := bgmocks.NewMockStreamingReader(t)
+	client := aerospike.NewMockClient(ctrl)
+	client.EXPECT().
+		Restore(gomock.Any(), gomock.Any(), reader).
+		Return(nil, errors.New("restore failed"))
+
+	operations := &mockStorageReader{reader: reader}
+	executor := NewRestoreExecutor(operations)
+
+	_, err := executor.Run(t.Context(), client, testRestoreRequest())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "restore failed")
+}
+
+func TestRestoreExecutor_Run_EmptyStorage(t *testing.T) {
+	operations := &mockStorageReader{err: common.ErrEmptyStorage}
+	executor := NewRestoreExecutor(operations)
+
+	client := aerospike.NewMockClient(gomock.NewController(t))
+
+	_, err := executor.Run(t.Context(), client, testRestoreRequest())
+	require.Error(t, err)
+	require.ErrorIs(t, err, common.ErrEmptyStorage)
+	assert.Equal(t, 1, operations.calls)
+}
+
+func TestRunScanRestore_CreateReaderError(t *testing.T) {
+	client := aerospike.NewMockClient(gomock.NewController(t))
+	operations := &mockStorageReader{err: errors.New("reader failed")}
+
+	_, err := runScanRestore(t.Context(), client, testRestoreRequest(), operations)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create backup reader")
+}
+
+func TestRunScanRestore_RestoreError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	reader := bgmocks.NewMockStreamingReader(t)
+	client := aerospike.NewMockClient(ctrl)
+	client.EXPECT().
+		Restore(gomock.Any(), gomock.Any(), reader).
+		Return(nil, errors.New("restore failed"))
+
+	operations := &mockStorageReader{reader: reader}
+
+	_, err := runScanRestore(t.Context(), client, testRestoreRequest(), operations)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to start restore")
+}
+
+func testRestoreRequest() *model.RestoreRequest {
+	source := "source-ns"
+	dest := "dest-ns"
+	return &model.RestoreRequest{
+		Policy: model.RestorePolicy{
+			Namespace: &model.RestoreNamespace{
+				Source:      &source,
+				Destination: &dest,
+			},
+		},
+		SourceStorage: &model.LocalStorage{Path: "/tmp/backups"},
+	}
+}

--- a/pkg/service/restoreexecutor/restore_executor_test.go
+++ b/pkg/service/restoreexecutor/restore_executor_test.go
@@ -32,7 +32,7 @@ func (m *mockStorageReader) CreateDirReader(
 	return m.reader, m.err
 }
 
-func TestRestoreExecutor_Run_ScanSuccess(t *testing.T) {
+func TestRestoreExecutor_Run_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	reader := bgmocks.NewMockStreamingReader(t)
@@ -49,10 +49,11 @@ func TestRestoreExecutor_Run_ScanSuccess(t *testing.T) {
 	handler, err := executor.Run(t.Context(), client, testRestoreRequest())
 	require.NoError(t, err)
 	require.NotNil(t, handler)
+	assert.Same(t, restoreHandler, handler)
 	assert.Equal(t, 1, operations.calls)
 }
 
-func TestRestoreExecutor_Run_FatalError(t *testing.T) {
+func TestRestoreExecutor_Run_RestoreStartError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	reader := bgmocks.NewMockStreamingReader(t)
@@ -70,10 +71,12 @@ func TestRestoreExecutor_Run_FatalError(t *testing.T) {
 }
 
 func TestRestoreExecutor_Run_EmptyStorage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
 	operations := &mockStorageReader{err: common.ErrEmptyStorage}
 	executor := NewRestoreExecutor(operations)
 
-	client := aerospike.NewMockClient(gomock.NewController(t))
+	client := aerospike.NewMockClient(ctrl)
 
 	_, err := executor.Run(t.Context(), client, testRestoreRequest())
 	require.Error(t, err)
@@ -81,8 +84,9 @@ func TestRestoreExecutor_Run_EmptyStorage(t *testing.T) {
 	assert.Equal(t, 1, operations.calls)
 }
 
-func TestRunScanRestore_CreateReaderError(t *testing.T) {
-	client := aerospike.NewMockClient(gomock.NewController(t))
+func TestRunRestore_CreateReaderError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := aerospike.NewMockClient(ctrl)
 	operations := &mockStorageReader{err: errors.New("reader failed")}
 
 	_, err := runScanRestore(t.Context(), client, testRestoreRequest(), operations)
@@ -90,7 +94,7 @@ func TestRunScanRestore_CreateReaderError(t *testing.T) {
 	assert.ErrorContains(t, err, "failed to create backup reader")
 }
 
-func TestRunScanRestore_RestoreError(t *testing.T) {
+func TestRunRestore_RestoreStartError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	reader := bgmocks.NewMockStreamingReader(t)

--- a/pkg/service/restoreexecutor/scan_test.go
+++ b/pkg/service/restoreexecutor/scan_test.go
@@ -95,20 +95,79 @@ func TestMakeRestoreConfig(t *testing.T) {
 }
 
 func TestMakeWritePolicy(t *testing.T) {
-	noGeneration := true
+	trueVal := true
+	falseVal := false
+	socketTimeout := 5 * time.Minute
 	totalTimeout := 30 * time.Second
-	restoreRequest := &model.RestoreRequest{
-		Policy: model.RestorePolicy{
-			NoGeneration: &noGeneration,
-			TotalTimeout: &totalTimeout,
+
+	tests := []struct {
+		name   string
+		policy model.RestorePolicy
+		assert func(t *testing.T, writePolicy *as.WritePolicy)
+	}{
+		{
+			name:   "defaults",
+			policy: model.RestorePolicy{},
+			assert: func(t *testing.T, writePolicy *as.WritePolicy) {
+				t.Helper()
+				assert.True(t, writePolicy.SendKey)
+				assert.Equal(t, as.EXPECT_GEN_GT, writePolicy.GenerationPolicy)
+				assert.Equal(t, as.UPDATE, writePolicy.RecordExistsAction)
+				assert.Equal(t, model.DefaultSocketTimeout, writePolicy.SocketTimeout)
+			},
+		},
+		{
+			name: "no generation and total timeout",
+			policy: model.RestorePolicy{
+				NoGeneration: &trueVal,
+				TotalTimeout: &totalTimeout,
+			},
+			assert: func(t *testing.T, writePolicy *as.WritePolicy) {
+				t.Helper()
+				assert.Equal(t, as.NONE, writePolicy.GenerationPolicy)
+				assert.Equal(t, totalTimeout, writePolicy.TotalTimeout)
+			},
+		},
+		{
+			name: "replace sets record exists action",
+			policy: model.RestorePolicy{
+				Replace: &trueVal,
+			},
+			assert: func(t *testing.T, writePolicy *as.WritePolicy) {
+				t.Helper()
+				assert.Equal(t, as.REPLACE, writePolicy.RecordExistsAction)
+			},
+		},
+		{
+			name: "unique sets record exists action",
+			policy: model.RestorePolicy{
+				Replace: &falseVal,
+				Unique:  &trueVal,
+			},
+			assert: func(t *testing.T, writePolicy *as.WritePolicy) {
+				t.Helper()
+				assert.Equal(t, as.CREATE_ONLY, writePolicy.RecordExistsAction)
+			},
+		},
+		{
+			name: "custom socket timeout",
+			policy: model.RestorePolicy{
+				SocketTimeout: &socketTimeout,
+			},
+			assert: func(t *testing.T, writePolicy *as.WritePolicy) {
+				t.Helper()
+				assert.Equal(t, socketTimeout, writePolicy.SocketTimeout)
+			},
 		},
 	}
 
-	writePolicy := makeWritePolicy(restoreRequest)
-
-	require.NotNil(t, writePolicy)
-	assert.Equal(t, as.NONE, writePolicy.GenerationPolicy)
-	assert.Equal(t, totalTimeout, writePolicy.TotalTimeout)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writePolicy := makeWritePolicy(&model.RestoreRequest{Policy: tt.policy})
+			require.NotNil(t, writePolicy)
+			tt.assert(t, writePolicy)
+		})
+	}
 }
 
 func TestRecordExistsAction(t *testing.T) {

--- a/pkg/service/restoreexecutor/scan_test.go
+++ b/pkg/service/restoreexecutor/scan_test.go
@@ -2,6 +2,7 @@ package restoreexecutor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
@@ -91,6 +92,23 @@ func TestMakeRestoreConfig(t *testing.T) {
 	assert.Equal(t, 2000, *config.SecretAgentConfig.TimeoutMillisecond)
 	assert.Equal(t, "ca-cert", *config.SecretAgentConfig.CaFile)
 	assert.True(t, *config.SecretAgentConfig.IsBase64)
+}
+
+func TestMakeWritePolicy(t *testing.T) {
+	noGeneration := true
+	totalTimeout := 30 * time.Second
+	restoreRequest := &model.RestoreRequest{
+		Policy: model.RestorePolicy{
+			NoGeneration: &noGeneration,
+			TotalTimeout: &totalTimeout,
+		},
+	}
+
+	writePolicy := makeWritePolicy(restoreRequest)
+
+	require.NotNil(t, writePolicy)
+	assert.Equal(t, as.NONE, writePolicy.GenerationPolicy)
+	assert.Equal(t, totalTimeout, writePolicy.TotalTimeout)
 }
 
 func TestRecordExistsAction(t *testing.T) {


### PR DESCRIPTION
## What does this change do?

Adds Phase 3 coverage unit tests for backup and restore executors:

- `pkg/service/backupexecutor/` — executor error paths and `closeOnWaitBackupHandler`
- `pkg/service/restoreexecutor/` — executor error paths, `makeWritePolicy`, and related config helpers

Cherry-picked from `realmgic/test/coverage-p3-executors`; P0–P2 coverage work is already on `dev` (#607, #608, #611).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- Source branch: https://github.com/realmgic/aerospike-backup-service/tree/test/coverage-p3-executors
- Adapted for current `dev` after XDR removal (BKRS-328):
  - `NewDefaultBackupExecutor` → `NewBackupExecutor`
  - `NewRestore` → `NewRestoreExecutor`
  - Removed `CombinedBackupHandler` / `CombinedRestoreHandler` tests (types no longer exist)
  - Restore executor now uses a single `CreateDirReader` call (no multi-reader empty-storage loop)

## Test plan

- [x] `go test ./pkg/service/backupexecutor/... ./pkg/service/restoreexecutor/... -count=1`
- [x] `golangci-lint run ./pkg/service/backupexecutor/... ./pkg/service/restoreexecutor/... --fix`


Made with [Cursor](https://cursor.com)