### PR TITLE
Test Phase 4: Add orchestration layer unit tests

### DIFF
--- a/pkg/service/backend_filter_test.go
+++ b/pkg/service/backend_filter_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoutineFilter_String(t *testing.T) {
+	routine := &model.BackupRoutine{
+		Name:    "routine-1",
+		Storage: &model.LocalStorage{Path: "/data"},
+	}
+
+	str := NewFullBackupFilter(routine).Last().String()
+
+	assert.Contains(t, str, "routine: routine-1")
+	assert.Contains(t, str, "storage: LocalStorage(Path: /data)")
+	assert.Contains(t, str, "type: full")
+	assert.Contains(t, str, "last: true")
+	assert.Contains(t, str, "timebounds: NA")
+}
+
+func TestPathFilter_WithFromTimeAndToTime(t *testing.T) {
+	storage := &model.LocalStorage{Path: "/data"}
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	filter := NewPathFilter("some/path", storage).WithFromTime(from).WithToTime(to)
+
+	require.NotNil(t, filter.FromTime)
+	require.NotNil(t, filter.ToTime)
+	assert.Equal(t, from, *filter.FromTime)
+	assert.Equal(t, to, *filter.ToTime)
+	assert.Equal(t, from, *filter.timeBounds().FromTime)
+	assert.Equal(t, to, *filter.timeBounds().ToTime)
+}
+
+func TestPathFilter_WithTimeBounds(t *testing.T) {
+	storage := &model.LocalStorage{Path: "/data"}
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+	bounds := model.TimeBounds{FromTime: &from, ToTime: &to}
+
+	filter := NewPathFilter("some/path", storage).WithTimeBounds(bounds)
+
+	assert.Equal(t, &from, filter.FromTime)
+	assert.Equal(t, &to, filter.ToTime)
+}
+
+func TestPathFilter_String(t *testing.T) {
+	storage := &model.LocalStorage{Path: "/data"}
+	filter := NewPathFilter("some/path", storage)
+
+	str := filter.String()
+
+	assert.Contains(t, str, "path: some/path")
+	assert.Contains(t, str, "storage: LocalStorage(Path: /data)")
+	assert.Contains(t, str, "timebounds: NA")
+}
+
+func TestPathFilter_String_WithBounds(t *testing.T) {
+	storage := &model.LocalStorage{Path: "/data"}
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	filter := NewPathFilter("some/path", storage).WithFromTime(from)
+
+	str := filter.String()
+
+	assert.Contains(t, str, "path: some/path")
+	assert.NotContains(t, str, "timebounds: NA")
+}

--- a/pkg/service/backup_completion_test.go
+++ b/pkg/service/backup_completion_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func TestBackupCompletionHandler_OnSuccess_Incremental(t *testing.T) {
 
 	handler := NewBackupCompletionHandler(registry, retention, clusterWriter)
 	handler.OnSuccess(
-		context.Background(),
+		t.Context(),
 		routine,
 		model.BackupTypeIncremental,
 		time.Now(),
@@ -62,7 +63,7 @@ func TestBackupCompletionHandler_OnSuccess_FullRunsRetentionAndClusterConfig(t *
 		},
 	}
 	timestamp := time.Now()
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := slog.New(slog.DiscardHandler)
 
 	registry := NewMockRunningBackupsRegistry(ctrl)
@@ -111,7 +112,7 @@ func TestBackupCompletionHandler_OnSuccess_FullSkipsClusterConfigWhenDisabled(t 
 		Name:         "routine-1",
 		BackupPolicy: &model.BackupPolicy{WithClusterConfig: ptr.Of(false)},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	registry := NewMockRunningBackupsRegistry(ctrl)
 	retention := NewMockRetentionManager(ctrl)
@@ -152,7 +153,7 @@ func TestBackupCompletionHandler_OnSuccess_LogsRetentionFailure(t *testing.T) {
 		Name:         "routine-1",
 		BackupPolicy: &model.BackupPolicy{},
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	capture := &slogCaptureHandler{}
 	logger := slog.New(capture)
 
@@ -199,10 +200,5 @@ func (h *slogCaptureHandler) WithGroup(_ string) slog.Handler      { return h }
 func (h *slogCaptureHandler) containsMessage(msg string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	for _, m := range h.messages {
-		if m == msg {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(h.messages, msg)
 }

--- a/pkg/service/backup_completion_test.go
+++ b/pkg/service/backup_completion_test.go
@@ -194,7 +194,7 @@ func (h *slogCaptureHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *slogCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *slogCaptureHandler) WithGroup(_ string) slog.Handler    { return h }
+func (h *slogCaptureHandler) WithGroup(_ string) slog.Handler      { return h }
 
 func (h *slogCaptureHandler) containsMessage(msg string) bool {
 	h.mu.Lock()

--- a/pkg/service/backup_completion_test.go
+++ b/pkg/service/backup_completion_test.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"slices"
-	"sync"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,14 +32,15 @@ func TestBackupCompletionHandler_OnSuccess_Incremental(t *testing.T) {
 
 	routine := &model.BackupRoutine{Name: "routine-1"}
 	registry := NewMockRunningBackupsRegistry(ctrl)
-	retention := NewMockRetentionManager(ctrl)
-	clusterWriter := NewMockClusterConfigWriter(ctrl)
-
 	recorded := make(chan struct{})
 	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeIncremental).
 		Do(func(*model.BackupRoutine, model.BackupType) { close(recorded) })
 
-	handler := NewBackupCompletionHandler(registry, retention, clusterWriter)
+	handler := NewBackupCompletionHandler(
+		registry,
+		NewMockRetentionManager(ctrl),
+		NewMockClusterConfigWriter(ctrl),
+	)
 	handler.OnSuccess(
 		t.Context(),
 		routine,
@@ -49,7 +49,7 @@ func TestBackupCompletionHandler_OnSuccess_Incremental(t *testing.T) {
 		slog.New(slog.DiscardHandler),
 	)
 
-	<-recorded
+	waitAsyncDone(t, recorded, "successful incremental backup recorded")
 }
 
 func TestBackupCompletionHandler_OnSuccess_FullRunsRetentionAndClusterConfig(t *testing.T) {
@@ -64,44 +64,34 @@ func TestBackupCompletionHandler_OnSuccess_FullRunsRetentionAndClusterConfig(t *
 	}
 	timestamp := time.Now()
 	ctx := t.Context()
-	logger := slog.New(slog.DiscardHandler)
 
 	registry := NewMockRunningBackupsRegistry(ctrl)
 	retention := NewMockRetentionManager(ctrl)
 	clusterWriter := NewMockClusterConfigWriter(ctrl)
 
-	var wg sync.WaitGroup
-	wg.Add(3)
+	recorded := make(chan struct{})
+	retentionDone := make(chan struct{})
+	clusterConfigDone := make(chan struct{})
 
 	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).
-		Do(func(*model.BackupRoutine, model.BackupType) { wg.Done() })
-	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
-		func(context.Context, *model.BackupRoutine) error {
-			wg.Done()
+		Do(func(*model.BackupRoutine, model.BackupType) { close(recorded) })
+	retention.EXPECT().deleteOldBackups(ctx, routine).
+		DoAndReturn(func(context.Context, *model.BackupRoutine) error {
+			close(retentionDone)
 			return nil
-		},
-	)
-	clusterWriter.EXPECT().Write(ctx, routine, timestamp).DoAndReturn(
-		func(context.Context, *model.BackupRoutine, time.Time) error {
-			wg.Done()
+		})
+	clusterWriter.EXPECT().Write(ctx, routine, timestamp).
+		DoAndReturn(func(context.Context, *model.BackupRoutine, time.Time) error {
+			close(clusterConfigDone)
 			return nil
-		},
-	)
+		})
 
 	handler := NewBackupCompletionHandler(registry, retention, clusterWriter)
-	handler.OnSuccess(ctx, routine, model.BackupTypeFull, timestamp, logger)
+	handler.OnSuccess(ctx, routine, model.BackupTypeFull, timestamp, slog.New(slog.DiscardHandler))
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for full backup completion side effects")
-	}
+	waitAsyncDone(t, recorded, "successful full backup recorded")
+	waitAsyncDone(t, retentionDone, "retention cleanup")
+	waitAsyncDone(t, clusterConfigDone, "cluster config backup")
 }
 
 func TestBackupCompletionHandler_OnSuccess_FullSkipsClusterConfigWhenDisabled(t *testing.T) {
@@ -117,32 +107,22 @@ func TestBackupCompletionHandler_OnSuccess_FullSkipsClusterConfigWhenDisabled(t 
 	registry := NewMockRunningBackupsRegistry(ctrl)
 	retention := NewMockRetentionManager(ctrl)
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	recorded := make(chan struct{})
+	retentionDone := make(chan struct{})
 
 	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).
-		Do(func(*model.BackupRoutine, model.BackupType) { wg.Done() })
-	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
-		func(context.Context, *model.BackupRoutine) error {
-			wg.Done()
+		Do(func(*model.BackupRoutine, model.BackupType) { close(recorded) })
+	retention.EXPECT().deleteOldBackups(ctx, routine).
+		DoAndReturn(func(context.Context, *model.BackupRoutine) error {
+			close(retentionDone)
 			return nil
-		},
-	)
+		})
 
 	handler := NewBackupCompletionHandler(registry, retention, NewMockClusterConfigWriter(ctrl))
 	handler.OnSuccess(ctx, routine, model.BackupTypeFull, time.Now(), slog.New(slog.DiscardHandler))
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for retention cleanup")
-	}
+	waitAsyncDone(t, recorded, "successful full backup recorded")
+	waitAsyncDone(t, retentionDone, "retention cleanup")
 }
 
 func TestBackupCompletionHandler_OnSuccess_LogsRetentionFailure(t *testing.T) {
@@ -154,51 +134,19 @@ func TestBackupCompletionHandler_OnSuccess_LogsRetentionFailure(t *testing.T) {
 		BackupPolicy: &model.BackupPolicy{},
 	}
 	ctx := t.Context()
-	capture := &slogCaptureHandler{}
-	logger := slog.New(capture)
+	logger, logBuf := newTestLogger(t)
 
 	registry := NewMockRunningBackupsRegistry(ctrl)
 	retention := NewMockRetentionManager(ctrl)
 
 	retentionErr := errors.New("retention failed")
-	retentionDone := make(chan struct{})
-
 	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).AnyTimes()
-	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
-		func(context.Context, *model.BackupRoutine) error {
-			close(retentionDone)
-			return retentionErr
-		},
-	)
+	retention.EXPECT().deleteOldBackups(ctx, routine).Return(retentionErr)
 
 	handler := NewBackupCompletionHandler(registry, retention, nil)
 	handler.OnSuccess(ctx, routine, model.BackupTypeFull, time.Now(), logger)
 
