### PR TITLE
BKRS-269 Merge secrets on config PUT to preserve stored values

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -3,6 +3,20 @@
 Upgrade notes and breaking changes between releases. For a terser, dated list of what shipped in each release, see
 [CHANGELOG.md](../CHANGELOG.md).
 
+## v3.6 -> v3.7
+
+This release redacts secret fields in configuration API responses and changes how secrets are updated via the REST API.
+
+#### Breaking changes
+
+- **Configuration API secret redaction** — GET endpoints (`/v1/config`, `/v1/config/clusters`, `/v1/config/storage`,
+  and related read paths) no longer return literal secret values. Literal passwords, keys, and similar fields are
+  replaced with the fixed sentinel `"[secret]"`. Secret Agent references (`secrets:...`) are still returned as-is.
+- **PUT requests must preserve the sentinel** — If you use a GET → edit other fields → PUT workflow, leave every
+  unchanged secret field as `"[secret]"`. The service treats that sentinel as “keep the stored value” and will not
+  overwrite the real secret. To change a secret, send the new literal value or a new Secret Agent reference explicitly.
+  Sending `"[secret]"` for a newly added entity (with no stored secret yet) is invalid.
+
 ## v3.5 -> v3.6
 
 This release adds compact backups, more flexible restore-by-timestamp, performance optimizations in the record

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -45,6 +45,9 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GET responses redact secrets as "[secret]". Before persisting a PUT, copy real secret
+	// values from the stored config into the incoming payload wherever the sentinel appears,
+	// so a GET-edit-PUT round trip does not overwrite secrets with the literal "[secret]".
 	decoder.MergeSecrets(newConfig, oldConfig)
 
 	newConfigModel, err := newConfig.ToModel()

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -45,7 +45,7 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	decoder.Merge(newConfig, oldConfig)
+	decoder.MergeSecrets(newConfig, oldConfig)
 
 	newConfigModel, err := newConfig.ToModel()
 	if err != nil {

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -45,6 +45,8 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	decoder.Merge(newConfig, oldConfig)
+
 	newConfigModel, err := newConfig.ToModel()
 	if err != nil {
 		httpError(w, errBadRequest(err))

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -29,7 +29,6 @@ func (s *Service) changeBackupConfig(
 	s.changeConfigLock.Lock()
 	defer s.changeConfigLock.Unlock()
 
-	existingConfig := dto.NewConfigFromModel(s.config)
 	dtoConfig := dto.NewConfigFromModel(s.config)
 	routinesToInvalidate, err := mutate(dtoConfig)
 	if err != nil {
@@ -39,6 +38,7 @@ func (s *Service) changeBackupConfig(
 	// GET responses redact secrets as "[secret]". Before persisting a PUT, copy real secret
 	// values from the stored config into the incoming payload wherever the sentinel appears,
 	// so a GET-edit-PUT round trip does not overwrite secrets with the literal "[secret]".
+	existingConfig := dto.NewConfigFromModel(s.config)
 	decoder.MergeSecrets(dtoConfig, existingConfig)
 
 	modelConfig, err := dtoConfig.ToModel(dto.ValidationSkipTLSFiles)

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 )
 
@@ -28,11 +29,14 @@ func (s *Service) changeBackupConfig(
 	s.changeConfigLock.Lock()
 	defer s.changeConfigLock.Unlock()
 
+	existingConfig := dto.NewConfigFromModel(s.config)
 	dtoConfig := dto.NewConfigFromModel(s.config)
 	routinesToInvalidate, err := mutate(dtoConfig)
 	if err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)
 	}
+
+	decoder.Merge(dtoConfig, existingConfig)
 
 	modelConfig, err := dtoConfig.ToModel(dto.ValidationSkipTLSFiles)
 	if err != nil {

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -36,7 +36,7 @@ func (s *Service) changeBackupConfig(
 		return fmt.Errorf("failed to update configuration: %w", err)
 	}
 
-	decoder.Merge(dtoConfig, existingConfig)
+	decoder.MergeSecrets(dtoConfig, existingConfig)
 
 	modelConfig, err := dtoConfig.ToModel(dto.ValidationSkipTLSFiles)
 	if err != nil {

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -36,6 +36,9 @@ func (s *Service) changeBackupConfig(
 		return fmt.Errorf("failed to update configuration: %w", err)
 	}
 
+	// GET responses redact secrets as "[secret]". Before persisting a PUT, copy real secret
+	// values from the stored config into the incoming payload wherever the sentinel appears,
+	// so a GET-edit-PUT round trip does not overwrite secrets with the literal "[secret]".
 	decoder.MergeSecrets(dtoConfig, existingConfig)
 
 	modelConfig, err := dtoConfig.ToModel(dto.ValidationSkipTLSFiles)

--- a/internal/server/handlers/config_cluster_test.go
+++ b/internal/server/handlers/config_cluster_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -213,6 +215,57 @@ func TestUpdateAerospikeCluster(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUpdateAerospikeCluster_PreservesSecretOnRoundTrip(t *testing.T) {
+	const realPassword = "real-secret-password"
+
+	svc := setupTestService(t)
+	ctrl := gomock.NewController(t)
+	mockNsValidator := aerospike.NewMockNamespaceValidator(ctrl)
+	svc.nsValidator = mockNsValidator
+	mockNsValidator.EXPECT().Validate(gomock.Any(), gomock.Eq(svc.config)).AnyTimes()
+
+	clusterModel := &model.AerospikeCluster{
+		SeedNodes: []model.SeedNode{{HostName: "localhost", Port: 3000}},
+		Credentials: &model.Credentials{
+			User:     "testUser",
+			Password: realPassword,
+			AuthMode: ptr.Of(model.AuthModeInternal),
+		},
+	}
+	require.NoError(t, svc.config.AddCluster("test-cluster", clusterModel))
+
+	getReq := httptest.NewRequestWithContext(
+		t.Context(), http.MethodGet, "/v1/config/clusters/test-cluster", nil,
+	)
+	getReq.SetPathValue("name", "test-cluster")
+	getW := httptest.NewRecorder()
+	svc.ReadAerospikeCluster(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+
+	var clusterDTO dto.AerospikeCluster
+	require.NoError(t, json.NewDecoder(getW.Body).Decode(&clusterDTO))
+	require.NotNil(t, clusterDTO.Credentials)
+	assert.Equal(t, decoder.RedactedSecret, string(clusterDTO.Credentials.Password))
+
+	clusterDTO.SeedNodes[0].HostName = "updated-host"
+	putBody, err := json.Marshal(clusterDTO)
+	require.NoError(t, err)
+
+	putReq := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPut, "/v1/config/clusters/test-cluster", strings.NewReader(string(putBody)),
+	)
+	putReq.SetPathValue("name", "test-cluster")
+	putW := httptest.NewRecorder()
+	svc.UpdateAerospikeCluster(putW, putReq)
+	require.Equal(t, http.StatusOK, putW.Code)
+
+	updated, ok := svc.config.BackupConfigCopy().AerospikeClusters["test-cluster"]
+	require.True(t, ok)
+	require.NotNil(t, updated.Credentials)
+	assert.Equal(t, realPassword, updated.Credentials.Password)
+	assert.Equal(t, "updated-host", updated.SeedNodes[0].HostName)
 }
 
 //nolint:dupl

--- a/internal/server/handlers/config_test.go
+++ b/internal/server/handlers/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
@@ -204,6 +205,56 @@ func TestService_changeConfig(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, called)
+}
+
+func TestService_UpdateConfig_PreservesSecretOnRoundTrip(t *testing.T) {
+	const realPassword = "real-secret-password"
+
+	svc, ctrl := newConfigTestService(t)
+	clusterModel := &model.AerospikeCluster{
+		SeedNodes: []model.SeedNode{{HostName: "localhost", Port: 3000}},
+		Credentials: &model.Credentials{
+			User:     "testUser",
+			Password: realPassword,
+			AuthMode: ptr.Of(model.AuthModeInternal),
+		},
+	}
+	require.NoError(t, svc.config.AddCluster("test-cluster", clusterModel))
+
+	mockConfigurationManager := NewmockManager(ctrl)
+	mockConfigurationManager.EXPECT().Write(gomock.Any(), gomock.Any()).Return(nil)
+	svc.configurationManager = mockConfigurationManager
+
+	mockConfigApplier := NewmockConfigApplier(ctrl)
+	mockConfigApplier.EXPECT().ApplyNewConfig(gomock.Any()).Return(nil)
+	svc.configApplier = mockConfigApplier
+
+	getReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/config", nil)
+	getW := httptest.NewRecorder()
+	svc.ReadConfig(getW, getReq)
+	require.Equal(t, http.StatusOK, getW.Code)
+
+	var configDTO dto.Config
+	require.NoError(t, json.NewDecoder(getW.Body).Decode(&configDTO))
+	require.NotNil(t, configDTO.AerospikeClusters["test-cluster"].Credentials)
+	assert.Equal(t, decoder.RedactedSecret, string(configDTO.AerospikeClusters["test-cluster"].Credentials.Password))
+
+	configDTO.AerospikeClusters["test-cluster"].ClusterLabel = "updated-label"
+	putBody, err := json.Marshal(configDTO)
+	require.NoError(t, err)
+
+	putReq := httptest.NewRequestWithContext(
+		t.Context(), http.MethodPut, "/v1/config", strings.NewReader(string(putBody)),
+	)
+	putW := httptest.NewRecorder()
+	svc.UpdateConfig(putW, putReq)
+	require.Equal(t, http.StatusOK, putW.Code)
+
+	updated, ok := svc.config.BackupConfigCopy().AerospikeClusters["test-cluster"]
+	require.True(t, ok)
+	require.NotNil(t, updated.Credentials)
+	assert.Equal(t, realPassword, updated.Credentials.Password)
+	assert.Equal(t, "updated-label", updated.ClusterLabel)
 }
 
 func TestService_changeConfig_UpdateFuncError(t *testing.T) {

--- a/pkg/dto/decoder/merge.go
+++ b/pkg/dto/decoder/merge.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 )
 
-// Merge mutates incoming in place, replacing RedactedSecret sentinel values
+// MergeSecrets mutates incoming in place, replacing RedactedSecret sentinel values
 // with the corresponding Secret values from existing.
-func Merge(incoming, existing any) {
+func MergeSecrets(incoming, existing any) {
 	if incoming == nil || existing == nil {
 		return
 	}

--- a/pkg/dto/decoder/merge.go
+++ b/pkg/dto/decoder/merge.go
@@ -6,6 +6,44 @@ import (
 
 // MergeSecrets mutates incoming in place, replacing RedactedSecret sentinel values
 // with the corresponding Secret values from existing.
+//
+// It walks incoming recursively and, for every Secret field equal to RedactedSecret,
+// copies the value from the matching field in existing.
+//
+// Example:
+//
+// Before:
+// Incoming:
+//
+//	{
+//	  "clusters": {
+//	    "c1": {
+//	      "password": "[secret]",
+//	      "user": "new-user"
+//	    }
+//	  }
+//	}
+//
+// Existing:
+//
+//	{
+//	  "clusters": {
+//	    "c1": {
+//	      "password": "real-password"
+//	    }
+//	  }
+//	}
+//
+// Incoming After:
+//
+//	{
+//	  "clusters": {
+//	    "c1": {
+//	      "password": "real-password",
+//	      "user": "new-user"
+//	    }
+//	  }
+//	}
 func MergeSecrets(incoming, existing any) {
 	if incoming == nil || existing == nil {
 		return

--- a/pkg/dto/decoder/merge.go
+++ b/pkg/dto/decoder/merge.go
@@ -1,0 +1,126 @@
+package decoder
+
+import (
+	"reflect"
+)
+
+// Merge mutates incoming in place, replacing RedactedSecret sentinel values
+// with the corresponding Secret values from existing.
+func Merge(incoming, existing any) {
+	if incoming == nil || existing == nil {
+		return
+	}
+
+	mergeValue(reflect.ValueOf(incoming), reflect.ValueOf(existing))
+}
+
+//nolint:gocognit,gocyclo,funlen // recursive reflect walk over nested DTO values
+func mergeValue(incoming, existing reflect.Value) {
+	if !incoming.IsValid() || !existing.IsValid() {
+		return
+	}
+
+	if incoming.Type() == secretType {
+		inSecret, ok := incoming.Interface().(Secret)
+		if !ok || !inSecret.IsRedacted() {
+			return
+		}
+
+		if existing.Type() != secretType || !incoming.CanSet() {
+			return
+		}
+
+		incoming.Set(existing)
+
+		return
+	}
+
+	if incoming.Type() == timeType {
+		return
+	}
+
+	switch incoming.Kind() {
+	case reflect.Pointer:
+		if incoming.IsNil() {
+			return
+		}
+
+		incomingElem := incoming.Elem()
+		if existing.Kind() == reflect.Pointer {
+			if existing.IsNil() {
+				return
+			}
+
+			mergeValue(incomingElem, existing.Elem())
+			return
+		}
+
+		mergeValue(incomingElem, existing)
+
+	case reflect.Interface:
+		if incoming.IsNil() {
+			return
+		}
+
+		if existing.IsNil() {
+			return
+		}
+
+		mergeValue(incoming.Elem(), existing.Elem())
+
+	case reflect.Struct:
+		if existing.Kind() != reflect.Struct || incoming.Type() != existing.Type() {
+			return
+		}
+
+		for i := 0; i < incoming.NumField(); i++ {
+			mergeValue(incoming.Field(i), existing.Field(i))
+		}
+
+	case reflect.Map:
+		if existing.Kind() != reflect.Map || incoming.Type() != existing.Type() {
+			return
+		}
+
+		for _, key := range incoming.MapKeys() {
+			existingVal := existing.MapIndex(key)
+			if !existingVal.IsValid() {
+				continue
+			}
+
+			incomingVal := incoming.MapIndex(key)
+			if incomingVal.Kind() != reflect.Pointer && !incomingVal.CanSet() {
+				mutable := reflect.New(incomingVal.Type()).Elem()
+				mutable.Set(incomingVal)
+				mergeValue(mutable, existingVal)
+				incoming.SetMapIndex(key, mutable)
+				continue
+			}
+
+			mergeValue(incomingVal, existingVal)
+		}
+
+	case reflect.Slice:
+		if existing.Kind() != reflect.Slice {
+			return
+		}
+
+		n := min(existing.Len(), incoming.Len())
+
+		for i := range n {
+			mergeValue(incoming.Index(i), existing.Index(i))
+		}
+
+	case reflect.Array:
+		if existing.Kind() != reflect.Array || incoming.Type() != existing.Type() {
+			return
+		}
+
+		for i := 0; i < incoming.Len(); i++ {
+			mergeValue(incoming.Index(i), existing.Index(i))
+		}
+
+	default:
+		return
+	}
+}

--- a/pkg/dto/decoder/merge_test.go
+++ b/pkg/dto/decoder/merge_test.go
@@ -1,0 +1,148 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeSecrets_ComplexFixture(t *testing.T) {
+	original := testComplexConfig()
+	redacted := RedactSecrets(original).(testConfig)
+
+	// Simulate editing non-secret fields on a GET response payload.
+	redacted.AerospikeClusters["cluster1"].Credentials.User = "updatedUser"
+	redacted.StorageProviders["s3-main"] = testStorage{
+		Name:            "updated-bucket",
+		AccessKeyID:     Secret(RedactedSecret),
+		SecretAccessKey: Secret(RedactedSecret),
+	}
+
+	Merge(&redacted, original)
+
+	t.Run("restores literal secrets", func(t *testing.T) {
+		assert.Equal(t, Secret(literalPassword), redacted.AerospikeClusters["cluster1"].Credentials.Password)
+		assert.Equal(t, Secret(literalTLSPassword), redacted.AerospikeClusters["cluster1"].TLS.KeyfilePassword)
+		assert.Equal(t, Secret(literalSecretKey), redacted.AerospikeClusters["cluster1"].Encryption.KeySecret)
+		assert.Equal(t, Secret(literalAccessKey), redacted.StorageProviders["s3-main"].AccessKeyID)
+		assert.Equal(t, Secret(literalSecretKey), redacted.StorageProviders["s3-main"].SecretAccessKey)
+		assert.Equal(t, Secret(literalAccessKey), redacted.Routines[0].Storages[0].AccessKeyID)
+		assert.Equal(t, Secret(literalPassword), redacted.Routines[0].Keys[0])
+	})
+
+	t.Run("preserves non-secret edits", func(t *testing.T) {
+		assert.Equal(t, "updatedUser", redacted.AerospikeClusters["cluster1"].Credentials.User)
+		assert.Equal(t, "updated-bucket", redacted.StorageProviders["s3-main"].Name)
+	})
+
+	t.Run("preserves valid secret refs", func(t *testing.T) {
+		assert.Equal(t, Secret(validSecretRef), redacted.AerospikeClusters["cluster2"].Credentials.Password)
+		assert.Equal(t, Secret(validSecretRef), redacted.StorageProviders["s3-ref"].AccessKeyID)
+		assert.Equal(t, Secret(validSecretRef), redacted.Routines[0].Keys[1])
+	})
+
+	t.Run("preserves empty secrets", func(t *testing.T) {
+		assert.Empty(t, redacted.AerospikeClusters["cluster3"].Credentials.Password)
+		assert.Empty(t, redacted.StorageProviders["s3-ref"].SecretAccessKey)
+	})
+
+	t.Run("does not mutate original", func(t *testing.T) {
+		assert.Equal(t, "testUser", original.AerospikeClusters["cluster1"].Credentials.User)
+		assert.Equal(t, "main-bucket", original.StorageProviders["s3-main"].Name)
+	})
+}
+
+func TestMergeSecrets_NewMapEntryWithSentinel(t *testing.T) {
+	existing := testConfig{
+		AerospikeClusters: map[string]*testCluster{},
+	}
+
+	incoming := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"new-cluster": {
+				Credentials: &testCredentials{
+					User:     "newUser",
+					Password: RedactedSecret,
+				},
+			},
+		},
+	}
+
+	Merge(&incoming, existing)
+
+	assert.Equal(t, Secret(RedactedSecret), incoming.AerospikeClusters["new-cluster"].Credentials.Password)
+}
+
+func TestMergeSecrets_ExplicitSecretUpdate(t *testing.T) {
+	existing := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: literalPassword,
+				},
+			},
+		},
+	}
+
+	incoming := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: "new-password",
+				},
+			},
+		},
+	}
+
+	Merge(&incoming, existing)
+
+	assert.Equal(t, Secret("new-password"), incoming.AerospikeClusters["cluster1"].Credentials.Password)
+}
+
+func TestMergeSecrets_ClearSecretWithEmptyString(t *testing.T) {
+	existing := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: literalPassword,
+				},
+			},
+		},
+	}
+
+	incoming := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: "",
+				},
+			},
+		},
+	}
+
+	Merge(&incoming, existing)
+
+	assert.Empty(t, incoming.AerospikeClusters["cluster1"].Credentials.Password)
+}
+
+func TestMergeSecrets_NilInput(t *testing.T) {
+	original := testComplexConfig()
+
+	require.NotPanics(t, func() {
+		Merge(nil, original)
+		Merge(&original, nil)
+		Merge(nil, nil)
+	})
+}
+
+func TestSecret_IsRedacted(t *testing.T) {
+	assert.True(t, Secret(RedactedSecret).IsRedacted())
+	assert.False(t, Secret("real-password").IsRedacted())
+	assert.False(t, Secret("").IsRedacted())
+	assert.False(t, Secret(validSecretRef).IsRedacted())
+}

