### PR TITLE
BKRS-315 Extend Aerospike Authentication tests

### DIFF
--- a/test/integration/auth_suite.go
+++ b/test/integration/auth_suite.go
@@ -35,6 +35,14 @@ const (
 	// certificate. The client sends it as SNI and then verifies it against the cert,
 	// so the two must stay in sync.
 	tlsName = "test-tls"
+	// clientKeyPassword unlocks the encrypted client key PEMs used in mTLS tests.
+	clientKeyPassword = "client-key-pass"
+	// tlsProtocols pins the handshake to TLS 1.2. That is the only version ABS
+	// currently maps (see pkg/tlsconfig); a single token is both min and max.
+	tlsProtocols = "TLSv1.2"
+	// tlsCipherSuite is an IANA name, colon-separated if there are several.
+	// These tests mint RSA certificates, so the suite must be ECDHE_RSA, not ECDSA.
+	tlsCipherSuite = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 
 	adminUser     = "admin"
 	adminPassword = "admin"
@@ -109,7 +117,11 @@ type authCluster struct {
 
 // certificateFiles is a throwaway PKI generated per suite run.
 type certificateFiles struct {
+	// caCert is the CA bundle as a single PEM file (dto.TLS.ca-file).
 	caCert string
+	// caDir is a directory containing that same CA PEM (dto.TLS.ca-path).
+	// ca-file and ca-path are mutually exclusive; tests pick one per cluster config.
+	caDir string
 	// serverCert and serverKey stay in memory because they are copied straight into the
 	// container rather than read by the client.
 	serverCert []byte
@@ -118,9 +130,12 @@ type certificateFiles struct {
 	// auth-mode PKI the server takes the username from the CN rather than from the
 	// connection credentials.
 	internalCert string
-	internalKey  string
-	pkiCert      string
-	pkiKey       string
+	// internalKey is the unencrypted private key, used only by waitForTLS.
+	internalKey string
+	// Encrypted keys are what ABS loads via dto.TLS.key-file + key-file-password.
+	internalKeyEncrypted string
+	pkiCert              string
+	pkiKeyEncrypted      string
 }
 
 // authProfile is the transport and client-authentication setup of a secured node.
@@ -438,9 +453,7 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
 	caCert, err := x509.ParseCertificate(caDER)
 	s.Require().NoError(err)
-
-	caFile := filepath.Join(dir, "ca.crt")
-	s.Require().NoError(os.WriteFile(caFile, caPEM, 0o600))
+	caFile, caDir := writeCAFiles(s, dir, caPEM)
 
 	// The DNS SAN, not the common name, is what the client checks, so tlsName has to
 	// appear there.
@@ -473,14 +486,40 @@ func (s *AuthSuite) generateCertificates() certificateFiles {
 	)
 
 	return certificateFiles{
-		caCert:       caFile,
-		serverCert:   serverCert,
-		serverKey:    serverKey,
-		internalCert: writeCertificateFile(s, dir, "internal.crt", internalCert),
-		internalKey:  writeCertificateFile(s, dir, "internal.key", internalKey),
-		pkiCert:      writeCertificateFile(s, dir, "pki.crt", pkiCert),
-		pkiKey:       writeCertificateFile(s, dir, "pki.key", pkiKey),
+		caCert:               caFile,
+		caDir:                caDir,
+		serverCert:           serverCert,
+		serverKey:            serverKey,
+		internalCert:         writeCertificateFile(s, dir, "internal.crt", internalCert),
+		internalKey:          writeCertificateFile(s, dir, "internal.key", internalKey),
+		internalKeyEncrypted: writeCertificateFile(s, dir, "internal.enc.key", encryptPEMKey(s, internalKey)),
+		pkiCert:              writeCertificateFile(s, dir, "pki.crt", pkiCert),
+		pkiKeyEncrypted:      writeCertificateFile(s, dir, "pki.enc.key", encryptPEMKey(s, pkiKey)),
 	}
+}
+
+// encryptPEMKey wraps a PKCS#1 key in a password-protected PEM block so the tests
+// can exercise dto.TLS.key-file-password. ABS decrypts this with the same
+// (deprecated) PEM encryption the Go stdlib still uses for DEK-Info keys.
+func encryptPEMKey(s *AuthSuite, keyPEM []byte) []byte {
+	block, _ := pem.Decode(keyPEM)
+	s.Require().NotNil(block, "client key PEM")
+
+	encrypted, err := x509.EncryptPEMBlock( //nolint:staticcheck // DEK-Info PEM is what ABS decrypts
+		rand.Reader, block.Type, block.Bytes, []byte(clientKeyPassword), x509.PEMCipherAES256)
+	s.Require().NoError(err)
+
+	return pem.EncodeToMemory(encrypted)
+}
+
+func writeCAFiles(s *AuthSuite, dir string, caPEM []byte) (caFile, caDir string) {
+	caFile = filepath.Join(dir, "ca.crt")
+	s.Require().NoError(os.WriteFile(caFile, caPEM, 0o600))
+	caDir = filepath.Join(dir, "ca")
+	s.Require().NoError(os.Mkdir(caDir, 0o700))
+	s.Require().NoError(os.WriteFile(filepath.Join(caDir, "ca.crt"), caPEM, 0o600))
+
+	return caFile, caDir
 }
 
 func issueCertificate(

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/ptr"
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -41,6 +42,25 @@ func (s *AuthSuite) TestInternalPlain() {
 			},
 		})
 	})