-	<-retentionDone
 	require.Eventually(t, func() bool {
-		return capture.containsMessage("Failed to clean up old backups")
-	}, time.Second, 10*time.Millisecond)
-}
-
-type slogCaptureHandler struct {
-	mu       sync.Mutex
-	messages []string
-}
-
-func (h *slogCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
-
-func (h *slogCaptureHandler) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.messages = append(h.messages, r.Message)
-	return nil
-}
-
-func (h *slogCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *slogCaptureHandler) WithGroup(_ string) slog.Handler      { return h }
-
-func (h *slogCaptureHandler) containsMessage(msg string) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	return slices.Contains(h.messages, msg)
+		return strings.Contains(logBuf.String(), "Failed to clean up old backups")
+	}, asyncWaitTimeout, 10*time.Millisecond)
 }

--- a/pkg/service/backup_completion_test.go
+++ b/pkg/service/backup_completion_test.go
@@ -1,0 +1,208 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestBackupCompletionHandler_OnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1"}
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	registry.EXPECT().clearFailedBackup("routine-1", model.BackupTypeFull)
+
+	handler := NewBackupCompletionHandler(registry, nil, nil)
+	handler.OnFailure(routine, model.BackupTypeFull)
+}
+
+func TestBackupCompletionHandler_OnSuccess_Incremental(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1"}
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	retention := NewMockRetentionManager(ctrl)
+	clusterWriter := NewMockClusterConfigWriter(ctrl)
+
+	recorded := make(chan struct{})
+	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeIncremental).
+		Do(func(*model.BackupRoutine, model.BackupType) { close(recorded) })
+
+	handler := NewBackupCompletionHandler(registry, retention, clusterWriter)
+	handler.OnSuccess(
+		context.Background(),
+		routine,
+		model.BackupTypeIncremental,
+		time.Now(),
+		slog.New(slog.DiscardHandler),
+	)
+
+	<-recorded
+}
+
+func TestBackupCompletionHandler_OnSuccess_FullRunsRetentionAndClusterConfig(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{
+		Name: "routine-1",
+		BackupPolicy: &model.BackupPolicy{
+			WithClusterConfig: ptr.Of(true),
+		},
+	}
+	timestamp := time.Now()
+	ctx := context.Background()
+	logger := slog.New(slog.DiscardHandler)
+
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	retention := NewMockRetentionManager(ctrl)
+	clusterWriter := NewMockClusterConfigWriter(ctrl)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).
+		Do(func(*model.BackupRoutine, model.BackupType) { wg.Done() })
+	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
+		func(context.Context, *model.BackupRoutine) error {
+			wg.Done()
+			return nil
+		},
+	)
+	clusterWriter.EXPECT().Write(ctx, routine, timestamp).DoAndReturn(
+		func(context.Context, *model.BackupRoutine, time.Time) error {
+			wg.Done()
+			return nil
+		},
+	)
+
+	handler := NewBackupCompletionHandler(registry, retention, clusterWriter)
+	handler.OnSuccess(ctx, routine, model.BackupTypeFull, timestamp, logger)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for full backup completion side effects")
+	}
+}
+
+func TestBackupCompletionHandler_OnSuccess_FullSkipsClusterConfigWhenDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{
+		Name:         "routine-1",
+		BackupPolicy: &model.BackupPolicy{WithClusterConfig: ptr.Of(false)},
+	}
+	ctx := context.Background()
+
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	retention := NewMockRetentionManager(ctrl)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).
+		Do(func(*model.BackupRoutine, model.BackupType) { wg.Done() })
+	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
+		func(context.Context, *model.BackupRoutine) error {
+			wg.Done()
+			return nil
+		},
+	)
+
+	handler := NewBackupCompletionHandler(registry, retention, NewMockClusterConfigWriter(ctrl))
+	handler.OnSuccess(ctx, routine, model.BackupTypeFull, time.Now(), slog.New(slog.DiscardHandler))
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retention cleanup")
+	}
+}
+
+func TestBackupCompletionHandler_OnSuccess_LogsRetentionFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{
+		Name:         "routine-1",
+		BackupPolicy: &model.BackupPolicy{},
+	}
+	ctx := context.Background()
+	capture := &slogCaptureHandler{}
+	logger := slog.New(capture)
+
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	retention := NewMockRetentionManager(ctrl)
+
+	retentionErr := errors.New("retention failed")
+	retentionDone := make(chan struct{})
+
+	registry.EXPECT().recordSuccessfulBackup(routine, model.BackupTypeFull).AnyTimes()
+	retention.EXPECT().deleteOldBackups(ctx, routine).DoAndReturn(
+		func(context.Context, *model.BackupRoutine) error {
+			close(retentionDone)
+			return retentionErr
+		},
+	)
+
+	handler := NewBackupCompletionHandler(registry, retention, nil)
+	handler.OnSuccess(ctx, routine, model.BackupTypeFull, time.Now(), logger)
+
+	<-retentionDone
+	require.Eventually(t, func() bool {
+		return capture.containsMessage("Failed to clean up old backups")
+	}, time.Second, 10*time.Millisecond)
+}
+
+type slogCaptureHandler struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (h *slogCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *slogCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.messages = append(h.messages, r.Message)
+	return nil
+}
+
+func (h *slogCaptureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *slogCaptureHandler) WithGroup(_ string) slog.Handler    { return h }
+
+func (h *slogCaptureHandler) containsMessage(msg string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, m := range h.messages {
+		if m == msg {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/service/backup_reporter_test.go
+++ b/pkg/service/backup_reporter_test.go
@@ -80,8 +80,7 @@ func TestBackupReporter_Report_DeadlineExceeded(t *testing.T) {
 
 func TestBackupReporter_Report_GenericFailure(t *testing.T) {
 	reporter := NewBackupReporter()
-	capture := &slogCaptureHandler{}
-	logger := slog.New(capture)
+	logger, logBuf := newTestLogger(t)
 
 	before := backupEventCount(t)
 	reporter.Report(
@@ -93,15 +92,12 @@ func TestBackupReporter_Report_GenericFailure(t *testing.T) {
 		logger,
 	)
 	require.Equal(t, before+1, backupEventCount(t))
-	require.Eventually(t, func() bool {
-		return capture.containsMessage("full backup failed")
-	}, time.Second, 10*time.Millisecond)
+	require.Contains(t, logBuf.String(), "full backup failed")
 }
 
 func TestBackupReporter_Report_AerospikeFailure(t *testing.T) {
 	reporter := NewBackupReporter()
-	capture := &slogCaptureHandler{}
-	logger := slog.New(capture)
+	logger, logBuf := newTestLogger(t)
 
 	aerr := &as.AerospikeError{ResultCode: astypes.KEY_NOT_FOUND_ERROR}
 	before := backupEventCount(t)
@@ -114,9 +110,7 @@ func TestBackupReporter_Report_AerospikeFailure(t *testing.T) {
 		logger,
 	)
 	require.Equal(t, before+1, backupEventCount(t))
-	require.Eventually(t, func() bool {
-		return capture.containsMessage("incremental backup failed due to Aerospike error")
-	}, time.Second, 10*time.Millisecond)
+	require.Contains(t, logBuf.String(), "incremental backup failed due to Aerospike error")
 }
 
 func backupEventCount(t *testing.T) int {

--- a/pkg/service/backup_reporter_test.go
+++ b/pkg/service/backup_reporter_test.go
@@ -1,0 +1,127 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	astypes "github.com/aerospike/aerospike-client-go/v8/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupReporter_Report_Success(t *testing.T) {
+	reporter := NewBackupReporter()
+	start := time.Now()
+	duration := 2 * time.Minute
+
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-success",
+		model.BackupTypeFull,
+		start,
+		duration,
+		nil,
+		slog.New(slog.DiscardHandler),
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+}
+
+func TestBackupReporter_Report_Skipped(t *testing.T) {
+	reporter := NewBackupReporter()
+
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-skip",
+		model.BackupTypeIncremental,
+		time.Now(),
+		time.Minute,
+		fmt.Errorf("wrapped: %w", errBackupSkipped),
+		slog.New(slog.DiscardHandler),
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+}
+
+func TestBackupReporter_Report_Canceled(t *testing.T) {
+	reporter := NewBackupReporter()
+
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-cancel",
+		model.BackupTypeFull,
+		time.Now(),
+		30*time.Second,
+		context.Canceled,
+		slog.New(slog.DiscardHandler),
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+}
+
+func TestBackupReporter_Report_DeadlineExceeded(t *testing.T) {
+	reporter := NewBackupReporter()
+
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-deadline",
+		model.BackupTypeFull,
+		time.Now(),
+		30*time.Second,
+		context.DeadlineExceeded,
+		slog.New(slog.DiscardHandler),
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+}
+
+func TestBackupReporter_Report_GenericFailure(t *testing.T) {
+	reporter := NewBackupReporter()
+	capture := &slogCaptureHandler{}
+	logger := slog.New(capture)
+
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-fail",
+		model.BackupTypeFull,
+		time.Now(),
+		time.Minute,
+		errors.New("backup failed"),
+		logger,
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+	require.Eventually(t, func() bool {
+		return capture.containsMessage("full backup failed")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestBackupReporter_Report_AerospikeFailure(t *testing.T) {
+	reporter := NewBackupReporter()
+	capture := &slogCaptureHandler{}
+	logger := slog.New(capture)
+
+	aerr := &as.AerospikeError{ResultCode: astypes.KEY_NOT_FOUND_ERROR}
+	before := backupEventCount(t)
+	reporter.Report(
+		"routine-as-fail",
+		model.BackupTypeIncremental,
+		time.Now(),
+		time.Minute,
+		aerr,
+		logger,
+	)
+	require.Equal(t, before+1, backupEventCount(t))
+	require.Eventually(t, func() bool {
+		return capture.containsMessage("incremental backup failed due to Aerospike error")
+	}, time.Second, 10*time.Millisecond)
+}
+
+func backupEventCount(t *testing.T) int {
+	t.Helper()
+	count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, "aerospike_backup_service_backup_events_total")
+	require.NoError(t, err)
+	return count
+}

--- a/pkg/service/backup_scheduler_test.go
+++ b/pkg/service/backup_scheduler_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/reugn/go-quartz/quartz"
@@ -86,5 +87,77 @@ func TestScheduleRoutines(t *testing.T) {
 			require.NoError(t, err)
 			scheduler.AssertNumberOfCalls(t, "ScheduleJob", tt.expectedCalls)
 		})
+	}
+}
+
+func TestBackupScheduler_DeleteJob(t *testing.T) {
+	key := jobKey("routine-1", model.BackupTypeFull)
+	scheduler := new(MockScheduler)
+	scheduler.On("DeleteJob", key).Return(nil)
+
+	bs := NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil))
+	require.NoError(t, bs.DeleteJob(key))
+	scheduler.AssertExpectations(t)
+}
+
+func TestBackupScheduler_TriggerAdHocFullBackup(t *testing.T) {
+	routine := &model.BackupRoutine{Name: "routine-1"}
+	scheduler := new(MockScheduler)
+	scheduler.On(
+		"ScheduleJob",
+		mock.MatchedBy(adHocJobMatcher("routine-1", model.BackupTypeFull)),
+		mock.Anything,
+	).Return(nil)
+
+	bs := NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil))
+	require.NoError(t, bs.TriggerAdHocFullBackup(routine, time.Second))
+	scheduler.AssertExpectations(t)
+}
+
+func TestBackupScheduler_TriggerAdHocIncrementalBackup(t *testing.T) {
+	routine := &model.BackupRoutine{Name: "routine-1"}
+	scheduler := new(MockScheduler)
+	scheduler.On(
+		"ScheduleJob",
+		mock.MatchedBy(adHocJobMatcher("routine-1", model.BackupTypeIncremental)),
+		mock.Anything,
+	).Return(nil)
+
+	bs := NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil))
+	require.NoError(t, bs.TriggerAdHocIncrementalBackup(routine, time.Second))
+	scheduler.AssertExpectations(t)
+}
+
+func TestBackupScheduler_TriggerAdHocBackup_EnforcesMinimumDelay(t *testing.T) {
+	routine := &model.BackupRoutine{Name: "routine-1"}
+	scheduler := new(MockScheduler)
+	scheduler.On(
+		"ScheduleJob",
+		mock.MatchedBy(adHocJobMatcher("routine-1", model.BackupTypeFull)),
+		mock.MatchedBy(func(trigger quartz.Trigger) bool {
+			now := time.Now().UnixNano()
+			next, err := trigger.NextFireTime(now)
+			if err != nil {
+				return false
+			}
+			delay := time.Duration(next - now)
+			return delay >= minAdHocBackupDelay
+		}),
+	).Return(nil)
+
+	bs := NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil))
+	require.NoError(t, bs.TriggerAdHocFullBackup(routine, 0))
+	scheduler.AssertExpectations(t)
+}
+
+func adHocJobMatcher(routineName string, backupType model.BackupType) func(*quartz.JobDetail) bool {
+	return func(detail *quartz.JobDetail) bool {
+		job, ok := detail.Job().(*backupJob)
+		if !ok {
+			return false
+		}
+		return detail.JobKey().Group() == string(quartzGroupAdHoc) &&
+			job.routine.Name == routineName &&
+			job.backupType == backupType
 	}
 }

