### PR TITLE
BKRS-354 Error masking

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -16,9 +16,11 @@ exclude = [
   # Pre-existing broken link in the Helm chart README, owned by the
   # security plan's docs-supporting item.
   "helm/aerospike-backup-service/examples$",
+  # kubernetes.io is often unreachable from GitHub Actions runners
+  # (connection failed / WAF), so CI cannot reliably verify these links.
+  "^https://kubernetes\\.io/",
   # Stable reference docs that time out or redirect heavily from GitHub
   # Actions runners; not worth failing CI over.
-  "^https://kubernetes\\.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes",
   "^https://docs\\.aerospike\\.com/cloud/kubernetes/operator",
 ]
 

--- a/pkg/dto/decoder/masking.go
+++ b/pkg/dto/decoder/masking.go
@@ -9,6 +9,7 @@ import (
 var (
 	secretType = reflect.TypeFor[Secret]()
 	timeType   = reflect.TypeFor[time.Time]()
+	errType    = reflect.TypeFor[error]()
 )
 
 // RedactSecrets returns a deep copy of v with all Secret-typed values replaced by redactedSecret.
@@ -43,6 +44,10 @@ func redactValue(v reflect.Value) reflect.Value {
 	}
 
 	if v.Type() == timeType {
+		return v
+	}
+
+	if v.Type().Implements(errType) {
 		return v
 	}
 

--- a/pkg/dto/decoder/masking_test.go
+++ b/pkg/dto/decoder/masking_test.go
@@ -2,6 +2,8 @@ package decoder
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -187,4 +189,99 @@ func TestRedactSecrets_PreservesTime(t *testing.T) {
 	assert.Equal(t, created, redacted["routine1"][0].Created)
 	assert.Equal(t, finished, redacted["routine1"][0].Finished)
 	assert.Equal(t, int64(1000), redacted["routine1"][0].Timestamp)
+}
+
+// credentialError mirrors aerospike.AerospikeError: exported fields on a type
+// stored behind fmt.Errorf("%w"). slog.Any("error", err) walks that wrapError,
+// whose err field is unexported, then Set panics when copying ResultCode.
+type credentialError struct {
+	ResultCode int
+	message    string
+}
+
+func (e *credentialError) Error() string {
+	return e.message
+}
+
+func TestRedactSecrets_WrappedError(t *testing.T) {
+	err := fmt.Errorf("failed to connect to cluster: %w", &credentialError{
+		ResultCode: 65,
+		message:    "Invalid credential",
+	})
+
+	assert.Equal(t, err, RedactSecrets(err))
+}
+
+// RedactSecrets returns errors untouched, so a secret interpolated into an error
+// message can only be masked by Secret's Stringer at construction time.
+func TestSecret_MaskedInErrorMessages(t *testing.T) {
+	secret := Secret(literalPassword)
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "%s verb",
+			err:  fmt.Errorf("login failed for password %s", secret),
+		},
+		{
+			name: "%v verb",
+			err:  fmt.Errorf("login failed for password %v", secret),
+		},
+		{
+			name: "wrapped with %w",
+			err:  fmt.Errorf("connect cluster1: %w", fmt.Errorf("bad password %s", secret)),
+		},
+		{
+			name: "joined errors",
+			err:  errors.Join(fmt.Errorf("cluster1: %v", secret), fmt.Errorf("cluster2: %v", secret)),
+		},
+		{
+			name: "secret nested in struct",
+			err:  fmt.Errorf("invalid credentials %v", testCreds),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Contains(t, tt.err.Error(), redactedSecret)
+			assert.NotContains(t, tt.err.Error(), literalPassword)
+
+			redacted, ok := RedactSecrets(tt.err).(error)
+			require.True(t, ok)
+			assert.NotContains(t, redacted.Error(), literalPassword)
+		})
+	}
+
+	t.Run("secret ref preserved", func(t *testing.T) {
+		err := fmt.Errorf("cannot resolve %v", Secret(validSecretRef))
+		assert.Contains(t, err.Error(), validSecretRef)
+	})
+
+	t.Run("logged error attribute is masked", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+			ReplaceAttr: RedactSecretsReplaceAttr(),
+		}))
+
+		logger.Error("connect failed", slog.Any("error", fmt.Errorf("bad password %s", secret)))
+
+		assert.Contains(t, buf.String(), redactedSecret)
+		assert.NotContains(t, buf.String(), literalPassword)
+	})
+
+	t.Run("%q verb", func(t *testing.T) {
+		err := fmt.Errorf("password %q", secret)
+		assert.Contains(t, err.Error(), redactedSecret)
+		assert.NotContains(t, err.Error(), literalPassword)
+	})
+
+	// Guards the one sharp edge: converting to string bypasses the Stringer, and
+	// RedactSecrets cannot repair an error message after the fact.
+	t.Run("raw string conversion leaks", func(t *testing.T) {
+		err := fmt.Errorf("password %s", string(secret))
+		assert.Contains(t, err.Error(), literalPassword)
+		assert.Equal(t, err.Error(), RedactSecrets(err).(error).Error())
+	})
 }

--- a/pkg/service/storage/azure_test.go
+++ b/pkg/service/storage/azure_test.go
@@ -67,7 +67,7 @@ func TestAzureStorage_ConnectivityFailure(t *testing.T) {
 
 	key := base64.StdEncoding.EncodeToString([]byte("dummy-key"))
 
-	ctx := t.Context()
+	ctx := connectivityFailureContext(t)
 	accessor := NewAzureStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getAzureClient(ctx, &model.AzureStorage{

--- a/pkg/service/storage/gcp_test.go
+++ b/pkg/service/storage/gcp_test.go
@@ -53,7 +53,7 @@ func TestGcpStorage_ConnectivityFailure(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	ctx := t.Context()
+	ctx := connectivityFailureContext(t)
 	accessor := NewGcpStorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getGcpClient(ctx, &model.GcpStorage{

--- a/pkg/service/storage/operations_test.go
+++ b/pkg/service/storage/operations_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -23,6 +24,18 @@ func newLocalOperations(t *testing.T) *operations {
 	require.True(t, ok)
 
 	return ops
+}
+
+// connectivityFailureContext bounds tests that point a storage client at a failing endpoint.
+// Storage clients retry up to model.StorageRetryPolicy.MaxRetries times, so without a deadline
+// shorter than connectivityTimeout such tests would keep retrying for the whole timeout.
+func connectivityFailureContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	return ctx
 }
 
 func TestNewOperations(t *testing.T) {

--- a/pkg/service/storage/s3_test.go
+++ b/pkg/service/storage/s3_test.go
@@ -5,17 +5,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	secrets "github.com/aerospike/aerospike-backup-service/v3/pkg/service/secret"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func init() {
-	connectivityTimeout = 100 * time.Millisecond
-}
 
 func TestS3Storage_ConnectivitySuccess(t *testing.T) {
 	t.Parallel()
@@ -69,7 +64,7 @@ func TestS3Storage_ConnectivityFailure(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 
-	ctx := t.Context()
+	ctx := connectivityFailureContext(t)
 	accessor := NewS3StorageAccessor(secrets.NewResolver())
 
 	_, err := accessor.getS3Client(ctx, &model.S3Storage{


### PR DESCRIPTION
## What does this change do?

<!-- Summarize the change and why it's needed. Link any related issue. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [ ] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

<!-- Anything else reviewers should know: alternatives considered, follow-up work, screenshots, etc. -->
