### PR TITLE
BKRS-279 Fix key-file-password doc bug 

### DIFF
--- a/docs/config.schema.json
+++ b/docs/config.schema.json
@@ -1782,9 +1782,9 @@
             "nullable": true
           },
           "key-file-password": {
-            "description": "Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).",
+            "description": "Passphrase for an encrypted TLS key file. The value is used verbatim as the decryption password.",
             "type": "string",
-            "example": "file:/path/to/password",
+            "example": "my-secret-passphrase",
             "nullable": true
           },
           "name": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3415,10 +3415,10 @@ const docTemplate = `{
                     "example": "/path/to/key.pem"
                 },
                 "key-file-password": {
-                    "description": "Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).",
+                    "description": "Passphrase for an encrypted TLS key file. The value is used verbatim as the decryption password.",
                     "type": "string",
                     "x-nullable": true,
-                    "example": "file:/path/to/password"
+                    "example": "my-secret-passphrase"
                 },
                 "name": {
                     "description": "TLSName used for server certificate verification (ServerName for SNI).",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3698,9 +3698,9 @@
                         "nullable": true
                     },
                     "key-file-password": {
-                        "description": "Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).",
+                        "description": "Passphrase for an encrypted TLS key file. The value is used verbatim as the decryption password.",
                         "type": "string",
-                        "example": "file:/path/to/password",
+                        "example": "my-secret-passphrase",
                         "nullable": true
                     },
                     "name": {

--- a/docs/readme/dto/dto.tls.md
+++ b/docs/readme/dto/dto.tls.md
@@ -1,13 +1,13 @@
 ## dto.TLS
 TLS represents the Aerospike cluster TLS configuration options.
 
-| Field               | Description                                                                            | Default Value |
-|---------------------|----------------------------------------------------------------------------------------|---------------|
-| `ca-file`           | Path to a trusted CA certificate file in PEM format.                                   |               |
-| `ca-path`           | Path to a directory of trusted CA certificates.                                        |               |
-| `cert-file`         | Path to a client certificate file for mutual TLS authentication.                       |               |
-| `cipher-suite`      | TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format. |               |
-| `key-file`          | Path to a client private key file for mutual TLS authentication.                       |               |
-| `key-file-password` | Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).                 |               |
-| `name`              | TLSName used for server certificate verification (ServerName for SNI).                 |               |
-| `protocols`         | TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.     | `TLSv1.2`     |
+| Field               | Description                                                                                      | Default Value |
+|---------------------|--------------------------------------------------------------------------------------------------|---------------|
+| `ca-file`           | Path to a trusted CA certificate file in PEM format.                                             |               |
+| `ca-path`           | Path to a directory of trusted CA certificates.                                                  |               |
+| `cert-file`         | Path to a client certificate file for mutual TLS authentication.                                 |               |
+| `cipher-suite`      | TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format.           |               |
+| `key-file`          | Path to a client private key file for mutual TLS authentication.                                 |               |
+| `key-file-password` | Passphrase for an encrypted TLS key file. The value is used verbatim as the decryption password. |               |
+| `name`              | TLSName used for server certificate verification (ServerName for SNI).                           |               |
+| `protocols`         | TLS protocol selection criteria. This format is the same as Apache's SSL Protocol.               | `TLSv1.2`     |

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -20,9 +20,8 @@ type TLS struct {
 	Protocols *string `yaml:"protocols,omitempty" json:"protocols,omitempty" default:"TLSv1.2"`
 	// TLS cipher selection criteria. The format is the same as OpenSSL's Cipher List Format.
 	CipherSuite *string `yaml:"cipher-suite,omitempty" json:"cipher-suite,omitempty" example:"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" extensions:"x-nullable"`
-
-	// Password to load protected TLS-keyfile (env:VAR, file:PATH, PASSWORD).
-	KeyfilePassword *string `yaml:"key-file-password,omitempty" json:"key-file-password,omitempty" example:"file:/path/to/password" extensions:"x-nullable"`
+	// Passphrase for an encrypted TLS key file. The value is used verbatim as the decryption password.
+	KeyfilePassword *string `yaml:"key-file-password,omitempty" json:"key-file-password,omitempty" example:"my-secret-passphrase" extensions:"x-nullable"`
 }
 
 func (t *TLS) Validate(opts ...ValidationOption) error {


### PR DESCRIPTION
## What does this change do?

Fixes misleading documentation for the `key-file-password` TLS config field. The DTO comment and example tag previously advertised `env:VAR` / `file:PATH` interpolation copied from asbackup/asadm, but Backup Service uses the value verbatim as the decryption passphrase. Updates the source comment and example in `pkg/dto/tls.go` and regenerates the four generated artifacts that inherited the bad text.

Related: [BKRS-279](https://aerospike.atlassian.net/browse/BKRS-279)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [x] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [ ] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

Doc-only fix; no behavior change. Implementing real `env:`/`file:` password interpolation (to match asbackup/asadm) is explicitly out of scope and can be tracked as follow-up work if desired.


Made with [Cursor](https://cursor.com)

[BKRS-279]: https://aerospike.atlassian.net/browse/BKRS-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