--- a/pkg/service/cluster_config_writer_test.go
+++ b/pkg/service/cluster_config_writer_test.go
@@ -43,7 +43,7 @@ func TestClusterConfigWriter_Write_GetClientError(t *testing.T) {
 		Return(nil, clientErr)
 
 	writer := NewClusterConfigWriter(clientManager, NewPathService(nil), &fakeStorageDataWriter{})
-	err := writer.Write(context.Background(), routine, time.Now())
+	err := writer.Write(t.Context(), routine, time.Now())
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, clientErr)

--- a/pkg/service/cluster_config_writer_test.go
+++ b/pkg/service/cluster_config_writer_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// fakeStorageDataWriter is a controllable stand-in for storageDataWriter.
+type fakeStorageDataWriter struct {
+	writes map[string][]byte
+	err    error
+}
+
+func (f *fakeStorageDataWriter) WriteDataFile(
+	_ context.Context, _ model.Storage, fileName string, content []byte,
+) error {
+	if f.err != nil {
+		return f.err
+	}
+	if f.writes == nil {
+		f.writes = make(map[string][]byte)
+	}
+	f.writes[fileName] = content
+	return nil
+}
+
+func TestClusterConfigWriter_Write_GetClientError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", SourceCluster: &model.AerospikeCluster{}}
+	clientManager := aerospike.NewMockClientManager(ctrl)
+	clientErr := errors.New("connection failed")
+	clientManager.EXPECT().
+		GetClient(gomock.Any(), routine.SourceCluster, nil, gomock.Any()).
+		Return(nil, clientErr)
+
+	writer := NewClusterConfigWriter(clientManager, NewPathService(nil), &fakeStorageDataWriter{})
+	err := writer.Write(context.Background(), routine, time.Now())
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, clientErr)
+}
+
+// Note: the success/no-active-hosts paths of Write delegate to the package-level
+// cluster.ReadConfiguration, which requires a fully initialized *as.Cluster (real or
+// dialed) and isn't mockable at this boundary; those paths are covered by integration
+// tests against a live Aerospike cluster instead (see pkg/service/aerospike/cluster/).