--- a/pkg/dto/decoder/merge_test.go
+++ b/pkg/dto/decoder/merge_test.go
@@ -19,7 +19,7 @@ func TestMergeSecrets_ComplexFixture(t *testing.T) {
 		SecretAccessKey: Secret(RedactedSecret),
 	}
 
-	Merge(&redacted, original)
+	MergeSecrets(&redacted, original)
 
 	t.Run("restores literal secrets", func(t *testing.T) {
 		assert.Equal(t, Secret(literalPassword), redacted.AerospikeClusters["cluster1"].Credentials.Password)
@@ -69,7 +69,7 @@ func TestMergeSecrets_NewMapEntryWithSentinel(t *testing.T) {
 		},
 	}
 
-	Merge(&incoming, existing)
+	MergeSecrets(&incoming, existing)
 
 	assert.Equal(t, Secret(RedactedSecret), incoming.AerospikeClusters["new-cluster"].Credentials.Password)
 }
@@ -97,7 +97,7 @@ func TestMergeSecrets_ExplicitSecretUpdate(t *testing.T) {
 		},
 	}
 
-	Merge(&incoming, existing)
+	MergeSecrets(&incoming, existing)
 
 	assert.Equal(t, Secret("new-password"), incoming.AerospikeClusters["cluster1"].Credentials.Password)
 }