+
+	s.Run("password from secret agent", func() {
+		// password is a secret-agent reference (secrets:<resource>:<key>), not the
+		// literal Aerospike password. ABS fetches the real value at connect time.
+		agent := s.startSecretAgent(intPassword)
+
+		s.testAuthenticatedBackup(cluster, &dto.AerospikeCluster{
+			SeedNodes:            []dto.SeedNode{cluster.seed},
+			UseServicesAlternate: ptr.Of(true),
+			Credentials: &dto.Credentials{
+				User:     intUser,
+				Password: decoder.Secret(secretRef()),
+				AuthMode: string(model.AuthModeInternal),
+				SecretAgentConfig: dto.SecretAgentConfig{
+					SecretAgent: agent,
+				},
+			},
+		})
+	})
 }
 
 func (s *AuthSuite) TestInternalServerTLS() {
@@ -54,9 +74,10 @@ func (s *AuthSuite) TestInternalServerTLS() {
 			Password: intPassword,
 			AuthMode: string(model.AuthModeInternal),
 		},
-		TLS: &dto.TLS{
-			ClientTLS: dto.ClientTLS{CAFile: s.certs.caCert},
-		},
+		// Server authenticates to us; we do not present a client certificate.
+		// Trust comes from ca-path. SNI is seed-nodes[].tls-name, not tls.name
+		// (name is only valid together with cert-file and key-file).
+		TLS: s.serverOnlyTLS(),
 	})
 }
 
@@ -72,14 +93,7 @@ func (s *AuthSuite) TestMutualTLS() {
 				Password: intPassword,
 				AuthMode: string(model.AuthModeInternal),
 			},
-			TLS: &dto.TLS{
-				ClientTLS: dto.ClientTLS{
-					CAFile:   s.certs.caCert,
-					Name:     tlsName,
-					Certfile: s.certs.internalCert,
-					Keyfile:  s.certs.internalKey,
-				},
-			},
+			TLS: s.mutualTLS(s.certs.internalCert, s.certs.internalKeyEncrypted),
 		})
 	})
 
@@ -90,14 +104,7 @@ func (s *AuthSuite) TestMutualTLS() {
 			Credentials: &dto.Credentials{
 				AuthMode: string(model.AuthModePKI),
 			},
-			TLS: &dto.TLS{
-				ClientTLS: dto.ClientTLS{
-					CAFile:   s.certs.caCert,
-					Name:     tlsName,
-					Certfile: s.certs.pkiCert,
-					Keyfile:  s.certs.pkiKey,
-				},
-			},
+			TLS: s.mutualTLS(s.certs.pkiCert, s.certs.pkiKeyEncrypted),
 		})
 	})
 }