--- a/pkg/service/config_applier_test.go
+++ b/pkg/service/config_applier_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDefaultConfigApplier_ApplyNewConfig_NoInvalidations(t *testing.T) {
+	cfg := model.NewConfig()
+	scheduler := new(MockScheduler)
+
+	applier := NewDefaultConfigApplier(
+		NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil)),
+		NewMockRunningBackupsRegistry(gomock.NewController(t)),
+		cfg,
+	)
+
+	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	scheduler.AssertNotCalled(t, "DeleteJob", mock.Anything)
+	scheduler.AssertNotCalled(t, "ScheduleJob", mock.Anything, mock.Anything)
+}
+
+func TestDefaultConfigApplier_ApplyNewConfig_ReschedulesInvalidatedRoutine(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := model.NewConfig()
+	require.NoError(t, cfg.AddRoutine(&model.BackupRoutine{
+		Name:         "routine-1",
+		IntervalCron: "0 0 * * * *",
+	}))
+	cfg.PopInvalidatedRoutineNames()
+	cfg.InvalidateRoutines([]string{"routine-1"})
+
+	scheduler := new(MockScheduler)
+	scheduler.On("DeleteJob", jobKey("routine-1", model.BackupTypeFull)).Return(nil)
+	scheduler.On("DeleteJob", jobKey("routine-1", model.BackupTypeIncremental)).Return(nil)
+	scheduler.On("ScheduleJob", mock.Anything, mock.Anything).Return(nil)
+
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	syncDone := make(chan struct{})
+	registry.EXPECT().SynchroniseBackupHistory(gomock.Any(), gomock.Any()).
+		Do(func(context.Context, []*model.BackupRoutine) { close(syncDone) })
+
+	applier := NewDefaultConfigApplier(
+		NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil)),
+		registry,
+		cfg,
+	)
+
+	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	scheduler.AssertNumberOfCalls(t, "DeleteJob", 2)
+	scheduler.AssertNumberOfCalls(t, "ScheduleJob", 1)
+	<-syncDone
+}
+
+func TestDefaultConfigApplier_ApplyNewConfig_SkipsDeletedRoutine(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := model.NewConfig()
+	cfg.InvalidateRoutines([]string{"removed-routine"})
+
+	scheduler := new(MockScheduler)
+	scheduler.On("DeleteJob", jobKey("removed-routine", model.BackupTypeFull)).Return(nil)
+	scheduler.On("DeleteJob", jobKey("removed-routine", model.BackupTypeIncremental)).Return(nil)
+
+	registry := NewMockRunningBackupsRegistry(ctrl)
+	syncDone := make(chan struct{})
+	registry.EXPECT().SynchroniseBackupHistory(gomock.Any(), gomock.Len(0)).
+		Do(func(context.Context, []*model.BackupRoutine) { close(syncDone) })
+
+	applier := NewDefaultConfigApplier(
+		NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil)),
+		registry,
+		cfg,
+	)
+
+	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	scheduler.AssertNotCalled(t, "ScheduleJob", mock.Anything, mock.Anything)
+	<-syncDone
+}
+
+func TestDefaultConfigApplier_ApplyNewConfig_ScheduleError(t *testing.T) {
+	cfg := model.NewConfig()
+	require.NoError(t, cfg.AddRoutine(&model.BackupRoutine{
+		Name:         "routine-1",
+		IntervalCron: "not-a-cron",
+	}))
+	cfg.PopInvalidatedRoutineNames()
+	cfg.InvalidateRoutines([]string{"routine-1"})
+
+	scheduler := new(MockScheduler)
+	scheduler.On("DeleteJob", mock.Anything).Return(nil)
+
+	applier := NewDefaultConfigApplier(
+		NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil)),
+		NewMockRunningBackupsRegistry(gomock.NewController(t)),
+		cfg,
+	)
+
+	err := applier.ApplyNewConfig(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to schedule periodic backups")
+}
+
+func TestDefaultConfigApplier_ApplyNewConfig_ScheduleJobError(t *testing.T) {
+	cfg := model.NewConfig()
+	require.NoError(t, cfg.AddRoutine(&model.BackupRoutine{
+		Name:         "routine-1",
+		IntervalCron: "0 0 * * * *",
+	}))
+	cfg.PopInvalidatedRoutineNames()
+	cfg.InvalidateRoutines([]string{"routine-1"})
+
+	scheduleErr := errors.New("schedule failed")
+	scheduler := new(MockScheduler)
+	scheduler.On("DeleteJob", mock.Anything).Return(nil)
+	scheduler.On("ScheduleJob", mock.Anything, mock.Anything).Return(scheduleErr)
+
+	applier := NewDefaultConfigApplier(
+		NewBackupScheduler(scheduler, NewBackupOrchestrator(nil, nil, nil, nil, nil)),
+		NewMockRunningBackupsRegistry(gomock.NewController(t)),
+		cfg,
+	)
+
+	err := applier.ApplyNewConfig(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, scheduleErr)
+}

