### PR TITLE
Test Phase 8: Ratchet filtered coverage threshold to 80%

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Check coverage threshold
         run: |
           TOTAL=$(go tool cover -func=coverage.out | awk '/total:/ {gsub(/%/,"",$3); print $3}')
-          THRESHOLD=53
+          THRESHOLD=80
           awk -v t="$TOTAL" -v min="$THRESHOLD" 'BEGIN { exit (t+0 >= min+0 ? 0 : 1) }' || \
             (echo "Coverage $TOTAL% below threshold $THRESHOLD%" && exit 1)
 


### PR DESCRIPTION
## What does this change do?

Raises the CI filtered coverage gate from 53% to 80%, completing Phase 8 of the coverage plan. After P0–P7 test work (#607–#619), filtered coverage is ~83%, so the old baseline no longer protects against regressions.

Cherry-picked from `realmgic/test/coverage-p8-ratchet`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [ ] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- Source branch: https://github.com/realmgic/aerospike-backup-service/tree/test/coverage-p8-ratchet
- Cherry-pick applied cleanly with no conflicts.
- Local verification: `go test -race -tags=ci ./...` with `.covignore` filtering reports **83.1%** total coverage (above the new 80% threshold).

## Test plan

- [x] `go test -race -tags=ci ./... -coverprofile=coverage.out -covermode=atomic`
- [x] Filtered coverage check: 83.1% ≥ 80%


Made with [Cursor](https://cursor.com)