@@ -121,5 +128,75 @@ func (s *AuthSuite) seedAuthRecords(client *as.Client, ages []int) {
 		key, err := as.NewKey(namespace, setName, i)
 		s.Require().NoError(err)
 		s.Require().NoError(client.Put(writePolicy, key, as.BinMap{"age": age}))
+	}
+}
+
+// dto.TLS is ABS's client-side TLS config for Aerospike. It does not configure the
+// database; it tells this process how to verify the server and, for mTLS, how to
+// prove who we are.
+//
+// Handshake, in one pass:
+//  1. We open a TLS connection and send SNI (the name we expect the cert to use).
+//  2. The server presents its certificate. We trust it only if it chains to a CA
+//     we loaded from ca-file or ca-path.
+//  3. If the server asks for a client cert (tls-authenticate-client), we present
+//     cert-file, proving possession with key-file (unlocked by key-file-password
+//     when the PEM is encrypted).
+//  4. Both sides agree a protocol version (protocols) and a cipher (cipher-suite).
+//
+// ca-file and ca-path are mutually exclusive. These helpers split them:
+// server-only TLS uses ca-path; mTLS uses ca-file. Together they set every field.
+func (s *AuthSuite) serverOnlyTLS() *dto.TLS {
+	return &dto.TLS{
+		ClientTLS: dto.ClientTLS{
+			// ca-file is the other way to load CAs (a single PEM bundle). Left empty
+			// here because ca-path is set below; both at once is a validation error.
+			CAFile: "",
+			// name is SNI / ServerName on the cluster TLS object. Validation requires
+			// it together with cert-file and key-file, so server-only TLS cannot set
+			// it. The seed node's tls-name (already set on cluster.seed) is what the
+			// Aerospike client sends as SNI in this profile.
+			Name:     "",
+			Certfile: "",
+			Keyfile:  "",
+		},
+		// ca-path is a directory of PEM CA files. Same purpose as ca-file: decide
+		// whether the server's certificate is trusted. Used when CAs are dropped
+		// in as separate files (for example a Kubernetes secret volume).
+		CAPath: s.certs.caDir,
+		// protocols is Apache SSLProtocol syntax, space-separated. ABS currently
+		// accepts TLSv1.2 only. One token pins both the minimum and the maximum.
+		Protocols: tlsProtocols,
+		// cipher-suite is colon-separated IANA names (not OpenSSL nicknames). It
+		// restricts which TLS 1.2 ciphers we offer. Empty means Go's defaults.
+		CipherSuite: tlsCipherSuite,
+		// key-file-password is only meaningful with key-file (encrypted client key).
+		KeyfilePassword: "",
+	}
+}
+
+func (s *AuthSuite) mutualTLS(certFile, encryptedKeyFile string) *dto.TLS {
+	return &dto.TLS{
+		ClientTLS: dto.ClientTLS{
+			// ca-file: PEM bundle of CAs we trust to sign the server certificate.
+			CAFile: s.certs.caCert,
+			// name: hostname we put in SNI and then check against the server cert.
+			// Must be set together with cert-file and key-file.
+			Name: tlsName,
+			// cert-file: our client certificate. The server uses this to decide
+			// who we are. For auth-mode PKI the Aerospike username is the cert CN.
+			Certfile: certFile,
+			// key-file: private key matching cert-file. Never sent on the wire;
+			// used to prove we own the certificate. Encrypted in these tests.
+			Keyfile: encryptedKeyFile,
+		},
+		// ca-path left empty: mutually exclusive with ca-file.
+		CAPath: "",
+		// protocols / cipher-suite: same meaning as in serverOnlyTLS.
+		Protocols:   tlsProtocols,
+		CipherSuite: tlsCipherSuite,
+		// key-file-password: passphrase for an encrypted key-file PEM. Can also be
+		// a secrets:<resource>:<key> reference when a secret agent is configured.
+		KeyfilePassword: clientKeyPassword,
 	}
 }