--- a/pkg/service/config_applier_test.go
+++ b/pkg/service/config_applier_test.go
@@ -43,8 +43,8 @@ func TestDefaultConfigApplier_ApplyNewConfig_ReschedulesInvalidatedRoutine(t *te
 	scheduler.On("DeleteJob", jobKey("routine-1", model.BackupTypeIncremental)).Return(nil)
 	scheduler.On("ScheduleJob", mock.Anything, mock.Anything).Return(nil)
 
-	registry := NewMockRunningBackupsRegistry(ctrl)
 	syncDone := make(chan struct{})
+	registry := NewMockRunningBackupsRegistry(ctrl)
 	registry.EXPECT().SynchroniseBackupHistory(gomock.Any(), gomock.Any()).
 		Do(func(context.Context, []*model.BackupRoutine) { close(syncDone) })
 
@@ -57,7 +57,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_ReschedulesInvalidatedRoutine(t *te
 	require.NoError(t, applier.ApplyNewConfig(t.Context()))
 	scheduler.AssertNumberOfCalls(t, "DeleteJob", 2)
 	scheduler.AssertNumberOfCalls(t, "ScheduleJob", 1)
-	<-syncDone
+	waitAsyncDone(t, syncDone, "backup history sync")
 }
 
 func TestDefaultConfigApplier_ApplyNewConfig_SkipsDeletedRoutine(t *testing.T) {
@@ -71,8 +71,8 @@ func TestDefaultConfigApplier_ApplyNewConfig_SkipsDeletedRoutine(t *testing.T) {
 	scheduler.On("DeleteJob", jobKey("removed-routine", model.BackupTypeFull)).Return(nil)
 	scheduler.On("DeleteJob", jobKey("removed-routine", model.BackupTypeIncremental)).Return(nil)
 
-	registry := NewMockRunningBackupsRegistry(ctrl)
 	syncDone := make(chan struct{})
+	registry := NewMockRunningBackupsRegistry(ctrl)
 	registry.EXPECT().SynchroniseBackupHistory(gomock.Any(), gomock.Len(0)).
 		Do(func(context.Context, []*model.BackupRoutine) { close(syncDone) })
 
@@ -84,7 +84,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_SkipsDeletedRoutine(t *testing.T) {
 
 	require.NoError(t, applier.ApplyNewConfig(t.Context()))
 	scheduler.AssertNotCalled(t, "ScheduleJob", mock.Anything, mock.Anything)
-	<-syncDone
+	waitAsyncDone(t, syncDone, "backup history sync")
 }
 
 func TestDefaultConfigApplier_ApplyNewConfig_ScheduleError(t *testing.T) {

--- a/pkg/service/config_applier_test.go
+++ b/pkg/service/config_applier_test.go
@@ -21,7 +21,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_NoInvalidations(t *testing.T) {
 		cfg,
 	)
 
-	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	require.NoError(t, applier.ApplyNewConfig(t.Context()))
 	scheduler.AssertNotCalled(t, "DeleteJob", mock.Anything)
 	scheduler.AssertNotCalled(t, "ScheduleJob", mock.Anything, mock.Anything)
 }
@@ -54,7 +54,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_ReschedulesInvalidatedRoutine(t *te
 		cfg,
 	)
 
-	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	require.NoError(t, applier.ApplyNewConfig(t.Context()))
 	scheduler.AssertNumberOfCalls(t, "DeleteJob", 2)
 	scheduler.AssertNumberOfCalls(t, "ScheduleJob", 1)
 	<-syncDone
@@ -82,7 +82,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_SkipsDeletedRoutine(t *testing.T) {
 		cfg,
 	)
 
-	require.NoError(t, applier.ApplyNewConfig(context.Background()))
+	require.NoError(t, applier.ApplyNewConfig(t.Context()))
 	scheduler.AssertNotCalled(t, "ScheduleJob", mock.Anything, mock.Anything)
 	<-syncDone
 }
@@ -105,7 +105,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_ScheduleError(t *testing.T) {
 		cfg,
 	)
 
-	err := applier.ApplyNewConfig(context.Background())
+	err := applier.ApplyNewConfig(t.Context())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "failed to schedule periodic backups")
 }
