### PR TITLE
BKRS-315 Add Aerospike cluster auth integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-logr/logr v1.4.4
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
+	github.com/moby/moby/api v1.54.2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
@@ -104,7 +105,6 @@ require (
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/api v1.54.2 // indirect
 	github.com/moby/moby/client v0.4.1 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect

--- a/test/integration/auth_suite.go
+++ b/test/integration/auth_suite.go
@@ -31,7 +31,10 @@ import (
 const (
 	containerConfPath = "/etc/aerospike/aerospike.conf"
 	tlsPort           = "4333/tcp"
-	tlsName           = "test-tls"
+	// tlsName is both the Aerospike `tls` stanza name and the DNS SAN of the server
+	// certificate. The client sends it as SNI and then verifies it against the cert,
+	// so the two must stay in sync.
+	tlsName = "test-tls"
 
 	adminUser     = "admin"
 	adminPassword = "admin"
@@ -45,8 +48,8 @@ const (
 	containerServerKey  = "/etc/aerospike/server.key"
 )
 
-// Stock EE docker conf plus a security stanza. The image entrypoint overwrites
-// /etc/aerospike/aerospike.conf on first start, so this is copied in after that.
+// secureConf is the stock EE docker conf plus an empty security stanza, which is all it
+// takes to turn RBAC on. The server then starts with the default admin/admin superuser.
 const secureConf = `service {
 	feature-key-file /etc/aerospike/features.conf
 	cluster-name docker
@@ -92,25 +95,63 @@ namespace test {
 }
 `
 
+// authCluster is one running secured node.
 type authCluster struct {
-	seed      dto.SeedNode
+	// seed is what ABS is pointed at, and carries the profile under test: the TLS port
+	// and tls-name for the TLS profiles.
+	seed dto.SeedNode
+	// adminSeed is always the plaintext service port. User and role management is done
+	// out of band so that bootstrapping never depends on the transport under test.
 	adminSeed dto.SeedNode
-	admin     *as.Client
+	// adminClient is logged in as the superuser over adminSeed.
+	adminClient *as.Client
 }
 
+// certificateFiles is a throwaway PKI generated per suite run.
 type certificateFiles struct {
-	caCert       string
-	serverCert   []byte
-	serverKey    []byte
+	caCert string
+	// serverCert and serverKey stay in memory because they are copied straight into the
+	// container rather than read by the client.
+	serverCert []byte
+	serverKey  []byte
+	// The client certificate common names are Aerospike usernames on purpose: with
+	// auth-mode PKI the server takes the username from the CN rather than from the
+	// connection credentials.
 	internalCert string
 	internalKey  string
 	pkiCert      string
 	pkiKey       string
 }
 
-// AuthSuite runs connection smoke tests against secured EE nodes. Only one
-// Aerospike container is kept running at a time; each Test* method starts the
-// profile it needs and testcontainers cleanup stops it when that test returns.
+// authProfile is the transport and client-authentication setup of a secured node.
+//
+// Each profile needs its own server process: plain and TLS differ in which ports are
+// open, and the two TLS profiles differ in tls-authenticate-client.
+type authProfile int
+
+const (
+	// profilePlain serves the plaintext port only.
+	profilePlain authProfile = iota
+	// profileServerTLS presents a server certificate and does not ask for a client one.
+	profileServerTLS
+	// profileMutualTLS additionally requires a client certificate, which is what PKI
+	// authentication needs to identify the user.
+	profileMutualTLS
+)
+
+func (p authProfile) usesTLS() bool {
+	return p != profilePlain
+}
+
+func (p authProfile) requiresClientCert() bool {
+	return p == profileMutualTLS
+}
+
+// AuthSuite runs connection smoke tests against secured EE nodes.
+//
+// Since no two profiles can share a server process, each Test* method starts the node
+// it needs and testcontainers cleanup stops it when that test returns, keeping only one
+// secured container alive at a time.
 type AuthSuite struct {
 	Suite
 
@@ -125,37 +166,48 @@ func (s *AuthSuite) SetupSuite() {
 // client, and each scenario truncates the node it just started.
 func (s *AuthSuite) SetupTest() {}
 
-func (s *AuthSuite) startAndProvision(withTLS, requireClientCert, withPKI bool) authCluster {
+// startAndProvision boots a node for one profile and creates the users the tests log in as.
+func (s *AuthSuite) startAndProvision(profile authProfile) authCluster {
 	t := s.T()
-	cluster := s.startSecureAerospike(context.Background(), withTLS, requireClientCert)
+	// Not t.Context(): it is canceled before t.Cleanup runs, which would make the
+	// terminate call below fail and leave the container behind.
+	cluster := s.startSecureAerospike(context.Background(), profile)
 
-	s.Require().NoError(cluster.admin.CreateUser(nil, intUser, intPassword, []string{readWriteRole}))
-	s.Require().NoError(cluster.admin.GrantRoles(
+	admin := cluster.adminClient
+	s.Require().NoError(admin.CreateUser(nil, intUser, intPassword, []string{readWriteRole}))
+	s.Require().NoError(admin.GrantRoles(
 		nil, adminUser, []string{"sys-admin", "truncate", readWriteRole},
 	))
-	if withPKI {
-		s.Require().NoError(cluster.admin.CreatePKIUser(nil, pkiUser, []string{readWriteRole}))
+	if profile.requiresClientCert() {
+		s.Require().NoError(admin.CreatePKIUser(nil, pkiUser, []string{readWriteRole}))
 	}
 
-	cluster.admin.Close()
+	// Roles are baked into the session token at login, so the admin client that granted
+	// them still holds a token without truncate. Reconnect to pick the new roles up.
+	admin.Close()
 	admin, err := newAdminClient(cluster.adminSeed)
 	s.Require().NoError(err)
 	t.Cleanup(admin.Close)
-	cluster.admin = admin
+	cluster.adminClient = admin
 
 	return cluster
 }
 
+// startSecureAerospike brings up a single node with security enabled.
+//
+// The image entrypoint rewrites /etc/aerospike/aerospike.conf every time it boots a
+// fresh container, so the config cannot simply be mounted. The sequence is: let the
+// image start normally, stop it, copy in the config (and certificates), start it again.
+//
 //nolint:funlen // Container lifecycle is clearer when setup remains in one place.
-func (s *AuthSuite) startSecureAerospike(
-	ctx context.Context,
-	withTLS bool,
-	requireClientCert bool,
-) authCluster {
+func (s *AuthSuite) startSecureAerospike(ctx context.Context, profile authProfile) authCluster {
 	t := s.T()
 
 	var options []testcontainers.ContainerCustomizer
-	if withTLS {
+	if profile.usesTLS() {
+		// Docker Desktop hands out a new host port whenever a container is stopped and
+		// started, but the port has to be baked into tls-alternate-access-port before the
+		// restart. Pinning the binding at create time keeps it stable across the restart.
 		mappedTLSPort := availableHostPort(ctx, s)
 		options = append(
 			options,
@@ -172,48 +224,47 @@ func (s *AuthSuite) startSecureAerospike(
 		)
 	}
 
-	container, err := tcAerospike.Run(ctx, aerospikeImage, options...)
+	asContainer, err := tcAerospike.Run(ctx, aerospikeImage, options...)
 	s.Require().NoError(err)
 	t.Cleanup(func() {
-		if err := container.Terminate(ctx); err != nil {
+		if err := asContainer.Terminate(ctx); err != nil {
 			t.Logf("failed to terminate Aerospike container: %v", err)
 		}
 	})
 
-	host, err := container.Host(ctx)
+	host, err := asContainer.Host(ctx)
 	s.Require().NoError(err)
 
 	var mappedTLSPort int
-	if withTLS {
-		mapped, mapErr := container.MappedPort(ctx, tlsPort)
+	if profile.usesTLS() {
+		mapped, mapErr := asContainer.MappedPort(ctx, tlsPort)
 		s.Require().NoError(mapErr)
 		mappedTLSPort = int(mapped.Num())
 	}
 
 	stopTimeout := 10 * time.Second
-	s.Require().NoError(container.Stop(ctx, &stopTimeout))
+	s.Require().NoError(asContainer.Stop(ctx, &stopTimeout))
 
 	config := secureConf
-	if withTLS {
-		config = tlsSecureConf(host, mappedTLSPort, requireClientCert)
-		s.copyServerCertificates(ctx, container)
+	if profile.usesTLS() {
+		config = tlsSecureConf(host, mappedTLSPort, profile)
+		s.copyServerCertificates(ctx, asContainer)
 	}
-	s.Require().NoError(container.CopyToContainer(ctx, []byte(config), containerConfPath, 0o644))
-	s.Require().NoError(container.Start(ctx))
+	s.Require().NoError(asContainer.CopyToContainer(ctx, []byte(config), containerConfPath, 0o644))
+	s.Require().NoError(asContainer.Start(ctx))
 
-	// Start() can return after the module sees logs from the first boot. Poll a
-	// real authenticated connection before proceeding.
-	plainPort, err := container.MappedPort(ctx, "3000/tcp")
+	// Poll real connections.
+	plainPort, err := asContainer.MappedPort(ctx, "3000/tcp")
 	s.Require().NoError(err)
 	adminSeed := dto.SeedNode{HostName: host, Port: dto.Port(plainPort.Num())}
-	s.Require().NoError(waitForAdmin(ctx, adminSeed))
+	s.Require().NoError(waitForDBStart(ctx, adminSeed))
 
 	seed := adminSeed
-	if withTLS {
-		mapped, mapErr := container.MappedPort(ctx, tlsPort)
+	if profile.usesTLS() {
+		mapped, mapErr := asContainer.MappedPort(ctx, tlsPort)
 		s.Require().NoError(mapErr)
 		s.Equal(mappedTLSPort, int(mapped.Num()), "TLS port mapping changed after restart")
-		s.Require().NoError(s.waitForTLS(ctx, host, mappedTLSPort, requireClientCert))
+		s.Require().NoError(s.waitForTLS(ctx, host, mappedTLSPort, profile))
 		seed = dto.SeedNode{
 			HostName: host,
 			Port:     dto.Port(mapped.Num()),
@@ -224,13 +275,18 @@ func (s *AuthSuite) startSecureAerospike(
 	admin, err := newAdminClient(adminSeed)
 	s.Require().NoError(err)
 
-	return authCluster{seed: seed, adminSeed: adminSeed, admin: admin}
+	return authCluster{seed: seed, adminSeed: adminSeed, adminClient: admin}
 }
 
+// tlsSecureConf keeps the plaintext service port for bootstrapping and adds a TLS port.
+//
+// The tls-alternate-access-* settings are what the node gossips back to clients; without
+// them it would advertise its in-container address, which is unreachable from the host.
+//
 //nolint:funlen // The embedded Aerospike configuration is intentionally kept together.
-func tlsSecureConf(host string, mappedTLSPort int, requireClientCert bool) string {
+func tlsSecureConf(host string, mappedTLSPort int, profile authProfile) string {
 	clientAuthentication := "false"
-	if requireClientCert {
+	if profile.requiresClientCert() {
 		clientAuthentication = "any"
 	}
 
@@ -317,7 +373,7 @@ func (s *AuthSuite) copyServerCertificates(ctx context.Context, container *tcAer
 	s.Require().NoError(container.CopyToContainer(ctx, s.certs.serverKey, containerServerKey, 0o600))
 }
 
-func (s *AuthSuite) waitForTLS(ctx context.Context, host string, port int, withClientCert bool) error {
+func (s *AuthSuite) waitForTLS(ctx context.Context, host string, port int, profile authProfile) error {
 	caPEM, err := os.ReadFile(s.certs.caCert)
 	if err != nil {
 		return err
@@ -333,7 +389,7 @@ func (s *AuthSuite) waitForTLS(ctx context.Context, host string, port int, withC
 		ServerName: tlsName,
 		MinVersion: tls.VersionTLS12,
 	}
-	if withClientCert {
+	if profile.requiresClientCert() {
 		cert, loadErr := tls.LoadX509KeyPair(s.certs.internalCert, s.certs.internalKey)
 		if loadErr != nil {
 			return loadErr
@@ -367,7 +423,7 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 	dir := s.T().TempDir()
 
 	caTemplate := &x509.Certificate{
-		SerialNumber:          randomSerial(s),
+		SerialNumber:          big.NewInt(1),
 		Subject:               pkix.Name{CommonName: "ABS integration CA"},
 		NotBefore:             time.Now().Add(-time.Hour),
 		NotAfter:              time.Now().Add(24 * time.Hour),
@@ -386,10 +442,13 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 	caFile := filepath.Join(dir, "ca.crt")
 	s.Require().NoError(os.WriteFile(caFile, caPEM, 0o600))
 
+	// The DNS SAN, not the common name, is what the client checks, so tlsName has to
+	// appear there.
 	serverCert, serverKey := issueCertificate(
 		s,
 		caCert,
 		caKey,
+		2,
 		pkix.Name{CommonName: tlsName},
 		[]string{tlsName},
 		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -398,6 +457,7 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 		s,
 		caCert,
 		caKey,
+		3,
 		pkix.Name{CommonName: intUser},
 		nil,
 		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -406,6 +466,7 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 		s,
 		caCert,
 		caKey,
+		4, // https://xkcd.com/221/
 		pkix.Name{CommonName: pkiUser},
 		nil,
 		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
@@ -426,6 +487,7 @@ func issueCertificate(
 	s *AuthSuite,
 	ca *x509.Certificate,
 	caKey *rsa.PrivateKey,
+	serial int64,
 	subject pkix.Name,
 	dnsNames []string,
 	usage []x509.ExtKeyUsage,
@@ -434,7 +496,7 @@ func issueCertificate(
 	s.Require().NoError(err)
 
 	template := &x509.Certificate{
-		SerialNumber: randomSerial(s),
+		SerialNumber: big.NewInt(serial),
 		Subject:      subject,
 		DNSNames:     dnsNames,
 		NotBefore:    time.Now().Add(-time.Hour),
@@ -449,20 +511,13 @@ func issueCertificate(
 		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 }
 
-func randomSerial(s *AuthSuite) *big.Int {
-	limit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serial, err := rand.Int(rand.Reader, limit)
-	s.Require().NoError(err)
-	return serial
-}
-
 func writeCertificateFile(s *AuthSuite, dir, name string, content []byte) string {
 	path := filepath.Join(dir, name)
 	s.Require().NoError(os.WriteFile(path, content, 0o600))
 	return path
 }
 
-func waitForAdmin(ctx context.Context, seed dto.SeedNode) error {
+func waitForDBStart(ctx context.Context, seed dto.SeedNode) error {
 	deadline := time.Now().Add(45 * time.Second)
 	var last error
 
@@ -486,6 +541,9 @@ func waitForAdmin(ctx context.Context, seed dto.SeedNode) error {
 	return fmt.Errorf("admin login to %s:%d: %w", seed.HostName, seed.Port, last)
 }
 
+// newAdminClient connects as the default EE superuser over the plaintext port. Every
+// profile keeps that port open so bootstrapping is identical regardless of the transport
+// under test.
 func newAdminClient(seed dto.SeedNode) (*as.Client, error) {
 	policy := as.NewClientPolicy()
 	policy.User = adminUser

--- a/test/integration/auth_suite.go
+++ b/test/integration/auth_suite.go
@@ -1,0 +1,497 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	as "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/testcontainers/testcontainers-go"
+	tcAerospike "github.com/testcontainers/testcontainers-go/modules/aerospike"
+)
+
+const (
+	containerConfPath = "/etc/aerospike/aerospike.conf"
+	tlsPort           = "4333/tcp"
+	tlsName           = "test-tls"
+
+	adminUser     = "admin"
+	adminPassword = "admin"
+	intUser       = "intuser"
+	intPassword   = "s3cr3t!"
+	pkiUser       = "pkiuser"
+	readWriteRole = "read-write"
+
+	containerCAFile     = "/etc/aerospike/ca.crt"
+	containerServerCert = "/etc/aerospike/server.crt"
+	containerServerKey  = "/etc/aerospike/server.key"
+)
+
+// Stock EE docker conf plus a security stanza. The image entrypoint overwrites
+// /etc/aerospike/aerospike.conf on first start, so this is copied in after that.
+const secureConf = `service {
+	feature-key-file /etc/aerospike/features.conf
+	cluster-name docker
+}
+
+logging {
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address any
+		port 3000
+	}
+
+	heartbeat {
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		address local
+		port 3001
+	}
+}
+
+security {
+}
+
+namespace test {
+	replication-factor 1
+	nsup-period 120
+	storage-engine device {
+		file /opt/aerospike/data/test.dat
+		filesize 4G
+		read-page-cache true
+	}
+}
+`
+
+type authCluster struct {
+	seed      dto.SeedNode
+	adminSeed dto.SeedNode
+	admin     *as.Client
+}
+
+type certificateFiles struct {
+	caCert       string
+	serverCert   []byte
+	serverKey    []byte
+	internalCert string
+	internalKey  string
+	pkiCert      string
+	pkiKey       string
+}
+
+// AuthSuite runs connection smoke tests against secured EE nodes. Only one
+// Aerospike container is kept running at a time; each Test* method starts the
+// profile it needs and testcontainers cleanup stops it when that test returns.
+type AuthSuite struct {
+	Suite
+
+	certs certificateFiles
+}
+
+func (s *AuthSuite) SetupSuite() {
+	s.certs = s.generateCertificates()
+}
+
+// SetupTest skips the shared namespace truncate: AuthSuite has no suite-wide
+// client, and each scenario truncates the node it just started.
+func (s *AuthSuite) SetupTest() {}
+
+func (s *AuthSuite) startAndProvision(withTLS, requireClientCert, withPKI bool) authCluster {
+	t := s.T()
+	cluster := s.startSecureAerospike(context.Background(), withTLS, requireClientCert)
+
+	s.Require().NoError(cluster.admin.CreateUser(nil, intUser, intPassword, []string{readWriteRole}))
+	s.Require().NoError(cluster.admin.GrantRoles(
+		nil, adminUser, []string{"sys-admin", "truncate", readWriteRole},
+	))
+	if withPKI {
+		s.Require().NoError(cluster.admin.CreatePKIUser(nil, pkiUser, []string{readWriteRole}))
+	}
+
+	cluster.admin.Close()
+	admin, err := newAdminClient(cluster.adminSeed)
+	s.Require().NoError(err)
+	t.Cleanup(admin.Close)
+	cluster.admin = admin
+
+	return cluster
+}
+
+//nolint:funlen // Container lifecycle is clearer when setup remains in one place.
+func (s *AuthSuite) startSecureAerospike(
+	ctx context.Context,
+	withTLS bool,
+	requireClientCert bool,
+) authCluster {
+	t := s.T()
+
+	var options []testcontainers.ContainerCustomizer
+	if withTLS {
+		mappedTLSPort := availableHostPort(ctx, s)
+		options = append(
+			options,
+			testcontainers.WithExposedPorts(tlsPort),
+			testcontainers.WithHostConfigModifier(func(hostConfig *container.HostConfig) {
+				if hostConfig.PortBindings == nil {
+					hostConfig.PortBindings = network.PortMap{}
+				}
+				hostConfig.PortBindings[network.MustParsePort(tlsPort)] = []network.PortBinding{{
+					HostIP:   netip.MustParseAddr("127.0.0.1"),
+					HostPort: strconv.Itoa(mappedTLSPort),
+				}}
+			}),
+		)
+	}
+
+	container, err := tcAerospike.Run(ctx, aerospikeImage, options...)
+	s.Require().NoError(err)
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("failed to terminate Aerospike container: %v", err)
+		}
+	})
+
+	host, err := container.Host(ctx)
+	s.Require().NoError(err)
+
+	var mappedTLSPort int
+	if withTLS {
+		mapped, mapErr := container.MappedPort(ctx, tlsPort)
+		s.Require().NoError(mapErr)
+		mappedTLSPort = int(mapped.Num())
+	}
+
+	stopTimeout := 10 * time.Second
+	s.Require().NoError(container.Stop(ctx, &stopTimeout))
+
+	config := secureConf
+	if withTLS {
+		config = tlsSecureConf(host, mappedTLSPort, requireClientCert)
+		s.copyServerCertificates(ctx, container)
+	}
+	s.Require().NoError(container.CopyToContainer(ctx, []byte(config), containerConfPath, 0o644))
+	s.Require().NoError(container.Start(ctx))
+
+	// Start() can return after the module sees logs from the first boot. Poll a
+	// real authenticated connection before proceeding.
+	plainPort, err := container.MappedPort(ctx, "3000/tcp")
+	s.Require().NoError(err)
+	adminSeed := dto.SeedNode{HostName: host, Port: dto.Port(plainPort.Num())}
+	s.Require().NoError(waitForAdmin(ctx, adminSeed))
+
+	seed := adminSeed
+	if withTLS {
+		mapped, mapErr := container.MappedPort(ctx, tlsPort)
+		s.Require().NoError(mapErr)
+		s.Equal(mappedTLSPort, int(mapped.Num()), "TLS port mapping changed after restart")
+		s.Require().NoError(s.waitForTLS(ctx, host, mappedTLSPort, requireClientCert))
+		seed = dto.SeedNode{
+			HostName: host,
+			Port:     dto.Port(mapped.Num()),
+			TLSName:  tlsName,
+		}
+	}
+
+	admin, err := newAdminClient(adminSeed)
+	s.Require().NoError(err)
+
+	return authCluster{seed: seed, adminSeed: adminSeed, admin: admin}
+}
+
+//nolint:funlen // The embedded Aerospike configuration is intentionally kept together.
+func tlsSecureConf(host string, mappedTLSPort int, requireClientCert bool) string {
+	clientAuthentication := "false"
+	if requireClientCert {
+		clientAuthentication = "any"
+	}
+
+	return fmt.Sprintf(`service {
+	feature-key-file /etc/aerospike/features.conf
+	cluster-name docker
+}
+
+logging {
+	console {
+		context any info
+	}
+}
+
+network {
+	tls %[1]s {
+		ca-file %[2]s
+		cert-file %[3]s
+		key-file %[4]s
+	}
+
+	service {
+		address any
+		port 3000
+		tls-address any
+		tls-port 4333
+		tls-name %[1]s
+		tls-authenticate-client %[6]s
+		tls-alternate-access-address %[5]s
+		tls-alternate-access-port %[7]d
+	}
+
+	heartbeat {
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		address local
+		port 3001
+	}
+}
+
+security {
+}
+
+namespace test {
+	replication-factor 1
+	nsup-period 120
+	storage-engine device {
+		file /opt/aerospike/data/test.dat
+		filesize 4G
+		read-page-cache true
+	}
+}
+`,
+		tlsName,
+		containerCAFile,
+		containerServerCert,
+		containerServerKey,
+		host,
+		clientAuthentication,
+		mappedTLSPort,
+	)
+}
+
+func availableHostPort(ctx context.Context, s *AuthSuite) int {
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp4", "127.0.0.1:0")
+	s.Require().NoError(err)
+	defer listener.Close()
+
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *AuthSuite) copyServerCertificates(ctx context.Context, container *tcAerospike.Container) {
+	ca, err := os.ReadFile(s.certs.caCert)
+	s.Require().NoError(err)
+	s.Require().NoError(container.CopyToContainer(ctx, ca, containerCAFile, 0o644))
+	s.Require().NoError(container.CopyToContainer(ctx, s.certs.serverCert, containerServerCert, 0o644))
+	s.Require().NoError(container.CopyToContainer(ctx, s.certs.serverKey, containerServerKey, 0o600))
+}
+
+func (s *AuthSuite) waitForTLS(ctx context.Context, host string, port int, withClientCert bool) error {
+	caPEM, err := os.ReadFile(s.certs.caCert)
+	if err != nil {
+		return err
+	}
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return errors.New("append test CA")
+	}
+
+	config := &tls.Config{
+		RootCAs:    roots,
+		ServerName: tlsName,
+		MinVersion: tls.VersionTLS12,
+	}
+	if withClientCert {
+		cert, loadErr := tls.LoadX509KeyPair(s.certs.internalCert, s.certs.internalKey)
+		if loadErr != nil {
+			return loadErr
+		}
+		config.Certificates = []tls.Certificate{cert}
+	}
+
+	deadline := time.Now().Add(45 * time.Second)
+	address := fmt.Sprintf("%s:%d", host, port)
+	var last error
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		dialer := tls.Dialer{Config: config}
+		conn, dialErr := dialer.DialContext(ctx, "tcp", address)
+		if dialErr == nil {
+			return conn.Close()
+		}
+		last = dialErr
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("TLS connection to %s: %w", address, last)
+}
+
+func (s *AuthSuite) generateCertificates() certificateFiles {
+	dir := s.T().TempDir()
+
+	caTemplate := &x509.Certificate{
+		SerialNumber:          randomSerial(s),
+		Subject:               pkix.Name{CommonName: "ABS integration CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.Require().NoError(err)
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	s.Require().NoError(err)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	caCert, err := x509.ParseCertificate(caDER)
+	s.Require().NoError(err)
+
+	caFile := filepath.Join(dir, "ca.crt")
+	s.Require().NoError(os.WriteFile(caFile, caPEM, 0o600))
+
+	serverCert, serverKey := issueCertificate(
+		s,
+		caCert,
+		caKey,
+		pkix.Name{CommonName: tlsName},
+		[]string{tlsName},
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	)
+	internalCert, internalKey := issueCertificate(
+		s,
+		caCert,
+		caKey,
+		pkix.Name{CommonName: intUser},
+		nil,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	)
+	pkiCert, pkiKey := issueCertificate(
+		s,
+		caCert,
+		caKey,
+		pkix.Name{CommonName: pkiUser},
+		nil,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	)
+
+	return certificateFiles{
+		caCert:       caFile,
+		serverCert:   serverCert,
+		serverKey:    serverKey,
+		internalCert: writeCertificateFile(s, dir, "internal.crt", internalCert),
+		internalKey:  writeCertificateFile(s, dir, "internal.key", internalKey),
+		pkiCert:      writeCertificateFile(s, dir, "pki.crt", pkiCert),
+		pkiKey:       writeCertificateFile(s, dir, "pki.key", pkiKey),
+	}
+}
+
+func issueCertificate(
+	s *AuthSuite,
+	ca *x509.Certificate,
+	caKey *rsa.PrivateKey,
+	subject pkix.Name,
+	dnsNames []string,
+	usage []x509.ExtKeyUsage,
+) ([]byte, []byte) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	s.Require().NoError(err)
+
+	template := &x509.Certificate{
+		SerialNumber: randomSerial(s),
+		Subject:      subject,
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  usage,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	s.Require().NoError(err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}
+
+func randomSerial(s *AuthSuite) *big.Int {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	s.Require().NoError(err)
+	return serial
+}
+
+func writeCertificateFile(s *AuthSuite, dir, name string, content []byte) string {
+	path := filepath.Join(dir, name)
+	s.Require().NoError(os.WriteFile(path, content, 0o600))
+	return path
+}
+
+func waitForAdmin(ctx context.Context, seed dto.SeedNode) error {
+	deadline := time.Now().Add(45 * time.Second)
+	var last error
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		client, err := newAdminClient(seed)
+		if err == nil {
+			client.Close()
+			return nil
+		}
+
+		last = err
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("admin login to %s:%d: %w", seed.HostName, seed.Port, last)
+}
+
+func newAdminClient(seed dto.SeedNode) (*as.Client, error) {
+	policy := as.NewClientPolicy()
+	policy.User = adminUser
+	policy.Password = adminPassword
+	policy.Timeout = 2 * time.Second
+	policy.UseServicesAlternate = true
+
+	return as.NewClientWithPolicyAndHost(policy, as.NewHost(seed.HostName, int(seed.Port)))
+}

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *AuthSuite) TestInternalPlain() {
-	cluster := s.startAndProvision(false, false, false)
+	cluster := s.startAndProvision(profilePlain)
 
 	s.Run("literal password", func() {
 		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
@@ -44,7 +44,7 @@ func (s *AuthSuite) TestInternalPlain() {
 }
 
 func (s *AuthSuite) TestInternalServerTLS() {
-	cluster := s.startAndProvision(true, false, false)
+	cluster := s.startAndProvision(profileServerTLS)
 
 	s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
 		SeedNodes:            []dto.SeedNode{cluster.seed},
@@ -61,7 +61,7 @@ func (s *AuthSuite) TestInternalServerTLS() {
 }
 
 func (s *AuthSuite) TestMutualTLS() {
-	cluster := s.startAndProvision(true, true, true)
+	cluster := s.startAndProvision(profileMutualTLS)
 
 	s.Run("internal", func() {
 		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
@@ -103,8 +103,8 @@ func (s *AuthSuite) TestMutualTLS() {
 }
 
 func (s *AuthSuite) testAuthenticatedBackup(cluster authCluster, config *dto.AerospikeCluster) {
-	s.Require().NoError(cluster.admin.Truncate(nil, namespace, "", nil))
-	s.seedAuthRecords(cluster.admin, []int{10, 20, 30})
+	s.Require().NoError(cluster.adminClient.Truncate(nil, namespace, "", nil))
+	s.seedAuthRecords(cluster.adminClient, []int{10, 20, 30})
 
 	e := s.setupEnv(func(c *dto.Config) {
 		c.AerospikeClusters[clusterName] = config

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
+	as "github.com/aerospike/aerospike-client-go/v8"
+)
+
+func (s *AuthSuite) TestInternalPlain() {
+	cluster := s.startAndProvision(false, false, false)
+
+	s.Run("literal password", func() {
+		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+			SeedNodes:            []dto.SeedNode{cluster.seed},
+			UseServicesAlternate: ptr.Of(true),
+			Credentials: &dto.Credentials{
+				User:     intUser,
+				Password: intPassword,
+				AuthMode: string(model.AuthModeInternal),
+			},
+		})
+	})
+
+	s.Run("password path", func() {
+		passwordPath := filepath.Join(s.T().TempDir(), "password.txt")
+		s.Require().NoError(os.WriteFile(passwordPath, []byte(intPassword+"\n"), 0o600))
+
+		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+			SeedNodes:            []dto.SeedNode{cluster.seed},
+			UseServicesAlternate: ptr.Of(true),
+			Credentials: &dto.Credentials{
+				User:         intUser,
+				PasswordPath: passwordPath,
+				AuthMode:     string(model.AuthModeInternal),
+			},
+		})
+	})
+}
+
+func (s *AuthSuite) TestInternalServerTLS() {
+	cluster := s.startAndProvision(true, false, false)
+
+	s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+		SeedNodes:            []dto.SeedNode{cluster.seed},
+		UseServicesAlternate: ptr.Of(true),
+		Credentials: &dto.Credentials{
+			User:     intUser,
+			Password: intPassword,
+			AuthMode: string(model.AuthModeInternal),
+		},
+		TLS: &dto.TLS{
+			ClientTLS: dto.ClientTLS{CAFile: s.certs.caCert},
+		},
+	})
+}
+
+func (s *AuthSuite) TestMutualTLS() {
+	cluster := s.startAndProvision(true, true, true)
+
+	s.Run("internal", func() {
+		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+			SeedNodes:            []dto.SeedNode{cluster.seed},
+			UseServicesAlternate: ptr.Of(true),
+			Credentials: &dto.Credentials{
+				User:     intUser,
+				Password: intPassword,
+				AuthMode: string(model.AuthModeInternal),
+			},
+			TLS: &dto.TLS{
+				ClientTLS: dto.ClientTLS{
+					CAFile:   s.certs.caCert,
+					Name:     tlsName,
+					Certfile: s.certs.internalCert,
+					Keyfile:  s.certs.internalKey,
+				},
+			},
+		})
+	})
+
+	s.Run("pki", func() {
+		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+			SeedNodes:            []dto.SeedNode{cluster.seed},
+			UseServicesAlternate: ptr.Of(true),
+			Credentials: &dto.Credentials{
+				AuthMode: string(model.AuthModePKI),
+			},
+			TLS: &dto.TLS{
+				ClientTLS: dto.ClientTLS{
+					CAFile:   s.certs.caCert,
+					Name:     tlsName,
+					Certfile: s.certs.pkiCert,
+					Keyfile:  s.certs.pkiKey,
+				},
+			},
+		})
+	})
+}
+
+func (s *AuthSuite) testAuthenticatedBackup(cluster authCluster, config *dto.AerospikeCluster) {
+	s.Require().NoError(cluster.admin.Truncate(nil, namespace, "", nil))
+	s.seedAuthRecords(cluster.admin, []int{10, 20, 30})
+
+	e := s.setupEnv(func(c *dto.Config) {
+		c.AerospikeClusters[clusterName] = config
+	})
+	s.triggerFullBackup(e)
+	backup := s.waitForFullBackup(e)
+
+	s.assertBackupDetails(backup, 3)
+}
+
+func (s *AuthSuite) seedAuthRecords(client *as.Client, ages []int) {
+	writePolicy := as.NewWritePolicy(0, 0)
+	for i, age := range ages {
+		key, err := as.NewKey(namespace, setName, i)
+		s.Require().NoError(err)
+		s.Require().NoError(client.Put(writePolicy, key, as.BinMap{"age": age}))
+	}
+}

--- a/test/integration/filter_expression_test.go
+++ b/test/integration/filter_expression_test.go
@@ -7,7 +7,7 @@ import (
 	as "github.com/aerospike/aerospike-client-go/v8"
 )
 
-func (s *Suite) TestBackupWithFilterExpression() {
+func (s *BackupSuite) TestBackupWithFilterExpression() {
 	filterExpression, asErr := as.ExpGreater(as.ExpIntBin("age"), as.ExpIntVal(25)).Base64()
 	s.Require().NoError(asErr)
 

--- a/test/integration/restore_path_test.go
+++ b/test/integration/restore_path_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestRestoreByPath runs a full backup, wipes the namespace, restores via POST /v1/restore/full,
 // and verifies both the restored data and the exposed restore metrics.
-func (s *Suite) TestRestoreByPath() {
+func (s *BackupSuite) TestRestoreByPath() {
 	e := s.setupEnv()
 
 	s.seedRecords([]int{10, 20, 30})
@@ -34,7 +34,7 @@ func (s *Suite) TestRestoreByPath() {
 }
 
 // TestBackupRestoreWithIndexes runs a backup-and-restore flow with secondary and set indexes.
-func (s *Suite) TestBackupRestoreWithIndexes() {
+func (s *BackupSuite) TestBackupRestoreWithIndexes() {
 	e := s.setupEnv()
 
 	var expectedIndexCount = uint64(1)

--- a/test/integration/restore_timestamp_test.go
+++ b/test/integration/restore_timestamp_test.go
@@ -12,7 +12,7 @@ import (
 // TestRestoreByTimestampWorkflow runs full backup, incremental backup, empty incremental backup,
 // then restores the namespace to a point in time via POST /v1/restore/timestamp.
 // Subtests share env, backup storage, and Aerospike state.
-func (s *Suite) TestRestoreByTimestampWorkflow() {
+func (s *BackupSuite) TestRestoreByTimestampWorkflow() {
 	e := s.setupEnv()
 
 	var fullBackup, incrBackup dto.BackupDetails

--- a/test/integration/secret_agent_test.go
+++ b/test/integration/secret_agent_test.go
@@ -10,7 +10,7 @@ import (
 // TestBackupRestoreWithSecretAgentEncryption starts Aerospike Secret Agent with the
 // local file backend, fetches the backup encryption key from it, then restores
 // with the same key.
-func (s *Suite) TestBackupRestoreWithSecretAgentEncryption() {
+func (s *BackupSuite) TestBackupRestoreWithSecretAgentEncryption() {
 	pemKey, err := generateEncryptionPEM()
 	s.Require().NoError(err)
 

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	aerospikeImage = "aerospike/aerospike-server:8.1"
+	aerospikeImage = "aerospike/aerospike-server-enterprise:8.1"
 
 	clusterName     = "testCluster"
 	storageName     = "local"
@@ -28,7 +28,7 @@ const (
 	setName         = "filteredSet"
 )
 
-// Suite runs every test in this package against a single Aerospike container.
+// Suite is the shared ABS test fixture: seed address, Aerospike client, and HTTP helpers.
 type Suite struct {
 	suite.Suite
 
@@ -36,12 +36,17 @@ type Suite struct {
 	client   *as.Client
 }
 
+// BackupSuite runs backup/restore scenarios against a stock EE node with no security.
+type BackupSuite struct {
+	Suite
+}
+
 // SetupSuite starts the Aerospike container and connects the shared client.
 //
 // Cleanup is registered with T().Cleanup instead of TearDownSuite because testify only registers
 // its TearDownSuite defer after SetupSuite returns; a failure part way through here would
 // otherwise leave the container running.
-func (s *Suite) SetupSuite() {
+func (s *BackupSuite) SetupSuite() {
 	t := s.T()
 	ctx := context.Background()
 

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -9,5 +9,9 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	suite.Run(t, new(Suite))
+	suite.Run(t, new(BackupSuite))
+}
+
+func TestClusterAuth(t *testing.T) {
+	suite.Run(t, new(AuthSuite))
 }


### PR DESCRIPTION
## What does this change do?

Adds a dedicated integration suite (`TestClusterAuth`) that proves ABS can connect to a secured Enterprise node using the scoped auth and TLS modes:

- INTERNAL + literal password (plain TCP)
- INTERNAL + `password-path`
- INTERNAL + server-only TLS
- INTERNAL + mTLS
- PKI + mTLS

Each scenario seeds three records and runs a real full backup. Existing no-auth backup/restore tests stay on `BackupSuite` and are unchanged in intent.

LDAP / `auth-mode: EXTERNAL` and Secret Agent password delivery are out of scope.

Related: [BKRS-315](https://aerospike.atlassian.net/browse/BKRS-315)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [ ] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [x] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

- The shared fixture is now a `Suite` with no `Test*` methods. `BackupSuite` owns the stock EE node (no `security {}`) so testify does not run backup/restore tests against the secured cluster.
- Integration tests now use `aerospike/aerospike-server-enterprise:8.1` (security and TLS need Enterprise).
- Auth profiles cannot share one process (plain vs TLS ports, `tls-authenticate-client`). Each `Test*` starts one node and tears it down, so only one secured container is live at a time.
- The EE image entrypoint overwrites `aerospike.conf` on first boot, so setup is start → stop → copy conf/certs → start, then poll a real `admin` login (and a TLS handshake when needed). Docker Desktop remaps ports across restart; the TLS host port is pinned at create time via `WithHostConfigModifier`.
- Admin/bootstrap always uses plaintext 3000. ABS is pointed at the profile under test (`UseServicesAlternate: true`).

[BKRS-315]: https://aerospike.atlassian.net/browse/BKRS-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