### PR TITLE
BKRS-338 Validate user-supplied filesystem paths

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -23,7 +23,7 @@ aerospike-clusters:
 storage:
     local:
         local-storage:
-            path: ./localStorage
+            path: localStorage
     minio:
         s3-storage:
             bucket: as-backup-bucket

--- a/internal/server/configuration/configuration_manager_test.go
+++ b/internal/server/configuration/configuration_manager_test.go
@@ -17,7 +17,7 @@ func TestConfigManagerBuilder_NewConfigManager(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Create an HTTP test server
-	storageDto := "local-storage:\n    path: ./config.yaml"
+	storageDto := "local-storage:\n    path: config.yaml"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/storage.yaml":

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // AerospikeCluster represents the configuration for an Aerospike cluster for backup.
@@ -226,8 +225,8 @@ func (c *Credentials) Validate(opts ...ValidationOption) error {
 	}
 
 	if c.PasswordPath != "" {
-		if err := safepath.ValidateClean(c.PasswordPath); err != nil {
-			return errValidationInvalidPath("password-path", c.PasswordPath)
+		if err := errValidationInvalidPath("password-path", c.PasswordPath); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // AerospikeCluster represents the configuration for an Aerospike cluster for backup.
@@ -222,6 +223,12 @@ func (c *Credentials) Validate(opts ...ValidationOption) error {
 
 	if c.Password != "" && c.PasswordPath != "" {
 		return errValidationMutuallyExclusive("password", "password-path")
+	}
+
+	if c.PasswordPath != "" {
+		if err := safepath.ValidateClean(c.PasswordPath); err != nil {
+			return errValidationInvalidPath("password-path", c.PasswordPath)
+		}
 	}
 
 	if _, err := model.ParseAuthMode(c.AuthMode); err != nil {

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // AerospikeCluster represents the configuration for an Aerospike cluster for backup.
@@ -224,10 +225,8 @@ func (c *Credentials) Validate(opts ...ValidationOption) error {
 		return errValidationMutuallyExclusive("password", "password-path")
 	}
 
-	if c.PasswordPath != "" {
-		if err := errValidationInvalidPath("password-path", c.PasswordPath); err != nil {
-			return err
-		}
+	if err := safepath.ValidateClean(c.PasswordPath); err != nil {
+		return errValidationInvalidPath("password-path", c.PasswordPath, err)
 	}
 
 	if _, err := model.ParseAuthMode(c.AuthMode); err != nil {

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -226,7 +226,7 @@ func (c *Credentials) Validate(opts ...ValidationOption) error {
 	}
 
 	if err := safepath.ValidateClean(c.PasswordPath); err != nil {
-		return errValidationInvalidPath("password-path", c.PasswordPath, err)
+		return fmt.Errorf("%w: invalid password-path", errInvalidPath)
 	}
 
 	if _, err := model.ParseAuthMode(c.AuthMode); err != nil {

--- a/pkg/dto/client_tls.go
+++ b/pkg/dto/client_tls.go
@@ -90,8 +90,8 @@ func (c *ClientTLS) validatePaths() error {
 		if path == "" {
 			continue
 		}
-		if err := safepath.ValidateClean(path); err != nil {
-			return errValidationInvalidPath(field, path)
+		if err := errValidationInvalidPath(field, path); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/dto/client_tls.go
+++ b/pkg/dto/client_tls.go
@@ -1,10 +1,10 @@
 package dto
 
 import (
-	"os"
 	"slices"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // ClientTLS represents the TLS configuration options relevant for client-side connections.
@@ -29,6 +29,10 @@ func (c *ClientTLS) Validate(opts ...ValidationOption) error {
 	}
 
 	if !slices.Contains(opts, ValidationSkipTLSFiles) {
+		if err := c.validatePaths(); err != nil {
+			return err
+		}
+
 		if err := verifyFilesExist(c); err != nil {
 			return err
 		}
@@ -77,21 +81,38 @@ func (c *ClientTLS) ToModel() model.ClientTLS {
 	}
 }
 
+func (c *ClientTLS) validatePaths() error {
+	for field, path := range map[string]string{
+		"ca-file":   c.CAFile,
+		"cert-file": c.Certfile,
+		"key-file":  c.Keyfile,
+	} {
+		if path == "" {
+			continue
+		}
+		if err := safepath.ValidateClean(path); err != nil {
+			return errValidationInvalidPath(field, path)
+		}
+	}
+
+	return nil
+}
+
 func verifyFilesExist(c *ClientTLS) error {
 	if c.CAFile != "" {
-		if _, err := os.Stat(c.CAFile); err != nil {
+		if _, err := safepath.Stat(c.CAFile); err != nil {
 			return errValidationNotFound("ca-file", c.CAFile)
 		}
 	}
 
 	if c.Certfile != "" {
-		if _, err := os.Stat(c.Certfile); err != nil {
+		if _, err := safepath.Stat(c.Certfile); err != nil {
 			return errValidationNotFound("cert-file", c.Certfile)
 		}
 	}
 
 	if c.Keyfile != "" {
-		if _, err := os.Stat(c.Keyfile); err != nil {
+		if _, err := safepath.Stat(c.Keyfile); err != nil {
 			return errValidationNotFound("key-file", c.Keyfile)
 		}
 	}

--- a/pkg/dto/client_tls.go
+++ b/pkg/dto/client_tls.go
@@ -22,7 +22,18 @@ type ClientTLS struct {
 	Keyfile string `yaml:"key-file,omitempty" json:"key-file,omitempty" example:"/path/to/key.pem" extensions:"x-nullable"`
 }
 
+const (
+	caField   = "ca-file"
+	certField = "cert-file"
+	keyField  = "key-file"
+	nameField = "name"
+)
+
 // Validate validates the ClientTLS configuration.
+//
+// ca-file is optional and independent: it trusts the server certificate.
+// cert-file, key-file, and name are a separate mTLS set:
+// together they identify this client to the server.
 func (c *ClientTLS) Validate(opts ...ValidationOption) error {
 	if c == nil {
 		return nil
@@ -33,35 +44,36 @@ func (c *ClientTLS) Validate(opts ...ValidationOption) error {
 			return err
 		}
 
-		if err := verifyFilesExist(c); err != nil {
+		if err := c.verifyFilesExist(); err != nil {
 			return err
 		}
 	}
 
+	// mTLS: cert-file, key-file, and name must be set together.
 	if c.Certfile != "" {
 		if c.Keyfile == "" {
-			return errValidationRequires("cert-file", "key-file")
+			return errValidationRequires(certField, keyField)
 		}
 		if c.Name == "" {
-			return errValidationRequires("cert-file", "name")
+			return errValidationRequires(certField, nameField)
 		}
 	}
 
 	if c.Keyfile != "" {
 		if c.Certfile == "" {
-			return errValidationRequires("key-file", "cert-file")
+			return errValidationRequires(keyField, certField)
 		}
 		if c.Name == "" {
-			return errValidationRequires("key-file", "name")
+			return errValidationRequires(keyField, nameField)
 		}
 	}
 
 	if c.Name != "" {
 		if c.Certfile == "" {
-			return errValidationRequires("name", "cert-file")
+			return errValidationRequires(nameField, certField)
 		}
 		if c.Keyfile == "" {
-			return errValidationRequires("name", "key-file")
+			return errValidationRequires(nameField, keyField)
 		}
 	}
 
@@ -83,9 +95,9 @@ func (c *ClientTLS) ToModel() model.ClientTLS {
 
 func (c *ClientTLS) validatePaths() error {
 	for field, path := range map[string]string{
-		"ca-file":   c.CAFile,
-		"cert-file": c.Certfile,
-		"key-file":  c.Keyfile,
+		caField:   c.CAFile,
+		certField: c.Certfile,
+		keyField:  c.Keyfile,
 	} {
 		if err := safepath.ValidateClean(path); err != nil {
 			return errValidationInvalidPath(field, path, err)
@@ -95,22 +107,14 @@ func (c *ClientTLS) validatePaths() error {
 	return nil
 }
 
-func verifyFilesExist(c *ClientTLS) error {
-	if c.CAFile != "" {
-		if _, err := safepath.Stat(c.CAFile); err != nil {
-			return errValidationNotFound("ca-file", c.CAFile)
-		}
-	}
-
-	if c.Certfile != "" {
-		if _, err := safepath.Stat(c.Certfile); err != nil {
-			return errValidationNotFound("cert-file", c.Certfile)
-		}
-	}
-
-	if c.Keyfile != "" {
-		if _, err := safepath.Stat(c.Keyfile); err != nil {
-			return errValidationNotFound("key-file", c.Keyfile)
+func (c *ClientTLS) verifyFilesExist() error {
+	for field, path := range map[string]string{
+		caField:   c.CAFile,
+		certField: c.Certfile,
+		keyField:  c.Keyfile,
+	} {
+		if err := safepath.EnsureFileExists(path); err != nil {
+			return errValidationNotFound(field, path)
 		}
 	}
 

--- a/pkg/dto/client_tls.go
+++ b/pkg/dto/client_tls.go
@@ -87,11 +87,8 @@ func (c *ClientTLS) validatePaths() error {
 		"cert-file": c.Certfile,
 		"key-file":  c.Keyfile,
 	} {
-		if path == "" {
-			continue
-		}
-		if err := errValidationInvalidPath(field, path); err != nil {
-			return err
+		if err := safepath.ValidateClean(path); err != nil {
+			return errValidationInvalidPath(field, path, err)
 		}
 	}
 

--- a/pkg/dto/client_tls_test.go
+++ b/pkg/dto/client_tls_test.go
@@ -1,0 +1,87 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientTLS_ValidatePaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		tls     ClientTLS
+		wantErr bool
+	}{
+		{
+			name: "clean paths",
+			tls: ClientTLS{
+				CAFile:   "/etc/ssl/certs/ca.pem",
+				Certfile: "/etc/ssl/certs/client.pem",
+				Keyfile:  "/etc/ssl/private/client-key.pem",
+			},
+		},
+		{
+			name: "traversal in ca-file",
+			tls: ClientTLS{
+				CAFile: "certs/../../outside.pem",
+			},
+			wantErr: true,
+		},
+		{
+			name: "dot prefix in key-file",
+			tls: ClientTLS{
+				Keyfile: "./keys/client-key.pem",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.tls.validatePaths()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, errInvalidPath)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCredentials_ValidatePasswordPath(t *testing.T) {
+	//nolint:gosec // test fixtures use fake credential fields
+	tests := []struct {
+		name    string
+		creds   Credentials
+		wantErr bool
+	}{
+		{
+			name: "clean password path",
+			creds: Credentials{
+				User:         "admin",
+				PasswordPath: "secrets/password.txt",
+			},
+		},
+		{
+			name: "traversal password path",
+			creds: Credentials{
+				User:         "admin",
+				PasswordPath: "secrets/../../outside/secret.txt",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.creds.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, errInvalidPath)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/dto/client_tls_test.go
+++ b/pkg/dto/client_tls_test.go
@@ -21,7 +21,14 @@ func TestClientTLS_ValidatePaths(t *testing.T) {
 			},
 		},
 		{
-			name: "traversal in ca-file",
+			name: "leading parent traversal in ca-file",
+			tls: ClientTLS{
+				CAFile: "../etc/passwd",
+			},
+			wantErr: true,
+		},
+		{
+			name: "embedded traversal in ca-file",
 			tls: ClientTLS{
 				CAFile: "certs/../../outside.pem",
 			},

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // RestoreRequest represents a restore operation request from custom storage
@@ -74,8 +75,8 @@ func (r *RestoreRequest) Validate(opts ...ValidationOption) error {
 	if !filepath.IsLocal(r.BackupDataPath) {
 		return fmt.Errorf("%w: backup-data-path must be local", errValidation)
 	}
-	if hasParentPathComponent(r.BackupDataPath) {
-		return fmt.Errorf("%w: backup-data-path must not contain traversal", errValidation)
+	if err := safepath.ValidateClean(r.BackupDataPath); err != nil {
+		return fmt.Errorf("%w: backup-data-path: %w", errValidation, err)
 	}
 	if err := r.DestinationClusterConfig.Validate(opts...); err != nil {
 		return err

--- a/pkg/dto/storage.go
+++ b/pkg/dto/storage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // Storage represents the configuration for a backup storage details.
@@ -28,8 +29,8 @@ func validateObjectStoragePath(path string) error {
 		if !filepath.IsLocal(path) {
 			return fmt.Errorf("storage path must be local: %q", path)
 		}
-		if hasParentPathComponent(path) {
-			return fmt.Errorf("storage path must not contain traversal: %q", path)
+		if err := safepath.ValidateClean(path); err != nil {
+			return fmt.Errorf("storage path: %w", err)
 		}
 	}
 	return nil

--- a/pkg/dto/storage_local.go
+++ b/pkg/dto/storage_local.go
@@ -2,11 +2,11 @@ package dto
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
-	"slices"
-	"strings"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // LocalStorage represents the configuration for local storage.
@@ -26,18 +26,14 @@ func (l *LocalStorage) Validate(_ ...ValidationOption) error {
 	if !filepath.IsAbs(l.Path) && !filepath.IsLocal(l.Path) {
 		return errors.New("local storage path must be absolute or local")
 	}
-	if hasParentPathComponent(l.Path) {
-		return errors.New("local storage path must not contain traversal")
+	if err := safepath.ValidateClean(l.Path); err != nil {
+		return fmt.Errorf("local storage path: %w", err)
 	}
 	if l.MinPartSize != nil && *l.MinPartSize <= 0 {
 		return errors.New("min-part-size for local storage must be a positive value")
 	}
 
 	return nil
-}
-
-func hasParentPathComponent(path string) bool {
-	return slices.Contains(strings.Split(path, string(filepath.Separator)), "..")
 }
 
 func (l *LocalStorage) toModel() (model.Storage, error) {

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -60,6 +60,7 @@ func (t *TLS) validatePaths() error {
 }
 
 // validateCACertificates ensures CA file and path are mutually exclusive.
+// Both are optional ways to trust the server certificate; see ClientTLS.Validate.
 func (t *TLS) validateCACertificates() error {
 	if t.CAFile != "" && t.CAPath != "" {
 		return errValidationMutuallyExclusive("ca-file", "ca-path")

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // TLS represents the Aerospike cluster TLS configuration options.
@@ -35,6 +36,10 @@ func (t *TLS) Validate(opts ...ValidationOption) error {
 		return err
 	}
 
+	if err := t.validatePaths(); err != nil {
+		return err
+	}
+
 	if err := t.validateCACertificates(); err != nil {
 		return err
 	}
@@ -44,6 +49,16 @@ func (t *TLS) Validate(opts ...ValidationOption) error {
 	}
 
 	return t.validateTLSConfig(opts...)
+}
+
+func (t *TLS) validatePaths() error {
+	if t.CAPath != "" {
+		if err := safepath.ValidateClean(t.CAPath); err != nil {
+			return errValidationInvalidPath("ca-path", t.CAPath)
+		}
+	}
+
+	return nil
 }
 
 // validateCACertificates ensures CA file and path are mutually exclusive.

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // TLS represents the Aerospike cluster TLS configuration options.
@@ -51,10 +52,8 @@ func (t *TLS) Validate(opts ...ValidationOption) error {
 }
 
 func (t *TLS) validatePaths() error {
-	if t.CAPath != "" {
-		if err := errValidationInvalidPath("ca-path", t.CAPath); err != nil {
-			return err
-		}
+	if err := safepath.ValidateClean(t.CAPath); err != nil {
+		return errValidationInvalidPath("ca-path", t.CAPath, err)
 	}
 
 	return nil

--- a/pkg/dto/tls.go
+++ b/pkg/dto/tls.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/service/aerospike"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // TLS represents the Aerospike cluster TLS configuration options.
@@ -53,8 +52,8 @@ func (t *TLS) Validate(opts ...ValidationOption) error {
 
 func (t *TLS) validatePaths() error {
 	if t.CAPath != "" {
-		if err := safepath.ValidateClean(t.CAPath); err != nil {
-			return errValidationInvalidPath("ca-path", t.CAPath)
+		if err := errValidationInvalidPath("ca-path", t.CAPath); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/dto/tls_test.go
+++ b/pkg/dto/tls_test.go
@@ -273,6 +273,16 @@ func TestTLS_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "non-clean CA file path",
+			tls: &TLS{
+				ClientTLS: ClientTLS{
+					CAFile: "/etc//passwd",
+				},
+			},
+			wantErr: true,
+			errType: errInvalidPath,
+		},
+		{
 			name: "invalid key file path",
 			tls: &TLS{
 				ClientTLS: ClientTLS{

--- a/pkg/dto/validate_errors.go
+++ b/pkg/dto/validate_errors.go
@@ -3,6 +3,7 @@ package dto
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -18,6 +19,7 @@ var (
 	errMissingDependency = fmt.Errorf("missing dependent field %w", errValidation)
 	errDuplicate         = fmt.Errorf("duplicate value %w", errValidation)
 	errSecretRefNoAgent  = fmt.Errorf("secret reference without agent %w", errValidation)
+	errInvalidPath       = fmt.Errorf("invalid path %w", errValidation)
 )
 
 func errValidationRequiredEither(fields ...string) error {
@@ -65,4 +67,10 @@ func errValidationDuplicate[T any](field string, value T) error {
 func errValidationSecretRefNoAgent(value secret) error {
 	return fmt.Errorf("%w: %q requires secret agent configuration (secret-agent or secret-agent-name)",
 		errSecretRefNoAgent, string(value))
+}
+
+func errValidationInvalidPath(field, path string) error {
+	cleaned := filepath.Clean(path)
+	return fmt.Errorf("%w: %q for %q is not a clean path (normalizes to %q)",
+		errInvalidPath, path, field, cleaned)
 }

--- a/pkg/dto/validate_errors.go
+++ b/pkg/dto/validate_errors.go
@@ -3,8 +3,9 @@ package dto
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 var (
@@ -70,7 +71,9 @@ func errValidationSecretRefNoAgent(value secret) error {
 }
 
 func errValidationInvalidPath(field, path string) error {
-	cleaned := filepath.Clean(path)
-	return fmt.Errorf("%w: %q for %q is not a clean path (normalizes to %q)",
-		errInvalidPath, path, field, cleaned)
+	if err := safepath.ValidateClean(path); err != nil {
+		return fmt.Errorf("%w: %q for %q: %w", errInvalidPath, path, field, err)
+	}
+
+	return nil
 }

--- a/pkg/dto/validate_errors.go
+++ b/pkg/dto/validate_errors.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 var (
@@ -70,10 +68,6 @@ func errValidationSecretRefNoAgent(value secret) error {
 		errSecretRefNoAgent, string(value))
 }
 
-func errValidationInvalidPath(field, path string) error {
-	if err := safepath.ValidateClean(path); err != nil {
-		return fmt.Errorf("%w: %q for %q: %w", errInvalidPath, path, field, err)
-	}
-
-	return nil
+func errValidationInvalidPath(field, path string, err error) error {
+	return fmt.Errorf("%w: %q for %q: %w", errInvalidPath, path, field, err)
 }

--- a/pkg/service/aerospike/tls.go
+++ b/pkg/service/aerospike/tls.go
@@ -85,13 +85,12 @@ func loadCertPool(caFile, caPath string) (*x509.CertPool, error) {
 
 	// Load from CAFile if provided.
 	if caFile != "" {
-		root, name, err := safepath.OpenRootForFile(caFile)
+		pemBytes, err := safepath.ReadFile(caFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open CA file: %w", err)
+			return nil, fmt.Errorf("failed to read CA file: %w", err)
 		}
-		defer root.Close()
 
-		if err := appendCertFile(pool, root, name); err != nil {
+		if err := appendCertPEM(pool, pemBytes, caFile); err != nil {
 			return nil, err
 		}
 	}
@@ -129,7 +128,13 @@ func loadCertsFromPath(pool *x509.CertPool, caPath string) error {
 		if fileInfo.IsDir() {
 			continue
 		}
-		if err := appendCertFile(pool, root, name); err != nil {
+		pemBytes, err := root.ReadFile(name)
+		if err != nil {
+			slog.Warn("Failed to read certificate file, skipping",
+				slog.String("path", name), attr.Error(err))
+			continue
+		}
+		if err := appendCertPEM(pool, pemBytes, name); err != nil {
 			slog.Warn("Failed to append certificate file, skipping",
 				slog.String("path", name), attr.Error(err))
 		}
@@ -138,13 +143,7 @@ func loadCertsFromPath(pool *x509.CertPool, caPath string) error {
 	return nil
 }
 
-// appendCertFile reads a PEM file and appends its certificates to the given CertPool.
-func appendCertFile(pool *x509.CertPool, root *os.Root, name string) error {
-	pemBytes, err := root.ReadFile(name)
-	if err != nil {
-		return err
-	}
-
+func appendCertPEM(pool *x509.CertPool, pemBytes []byte, name string) error {
 	if !pool.AppendCertsFromPEM(pemBytes) {
 		return fmt.Errorf("failed to append certificates from CA file %s", name)
 	}

--- a/pkg/service/aerospike/tls.go
+++ b/pkg/service/aerospike/tls.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/aerospike/aerospike-backup-service/v3/internal/attr"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 var protocolMap = map[string]uint16{
@@ -85,48 +85,68 @@ func loadCertPool(caFile, caPath string) (*x509.CertPool, error) {
 
 	// Load from CAFile if provided.
 	if caFile != "" {
-		if err := appendCertFile(pool, caFile); err != nil {
+		root, name, err := safepath.OpenRootForFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open CA file: %w", err)
+		}
+		defer root.Close()
+
+		if err := appendCertFile(pool, root, name); err != nil {
 			return nil, err
 		}
 	}
 
 	// Load from CAPath if provided.
 	if caPath != "" {
-		files, err := os.ReadDir(caPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read CA path directory %s: %w", caPath, err)
-		}
-
-		for _, file := range files {
-			path := filepath.Join(caPath, file.Name())
-			fileInfo, err := os.Stat(path)
-			if err != nil {
-				slog.Warn("Failed to stat file, skipping",
-					slog.String("path", path), attr.Error(err))
-				continue
-			}
-			if fileInfo.IsDir() {
-				continue
-			}
-			if err := appendCertFile(pool, path); err != nil {
-				slog.Warn("Failed to append certificate file, skipping",
-					slog.String("path", path), attr.Error(err))
-			}
+		if err := loadCertsFromPath(pool, caPath); err != nil {
+			return nil, err
 		}
 	}
 
 	return pool, nil
 }
 
+func loadCertsFromPath(pool *x509.CertPool, caPath string) error {
+	root, err := os.OpenRoot(caPath)
+	if err != nil {
+		return fmt.Errorf("failed to open CA path directory: %w", err)
+	}
+	defer root.Close()
+
+	files, err := safepath.ReadDir(caPath)
+	if err != nil {
+		return fmt.Errorf("failed to read CA path directory: %w", err)
+	}
+
+	for _, file := range files {
+		name := file.Name()
+		fileInfo, err := root.Stat(name)
+		if err != nil {
+			slog.Warn("Failed to stat file, skipping",
+				slog.String("path", name), attr.Error(err))
+			continue
+		}
+		if fileInfo.IsDir() {
+			continue
+		}
+		if err := appendCertFile(pool, root, name); err != nil {
+			slog.Warn("Failed to append certificate file, skipping",
+				slog.String("path", name), attr.Error(err))
+		}
+	}
+
+	return nil
+}
+
 // appendCertFile reads a PEM file and appends its certificates to the given CertPool.
-func appendCertFile(pool *x509.CertPool, path string) error {
-	pemBytes, err := readFromFile(path)
+func appendCertFile(pool *x509.CertPool, root *os.Root, name string) error {
+	pemBytes, err := root.ReadFile(name)
 	if err != nil {
 		return err
 	}
 
 	if !pool.AppendCertsFromPEM(pemBytes) {
-		return fmt.Errorf("failed to append certificates from CA file %s", path)
+		return fmt.Errorf("failed to append certificates from CA file %s", name)
 	}
 
 	return nil
@@ -247,9 +267,9 @@ func parseCipherSuites(cipherSuiteStr string) ([]uint16, error) {
 }
 
 func readFromFile(filePath string) ([]byte, error) {
-	dataBytes, err := os.ReadFile(filePath)
+	dataBytes, err := safepath.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read from file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 	data := bytes.TrimSuffix(dataBytes, []byte("\n"))
 

--- a/pkg/service/secret/password.go
+++ b/pkg/service/secret/password.go
@@ -40,7 +40,7 @@ func (r passwordResolverImpl) Resolve(ctx context.Context, creds *model.Credenti
 	if creds.PasswordPath != "" {
 		data, err := safepath.ReadFile(creds.PasswordPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read password from password-path: %w", err)
+			return nil, errors.New("failed to read password from password-path")
 		}
 		slog.Debug("Successfully read password from password-path")
 

--- a/pkg/service/secret/password.go
+++ b/pkg/service/secret/password.go
@@ -5,10 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
 // PasswordResolver resolves password from either a file, a literal value,
@@ -38,9 +38,9 @@ func (r passwordResolverImpl) Resolve(ctx context.Context, creds *model.Credenti
 
 	// 1) Resolve Path (file)
 	if creds.PasswordPath != "" {
-		data, err := os.ReadFile(creds.PasswordPath)
+		data, err := safepath.ReadFile(creds.PasswordPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read password from password-path %s: %w", creds.PasswordPath, err)
+			return nil, fmt.Errorf("failed to read password from password-path: %w", err)
 		}
 		slog.Debug("Successfully read password from password-path")
 

--- a/pkg/service/secret/password_test.go
+++ b/pkg/service/secret/password_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	testdataFolder = "./testdata"
+	testdataFolder = "testdata"
 	passwordPath   = testdataFolder + "/password.txt"
 )
 

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -9,14 +9,10 @@ import (
 	"strings"
 )
 
-// HasParentPathComponent reports whether path contains a ".." path element.
-func HasParentPathComponent(path string) bool {
-	return slices.Contains(strings.Split(path, string(filepath.Separator)), "..")
-}
-
 // ValidateClean reports whether path is safe for config use.
 // Empty paths are allowed and return nil.
-// Paths must be in canonical form and must not contain ".." elements.
+// Paths must be in canonical form (no ./ prefix, redundant separators, etc.)
+// and must not contain ".." elements.
 func ValidateClean(path string) error {
 	if path == "" {
 		return nil
@@ -27,7 +23,7 @@ func ValidateClean(path string) error {
 		return fmt.Errorf("path %q is not clean (normalizes to %q)", path, cleaned)
 	}
 
-	if HasParentPathComponent(path) {
+	if slices.Contains(strings.Split(path, string(filepath.Separator)), "..") {
 		return fmt.Errorf("path %q must not contain traversal", path)
 	}
 

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -43,9 +43,15 @@ func EnsureFileExists(path string) error {
 	}
 	defer root.Close()
 
-	_, err = root.Stat(name)
+	info, err := root.Stat(name)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("path %q is a directory, not a file", path)
+	}
 
-	return err
+	return nil
 }
 
 // ReadFile reads the full contents of a validated file path using os.Root.
@@ -55,6 +61,14 @@ func ReadFile(path string) ([]byte, error) {
 		return nil, err
 	}
 	defer root.Close()
+
+	info, err := root.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("path %q is a directory, not a file", path)
+	}
 
 	return root.ReadFile(name)
 }

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -1,0 +1,85 @@
+package safepath
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ValidateClean reports whether path is already in canonical form.
+// Empty paths are allowed and return nil.
+func ValidateClean(path string) error {
+	if path == "" {
+		return nil
+	}
+
+	cleaned := filepath.Clean(path)
+	if cleaned != path {
+		return fmt.Errorf("path %q is not clean (normalizes to %q)", path, cleaned)
+	}
+
+	return nil
+}
+
+// Stat returns file metadata for a validated clean path using os.Root.
+func Stat(path string) (fs.FileInfo, error) {
+	root, name, err := openRootForFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return root.Stat(name)
+}
+
+// ReadFile reads the full contents of a file at a validated clean path using os.Root.
+func ReadFile(path string) ([]byte, error) {
+	root, name, err := openRootForFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return root.ReadFile(name)
+}
+
+// ReadDir lists entries in a validated clean directory path using os.Root.
+func ReadDir(path string) ([]fs.DirEntry, error) {
+	if err := ValidateClean(path); err != nil {
+		return nil, err
+	}
+
+	root, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	return fs.ReadDir(root.FS(), ".")
+}
+
+// OpenRoot opens an os.Root for the directory part of a file path.
+func OpenRootForFile(path string) (*os.Root, string, error) {
+	return openRootForFile(path)
+}
+
+func openRootForFile(path string) (*os.Root, string, error) {
+	dir, name := filepath.Split(path)
+	if name == "" {
+		return nil, "", fmt.Errorf("path %q is not a file path", path)
+	}
+
+	if dir == "" {
+		dir = "."
+	} else {
+		dir = filepath.Clean(dir)
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return root, name, nil
+}

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -5,10 +5,18 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 )
 
-// ValidateClean reports whether path is already in canonical form.
+// HasParentPathComponent reports whether path contains a ".." path element.
+func HasParentPathComponent(path string) bool {
+	return slices.Contains(strings.Split(path, string(filepath.Separator)), "..")
+}
+
+// ValidateClean reports whether path is safe for config use.
 // Empty paths are allowed and return nil.
+// Paths must be in canonical form and must not contain ".." elements.
 func ValidateClean(path string) error {
 	if path == "" {
 		return nil
@@ -17,6 +25,10 @@ func ValidateClean(path string) error {
 	cleaned := filepath.Clean(path)
 	if cleaned != path {
 		return fmt.Errorf("path %q is not clean (normalizes to %q)", path, cleaned)
+	}
+
+	if HasParentPathComponent(path) {
+		return fmt.Errorf("path %q must not contain traversal", path)
 	}
 
 	return nil

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -30,18 +30,25 @@ func ValidateClean(path string) error {
 	return nil
 }
 
-// Stat returns file metadata for a validated clean path using os.Root.
-func Stat(path string) (fs.FileInfo, error) {
+// EnsureFileExists checks that a validated file path exists using os.Root.
+// path must have passed ValidateClean.
+func EnsureFileExists(path string) error {
+	if path == "" {
+		return nil
+	}
+
 	root, name, err := openRootForFile(path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer root.Close()
 
-	return root.Stat(name)
+	_, err = root.Stat(name)
+
+	return err
 }
 
-// ReadFile reads the full contents of a file at a validated clean path using os.Root.
+// ReadFile reads the full contents of a validated file path using os.Root.
 func ReadFile(path string) ([]byte, error) {
 	root, name, err := openRootForFile(path)
 	if err != nil {
@@ -52,12 +59,8 @@ func ReadFile(path string) ([]byte, error) {
 	return root.ReadFile(name)
 }
 
-// ReadDir lists entries in a validated clean directory path using os.Root.
+// ReadDir lists entries in a validated directory path using os.Root.
 func ReadDir(path string) ([]fs.DirEntry, error) {
-	if err := ValidateClean(path); err != nil {
-		return nil, err
-	}
-
 	root, err := os.OpenRoot(path)
 	if err != nil {
 		return nil, err
@@ -67,11 +70,7 @@ func ReadDir(path string) ([]fs.DirEntry, error) {
 	return fs.ReadDir(root.FS(), ".")
 }
 
-// OpenRoot opens an os.Root for the directory part of a file path.
-func OpenRootForFile(path string) (*os.Root, string, error) {
-	return openRootForFile(path)
-}
-
+// openRootForFile splits a validated file path into its directory and base name.
 func openRootForFile(path string) (*os.Root, string, error) {
 	dir, name := filepath.Split(path)
 	if name == "" {
@@ -80,8 +79,6 @@ func openRootForFile(path string) (*os.Root, string, error) {
 
 	if dir == "" {
 		dir = "."
-	} else {
-		dir = filepath.Clean(dir)
 	}
 
 	root, err := os.OpenRoot(dir)

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -59,14 +59,12 @@ func TestReadFileRejectsRootEscape(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestStat(t *testing.T) {
+func TestEnsureFileExists(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "cert.pem")
 	require.NoError(t, os.WriteFile(filePath, []byte("cert"), 0600))
 
-	info, err := Stat(filePath)
-	require.NoError(t, err)
-	require.False(t, info.IsDir())
+	require.NoError(t, EnsureFileExists(filePath))
 }
 
 func TestReadDir(t *testing.T) {

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -35,13 +35,6 @@ func TestValidateClean(t *testing.T) {
 	}
 }
 
-func TestHasParentPathComponent(t *testing.T) {
-	require.True(t, HasParentPathComponent("../etc/passwd"))
-	require.True(t, HasParentPathComponent("backups/../../outside"))
-	require.False(t, HasParentPathComponent("backups/data"))
-	require.False(t, HasParentPathComponent("/var/backups"))
-}
-
 func TestReadFile(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "secret.txt")

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -18,7 +18,7 @@ func TestValidateClean(t *testing.T) {
 		{name: "clean relative path", path: "testdata/password.txt"},
 		{name: "clean absolute path", path: "/etc/ssl/certs/ca.pem"},
 		{name: "parent traversal", path: "certs/../../outside.pem", wantErr: true},
-		{name: "leading parent traversal segment", path: "../etc/passwd"},
+		{name: "leading parent traversal segment", path: "../etc/passwd", wantErr: true},
 		{name: "dot prefix", path: "./certs/ca.pem", wantErr: true},
 		{name: "redundant separators", path: "/etc//ssl/ca.pem", wantErr: true},
 	}
@@ -33,6 +33,13 @@ func TestValidateClean(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasParentPathComponent(t *testing.T) {
+	require.True(t, HasParentPathComponent("../etc/passwd"))
+	require.True(t, HasParentPathComponent("backups/../../outside"))
+	require.False(t, HasParentPathComponent("backups/data"))
+	require.False(t, HasParentPathComponent("/var/backups"))
 }
 
 func TestReadFile(t *testing.T) {

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -1,0 +1,80 @@
+package safepath
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateClean(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "empty path", path: ""},
+		{name: "clean relative path", path: "testdata/password.txt"},
+		{name: "clean absolute path", path: "/etc/ssl/certs/ca.pem"},
+		{name: "parent traversal", path: "certs/../../outside.pem", wantErr: true},
+		{name: "leading parent traversal segment", path: "../etc/passwd"},
+		{name: "dot prefix", path: "./certs/ca.pem", wantErr: true},
+		{name: "redundant separators", path: "/etc//ssl/ca.pem", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClean(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadFile(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "secret.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("secret"), 0600))
+
+	data, err := ReadFile(filePath)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secret"), data)
+}
+
+func TestReadFileRejectsRootEscape(t *testing.T) {
+	rootDir := t.TempDir()
+	innerDir := filepath.Join(rootDir, "inner")
+	require.NoError(t, os.Mkdir(innerDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "secret.txt"), []byte("secret"), 0600))
+
+	root, err := os.OpenRoot(innerDir)
+	require.NoError(t, err)
+	defer root.Close()
+
+	_, err = root.ReadFile("../secret.txt")
+	require.Error(t, err)
+}
+
+func TestStat(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "cert.pem")
+	require.NoError(t, os.WriteFile(filePath, []byte("cert"), 0600))
+
+	info, err := Stat(filePath)
+	require.NoError(t, err)
+	require.False(t, info.IsDir())
+}
+
+func TestReadDir(t *testing.T) {
+	tempDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "a.pem"), []byte("a"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "b.pem"), []byte("b"), 0600))
+
+	entries, err := ReadDir(tempDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -35,6 +35,24 @@ func TestValidateClean(t *testing.T) {
 	}
 }
 
+func TestEnsureFileExistsRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "certs"), 0755))
+
+	err := EnsureFileExists(filepath.Join(dir, "certs"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "directory")
+}
+
+func TestReadFileRejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "certs"), 0755))
+
+	_, err := ReadFile(filepath.Join(dir, "certs"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "directory")
+}
+
 func TestReadFile(t *testing.T) {
 	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "secret.txt")


### PR DESCRIPTION
## What does this change do?

Resolves CodeQL path-injection findings from PR #616 by validating config-controlled filesystem paths before use and confining file access with `os.Root`.

- Add `pkg/util/safepath` helpers: `ValidateClean` (reject paths where `filepath.Clean(path) != path` or path contains `..`), `HasParentPathComponent`, plus `Stat`/`ReadFile`/`ReadDir` backed by `os.OpenRoot`.
- Validate TLS cert/key paths (`ca-file`, `cert-file`, `key-file`, `ca-path`) and credentials `password-path` in DTO `Validate()`.
- Unify traversal checks: replace dto `hasParentPathComponent` with `safepath` in local storage, object storage paths, and restore `backup-data-path` validation.
- Switch TLS cert loading and password file reads to `os.Root`-based access.
- Stop logging password file paths in error messages.

Related: https://aerospike.atlassian.net/browse/BKRS-338

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [ ] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

Paths that normalize under `filepath.Clean` (e.g. `./certs/ca.pem`, `a//b`, embedded `../`) or contain `..` segments (e.g. `../etc/passwd`) are rejected at validation with a detailed error.

Other config-controlled paths (logger filename, encryption key-file, GCP key-file-path) are out of scope for this PR but noted in BKRS-338 / BKRS-271 follow-up work.