@@ -130,7 +130,7 @@ func TestDefaultConfigApplier_ApplyNewConfig_ScheduleJobError(t *testing.T) {
 		cfg,
 	)
 
-	err := applier.ApplyNewConfig(context.Background())
+	err := applier.ApplyNewConfig(t.Context())
 	require.Error(t, err)
 	require.ErrorIs(t, err, scheduleErr)
 }

--- a/pkg/service/history_manager_test.go
+++ b/pkg/service/history_manager_test.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// backupTypeMatcher matches a BackupFilter argument by its underlying backup type,
+// letting tests distinguish the full-backup lookup from the incremental-backup lookup.
+type backupTypeMatcher struct {
+	backupType model.BackupType
+}
+
+func (m backupTypeMatcher) Matches(x any) bool {
+	rf, ok := x.(*RoutineFilter)
+	return ok && rf.backupType == m.backupType
+}
+
+func (m backupTypeMatcher) String() string {
+	return "backupType=" + string(m.backupType)
+}
+
+func TestHistoryManager_FindLastRun_NoBackups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	reader := NewMockBackupReader(ctrl)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeFull}).
+		Return(nil, nil)
+
+	hm := NewHistoryManager(reader)
+	result, err := hm.FindLastRun(t.Context(), routine)
+
+	require.NoError(t, err)
+	assert.True(t, result.NoFullBackup())
+}
+
+func TestHistoryManager_FindLastRun_FullOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	fullTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	reader := NewMockBackupReader(ctrl)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeFull}).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: fullTime}}}, nil)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeIncremental}).
+		Return(nil, nil)
+
+	hm := NewHistoryManager(reader)
+	result, err := hm.FindLastRun(t.Context(), routine)
+
+	require.NoError(t, err)
+	require.False(t, result.NoFullBackup())
+	assert.Equal(t, fullTime, *result.FullBackupTime())
+	assert.Nil(t, result.IncrementalBackupTime())
+}
+
+func TestHistoryManager_FindLastRun_FullAndIncremental(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	fullTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	incrTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	reader := NewMockBackupReader(ctrl)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeFull}).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: fullTime}}}, nil)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeIncremental}).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: incrTime}}}, nil)
+
+	hm := NewHistoryManager(reader)
+	result, err := hm.FindLastRun(t.Context(), routine)
+
+	require.NoError(t, err)
+	assert.Equal(t, fullTime, *result.FullBackupTime())
+	assert.Equal(t, incrTime, *result.IncrementalBackupTime())
+}
+
+func TestHistoryManager_FindLastRun_FullBackupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	fullErr := errors.New("full backup scan failed")
+
+	reader := NewMockBackupReader(ctrl)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeFull}).
+		Return(nil, fullErr)
+
+	hm := NewHistoryManager(reader)
+	_, err := hm.FindLastRun(t.Context(), routine)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, fullErr)
+	assert.Contains(t, err.Error(), "read last full backup failed")
+}
+
+func TestHistoryManager_FindLastRun_IncrementalBackupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	fullTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	incrErr := errors.New("incremental backup scan failed")
+
+	reader := NewMockBackupReader(ctrl)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeFull}).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: fullTime}}}, nil)
+	reader.EXPECT().
+		GetBackups(gomock.Any(), backupTypeMatcher{model.BackupTypeIncremental}).
+		Return(nil, incrErr)
+
+	hm := NewHistoryManager(reader)
+	_, err := hm.FindLastRun(t.Context(), routine)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, incrErr)
+	assert.Contains(t, err.Error(), "read last incremental backup failed")
+}

--- a/pkg/service/namespace_backup_runner_test.go
+++ b/pkg/service/namespace_backup_runner_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceBackupRunnerImpl_DeleteFolder_Success(t *testing.T) {
+	mocks, runner := initMocks(t)
+	defer mocks.ctrl.Finish()
+
+	impl, ok := runner.(*NamespaceBackupRunnerImpl)
+	require.True(t, ok)
+
+	routine := &model.BackupRoutine{Name: routineName}
+	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(nil)
+
+	impl.deleteFolder(context.Background(), routine, "some/path", slog.New(slog.DiscardHandler))
+}
+
+func TestNamespaceBackupRunnerImpl_DeleteFolder_ContextCanceled(t *testing.T) {
+	mocks, runner := initMocks(t)
+	defer mocks.ctrl.Finish()
+
+	impl, ok := runner.(*NamespaceBackupRunnerImpl)
+	require.True(t, ok)
+
+	routine := &model.BackupRoutine{Name: routineName}
+	capture := &slogCaptureHandler{}
+	logger := slog.New(capture)
+
+	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(context.Canceled)
+
+	impl.deleteFolder(context.Background(), routine, "some/path", logger)
+
+	require.True(t, capture.containsMessage("Delete folder context canceled"))
+}
+
+func TestNamespaceBackupRunnerImpl_DeleteFolder_Error(t *testing.T) {
+	mocks, runner := initMocks(t)
+	defer mocks.ctrl.Finish()
+
+	impl, ok := runner.(*NamespaceBackupRunnerImpl)
+	require.True(t, ok)
+
+	routine := &model.BackupRoutine{Name: routineName}
+	capture := &slogCaptureHandler{}
+	logger := slog.New(capture)
+	deleteErr := errors.New("delete failed")
+
+	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(deleteErr)
+
+	impl.deleteFolder(context.Background(), routine, "some/path", logger)
+
+	require.True(t, capture.containsMessage("Failed to delete folder"))
+}