--- a/test/integration/metrics.go
+++ b/test/integration/metrics.go
@@ -42,6 +42,7 @@ func (e *env) fetchMetricFamilies(ctx context.Context) (map[string]*dto.MetricFa
 	}
 
 	var parser = expfmt.NewTextParser(prommodel.UTF8Validation)
+
 	return parser.TextToMetricFamilies(resp.Body)
 }
 

--- a/test/integration/restore_path_test.go
+++ b/test/integration/restore_path_test.go
@@ -46,9 +46,9 @@ func (s *BackupSuite) TestBackupRestoreWithIndexes() {
 
 	// TODO: uncomment when https://aerospike.atlassian.net/browse/BKRS-334 fixed
 	// Create a set index on namespace & set
-	//setTask, err := s.client.CreateSetIndex(nil, namespace, setName, "set_sidx")
-	//s.Require().NoError(err)
-	//s.Require().NoError(<-setTask.OnComplete())
+	// setTask, err := s.client.CreateSetIndex(nil, namespace, setName, "set_sidx")
+	// s.Require().NoError(err)
+	// s.Require().NoError(<-setTask.OnComplete())
 	// expectedIndexCount++
 
 	s.triggerFullBackup(e)

--- a/test/integration/secret_agent.go
+++ b/test/integration/secret_agent.go
@@ -35,7 +35,7 @@ func secretRef() string {
 
 // startSecretAgent starts Aerospike Secret Agent with the file backend described in
 // https://github.com/aerospike/aerospike-secret-agent/blob/main/docs/file.md
-func (s *Suite) startSecretAgent(pemKey string) *dto.SecretAgent {
+func (s *Suite) startSecretAgent(secret string) *dto.SecretAgent {
 	ctx := s.T().Context()
 
 	agent, err := testcontainers.Run(ctx, secretAgentImage,
@@ -48,7 +48,7 @@ func (s *Suite) startSecretAgent(pemKey string) *dto.SecretAgent {
 				FileMode:          0o644,
 			},
 			testcontainers.ContainerFile{
-				Reader:            strings.NewReader(secretsJSON(pemKey)),
+				Reader:            strings.NewReader(secretsJSON(secret)),
 				ContainerFilePath: secretsFilePath,
 				FileMode:          0o600,
 			},
@@ -69,6 +69,11 @@ func (s *Suite) startSecretAgent(pemKey string) *dto.SecretAgent {
 		Address:        host,
 		Port:           ptr.Of(dto.Port(mapped.Num())),
 		Timeout:        ptr.Of(5000),
+		// The file backend stores values base64-encoded and returns them as stored,
+		// so the client has to decode. Without this the caller gets the encoded
+		// string: harmless for an encryption key that is only compared to itself,
+		// but a cluster password fails with INVALID_CREDENTIAL.
+		IsBase64: ptr.Of(true),
 	}
 }
 
@@ -96,9 +101,9 @@ func (s *Suite) secretAgentConfigYAML() string {
 	return string(data)
 }
 
-func secretsJSON(pemKey string) string {
+func secretsJSON(secret string) string {
 	// File-backend values must be base64-encoded strings.
-	return fmt.Sprintf(`{%q:%q}`, secretKeyName, base64.StdEncoding.EncodeToString([]byte(pemKey)))
+	return fmt.Sprintf(`{%q:%q}`, secretKeyName, base64.StdEncoding.EncodeToString([]byte(secret)))
 }
 
 func (s *Suite) cleanupContainer(c testcontainers.Container) {


### PR DESCRIPTION
## What does this change do?

Secret agent password — TestInternalPlain/password_from_secret_agent sets password to a secrets:backup:key reference and lets ABS fetch the real password at connect time.

  TLS fields — every field of dto.TLS now appears across two helpers in auth_test.go. They had to be split because ca-file and ca-path are mutually exclusive: serverOnlyTLS()
  uses ca-path, mutualTLS() uses ca-file. Each field carries a comment explaining what it does, with a summary of the handshake above them so the individual fields have
  context. Both helpers set protocols and cipher-suite; the mTLS one uses encrypted client keys so key-file-password is exercised for real.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [ ] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

<!-- Anything else reviewers should know: alternatives considered, follow-up work, screenshots, etc. -->