@@ -125,7 +125,7 @@ func TestMergeSecrets_ClearSecretWithEmptyString(t *testing.T) {
 		},
 	}
 
-	Merge(&incoming, existing)
+	MergeSecrets(&incoming, existing)
 
 	assert.Empty(t, incoming.AerospikeClusters["cluster1"].Credentials.Password)
 }
@@ -134,9 +134,9 @@ func TestMergeSecrets_NilInput(t *testing.T) {
 	original := testComplexConfig()
 
 	require.NotPanics(t, func() {
-		Merge(nil, original)
-		Merge(&original, nil)
-		Merge(nil, nil)
+		MergeSecrets(nil, original)
+		MergeSecrets(&original, nil)
+		MergeSecrets(nil, nil)
 	})
 }
 

--- a/pkg/dto/decoder/secret.go
+++ b/pkg/dto/decoder/secret.go
@@ -65,3 +65,7 @@ func (s Secret) GoString() string {
 func (s Secret) LogValue() slog.Value {
 	return slog.StringValue(s.DisplayString())
 }
+
+func (s Secret) IsRedacted() bool {
+	return s == RedactedSecret
+}


### PR DESCRIPTION
## What does this change do?

Completes the write-path half of BKRS-269: when a config PUT payload contains the `"[secret]"` sentinel (as returned by GET), the service keeps the existing stored secret instead of overwriting it with the literal sentinel string.

Adds `decoder.MergeSecrets`, a reflection-based helper that walks all `Secret`-typed fields (same discovery model as `RedactSecrets`), and wires it into `UpdateConfig` and `changeBackupConfig` (cluster/storage/policy/routine PUTs). Also adds round-trip handler tests and a migration guide entry for the breaking REST API behavior introduced with secret redaction on GET.


## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change (config file, REST API, or CLI flags)
- [x] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [ ] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [ ] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [x] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- Read-path redaction (`"[secret]"` on GET) landed in BKRS-333 (#622). This PR adds the symmetric write-path merge so GET → edit other fields → PUT round trips work correctly.
- New secret fields only need the `secret` type alias; no per-field handler changes required.

## Test plan

- [x] `go test ./pkg/dto/decoder/... ./internal/server/handlers/...`
- [x] `TestMergeSecrets_*` unit tests (sentinel restore, explicit update, empty clear, new entity edge case)
- [x] `TestUpdateAerospikeCluster_PreservesSecretOnRoundTrip`
- [x] `TestService_UpdateConfig_PreservesSecretOnRoundTrip`