--- a/pkg/service/namespace_backup_runner_test.go
+++ b/pkg/service/namespace_backup_runner_test.go
@@ -31,14 +31,13 @@ func TestNamespaceBackupRunnerImpl_DeleteFolder_ContextCanceled(t *testing.T) {
 	require.True(t, ok)
 
 	routine := &model.BackupRoutine{Name: routineName}
-	capture := &slogCaptureHandler{}
-	logger := slog.New(capture)
+	logger, logBuf := newTestLogger(t)
 
 	mocks.backendService.EXPECT().Delete(t.Context(), routine, "some/path").Return(context.Canceled)
 
 	impl.deleteFolder(t.Context(), routine, "some/path", logger)
 
-	require.True(t, capture.containsMessage("Delete folder context canceled"))
+	require.Contains(t, logBuf.String(), "Delete folder context canceled")
 }
 
 func TestNamespaceBackupRunnerImpl_DeleteFolder_Error(t *testing.T) {
@@ -49,13 +48,12 @@ func TestNamespaceBackupRunnerImpl_DeleteFolder_Error(t *testing.T) {
 	require.True(t, ok)
 
 	routine := &model.BackupRoutine{Name: routineName}
-	capture := &slogCaptureHandler{}
-	logger := slog.New(capture)
+	logger, logBuf := newTestLogger(t)
 	deleteErr := errors.New("delete failed")
 
 	mocks.backendService.EXPECT().Delete(t.Context(), routine, "some/path").Return(deleteErr)
 
 	impl.deleteFolder(t.Context(), routine, "some/path", logger)
 
-	require.True(t, capture.containsMessage("Failed to delete folder"))
+	require.Contains(t, logBuf.String(), "Failed to delete folder")
 }

--- a/pkg/service/namespace_backup_runner_test.go
+++ b/pkg/service/namespace_backup_runner_test.go
@@ -18,9 +18,9 @@ func TestNamespaceBackupRunnerImpl_DeleteFolder_Success(t *testing.T) {
 	require.True(t, ok)
 
 	routine := &model.BackupRoutine{Name: routineName}
-	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(nil)
+	mocks.backendService.EXPECT().Delete(t.Context(), routine, "some/path").Return(nil)
 
-	impl.deleteFolder(context.Background(), routine, "some/path", slog.New(slog.DiscardHandler))
+	impl.deleteFolder(t.Context(), routine, "some/path", slog.New(slog.DiscardHandler))
 }
 
 func TestNamespaceBackupRunnerImpl_DeleteFolder_ContextCanceled(t *testing.T) {
@@ -34,9 +34,9 @@ func TestNamespaceBackupRunnerImpl_DeleteFolder_ContextCanceled(t *testing.T) {
 	capture := &slogCaptureHandler{}
 	logger := slog.New(capture)
 
-	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(context.Canceled)
+	mocks.backendService.EXPECT().Delete(t.Context(), routine, "some/path").Return(context.Canceled)
 
-	impl.deleteFolder(context.Background(), routine, "some/path", logger)
+	impl.deleteFolder(t.Context(), routine, "some/path", logger)
 
 	require.True(t, capture.containsMessage("Delete folder context canceled"))
 }
@@ -53,9 +53,9 @@ func TestNamespaceBackupRunnerImpl_DeleteFolder_Error(t *testing.T) {
 	logger := slog.New(capture)
 	deleteErr := errors.New("delete failed")
 
-	mocks.backendService.EXPECT().Delete(context.Background(), routine, "some/path").Return(deleteErr)
+	mocks.backendService.EXPECT().Delete(t.Context(), routine, "some/path").Return(deleteErr)
 
-	impl.deleteFolder(context.Background(), routine, "some/path", logger)
+	impl.deleteFolder(t.Context(), routine, "some/path", logger)
 
 	require.True(t, capture.containsMessage("Failed to delete folder"))
 }

--- a/pkg/service/restore_manager_test.go
+++ b/pkg/service/restore_manager_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobNotFoundError_Error(t *testing.T) {
+	err := NewJobNotFoundError(model.RestoreJobID(42))
+	assert.Equal(t, "restore job with ID 42 not found", err.Error())
+}
+
+func TestRestoreManagerImpl_GetFilteredJobs(t *testing.T) {
+	jobsHolder := NewRestoreJobsHolder()
+	mgr := &RestoreManagerImpl{restoreJobs: jobsHolder}
+
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	jobsHolder.Store(model.RestoreJobID(1), &restoreJob{started: older, status: model.RestoreSuccess})
+	jobsHolder.Store(model.RestoreJobID(2), &restoreJob{started: newer, status: model.RestoreFailure})
+	jobsHolder.Store(model.RestoreJobID(3), &restoreJob{started: newer, status: model.RestoreRunning})
+
+	t.Run("no filters returns all jobs", func(t *testing.T) {
+		results := mgr.GetFilteredJobs(model.TimeBounds{}, model.StatusFilter{})
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("time bounds filter excludes jobs outside the window", func(t *testing.T) {
+		from := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+		results := mgr.GetFilteredJobs(model.TimeBounds{FromTime: &from}, model.StatusFilter{})
+		assert.Len(t, results, 2)
+		assert.NotContains(t, results, model.RestoreJobID(1))
+	})
+
+	t.Run("status filter includes only matching statuses", func(t *testing.T) {
+		statusFilter := model.NewStatusFilter([]model.RestoreState{model.RestoreSuccess}, false)
+		results := mgr.GetFilteredJobs(model.TimeBounds{}, statusFilter)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results, model.RestoreJobID(1))
+	})
+
+	t.Run("status filter in exclude mode omits matching statuses", func(t *testing.T) {
+		statusFilter := model.NewStatusFilter([]model.RestoreState{model.RestoreRunning}, true)
+		results := mgr.GetFilteredJobs(model.TimeBounds{}, statusFilter)
+		assert.Len(t, results, 2)
+		assert.NotContains(t, results, model.RestoreJobID(3))
+	})
+
+	t.Run("combined time bounds and status filter", func(t *testing.T) {
+		from := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+		statusFilter := model.NewStatusFilter([]model.RestoreState{model.RestoreFailure}, false)
+		results := mgr.GetFilteredJobs(model.TimeBounds{FromTime: &from}, statusFilter)
+		assert.Len(t, results, 1)
+		assert.Contains(t, results, model.RestoreJobID(2))
+	})
+}

--- a/pkg/service/retrieve_config_test.go
+++ b/pkg/service/retrieve_config_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,14 +60,16 @@ func TestConfigRetriever_RetrieveConfiguration_Success(t *testing.T) {
 	require.Len(t, zr.File, 2)
 
 	var allContent string
+	var allContentSb62 strings.Builder
 	for _, f := range zr.File {
 		rc, err := f.Open()
 		require.NoError(t, err)
 		b, err := io.ReadAll(rc)
 		require.NoError(t, err)
 		require.NoError(t, rc.Close())
-		allContent += string(b)
+		allContentSb62.WriteString(string(b))
 	}
+	allContent += allContentSb62.String()
 	assert.Contains(t, allContent, "config-a")
 	assert.Contains(t, allContent, "config-b")
 }

--- a/pkg/service/retrieve_config_test.go
+++ b/pkg/service/retrieve_config_test.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// fakeStorageFileReader is a controllable stand-in for storageFileReader used to
+// exercise ConfigRetrieverImpl error paths without real storage I/O.
+type fakeStorageFileReader struct {
+	buffers []*bytes.Buffer
+	err     error
+}
+
+func (f *fakeStorageFileReader) ReadFiles(
+	_ context.Context, _ model.Storage, _ string, _ string,
+) ([]*bytes.Buffer, error) {
+	return f.buffers, f.err
+}
+
+func TestConfigRetriever_RetrieveConfiguration_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{
+		Name:    "test-routine",
+		Storage: &model.LocalStorage{Path: t.TempDir()},
+	}
+	pathService := NewPathService(nil)
+	operations := storage.NewOperations(storage.NewLocalStorageAccessor())
+
+	backupCreated := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i, content := range []string{"config-a", "config-b"} {
+		filePath := pathService.GetConfigurationFilePath(routine.Name, backupCreated, i)
+		require.NoError(t, operations.WriteDataFile(t.Context(), routine.Storage, filePath, []byte(content)))
+	}
+
+	backupReader := NewMockBackupReaderWriter(ctrl)
+	backupReader.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: backupCreated}}}, nil)
+
+	retriever := NewConfigRetriever(backupReader, pathService, operations)
+	data, err := retriever.RetrieveConfiguration(t.Context(), routine, time.Now())
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	require.Len(t, zr.File, 2)
+
+	var allContent string
+	for _, f := range zr.File {
+		rc, err := f.Open()
+		require.NoError(t, err)
+		b, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+		allContent += string(b)
+	}
+	assert.Contains(t, allContent, "config-a")
+	assert.Contains(t, allContent, "config-b")
+}
+
+func TestConfigRetriever_RetrieveConfiguration_GetBackupsError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	backupReader := NewMockBackupReaderWriter(ctrl)
+	backupsErr := errors.New("backend unavailable")
+	backupReader.EXPECT().GetBackups(gomock.Any(), gomock.Any()).Return(nil, backupsErr)
+
+	retriever := NewConfigRetriever(backupReader, NewPathService(nil), &fakeStorageFileReader{})
+	_, err := retriever.RetrieveConfiguration(t.Context(), routine, time.Now())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, backupsErr)
+}
+
+func TestConfigRetriever_RetrieveConfiguration_NoFullBackups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	backupReader := NewMockBackupReaderWriter(ctrl)
+	backupReader.EXPECT().GetBackups(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	retriever := NewConfigRetriever(backupReader, NewPathService(nil), &fakeStorageFileReader{})
+	_, err := retriever.RetrieveConfiguration(t.Context(), routine, time.Now())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, model.ErrNotFound)
+}
+
+func TestConfigRetriever_RetrieveConfiguration_ReadFilesError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	backupReader := NewMockBackupReaderWriter(ctrl)
+	backupReader.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: time.Now()}}}, nil)
+
+	readErr := errors.New("read failed")
+	retriever := NewConfigRetriever(backupReader, NewPathService(nil), &fakeStorageFileReader{err: readErr})
+	_, err := retriever.RetrieveConfiguration(t.Context(), routine, time.Now())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, readErr)
+}
+
+func TestConfigRetriever_RetrieveConfiguration_NoConfigFiles(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	routine := &model.BackupRoutine{Name: "routine-1", Storage: &model.LocalStorage{Path: "/data"}}
+	backupReader := NewMockBackupReaderWriter(ctrl)
+	backupReader.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
+		Return([]model.BackupDetails{{BackupMetadata: model.BackupMetadata{Created: time.Now()}}}, nil)
+
+	retriever := NewConfigRetriever(backupReader, NewPathService(nil), &fakeStorageFileReader{})
+	_, err := retriever.RetrieveConfiguration(t.Context(), routine, time.Now())
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, model.ErrNotFound)
+}
+
+func TestPackageFiles(t *testing.T) {
+	buffers := []*bytes.Buffer{
+		bytes.NewBufferString("content-0"),
+		bytes.NewBufferString("content-1"),
+	}
+
+	data, err := packageFiles(buffers)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	require.Len(t, zr.File, 2)
+	assert.Equal(t, "aerospike_0.conf", zr.File[0].Name)
+	assert.Equal(t, "aerospike_1.conf", zr.File[1].Name)
+}
+
+func TestPackageFiles_Empty(t *testing.T) {
+	data, err := packageFiles(nil)
+	require.NoError(t, err)
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	assert.Empty(t, zr.File)
+}

--- a/pkg/service/test_helpers_test.go
+++ b/pkg/service/test_helpers_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"bytes"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+const asyncWaitTimeout = time.Second
+
+func waitAsyncDone(t *testing.T, done <-chan struct{}, description string) {
+	t.Helper()
+
+	select {
+	case <-done:
+	case <-time.After(asyncWaitTimeout):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+// logBuffer is a thread-safe buffer for slog test output.
+type logBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *logBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *logBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func newTestLogger(t *testing.T) (*slog.Logger, *logBuffer) {
+	t.Helper()
+
+	buf := &logBuffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	return logger, buf
+}


### PR DESCRIPTION
## What does this change do?

Adds Phase 4 coverage unit tests for the orchestration layer in `pkg/service/`:

- Backup completion, reporter, scheduler, and config applier
- Backend filter, history manager, namespace backup runner, restore manager, cluster config writer, and config retrieval

Cherry-picked from `realmgic/test/coverage-p4-orchestration`; P0–P3 coverage work is already on `dev` (#607, #608, #611, #612).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- Source branch: https://github.com/realmgic/aerospike-backup-service/tree/test/coverage-p4-orchestration
- Two commits cherry-picked cleanly onto current `dev` with minor lint fixes (`require.ErrorIs` in history manager tests).

## Test plan

- [x] `go test ./pkg/service/... -count=1`
- [x] `golangci-lint run ./pkg/service/... --fix`


Made with [Cursor](https://cursor.com)