### PR TITLE
Add post-release verification workflows

### DIFF
--- a/.github/actions/poll-abs-job/action.yml
+++ b/.github/actions/poll-abs-job/action.yml
@@ -1,0 +1,100 @@
+name: Poll aerospike-backup-service backup/restore job
+description: >
+  Polls the aerospike-backup-service REST API until a backup appears for a routine, or a
+  restore job reaches a terminal status. Callers are responsible for making base-url reachable
+  first (e.g. via `kubectl port-forward` when targeting an in-cluster Helm deployment).
+
+inputs:
+  base-url:
+    description: "Base URL of the running aerospike-backup-service, e.g. http://127.0.0.1:8080"
+    required: true
+  kind:
+    description: "'backup' or 'restore'"
+    required: true
+  routine:
+    description: Backup routine name (required when kind=backup)
+    required: false
+    default: ""
+  job-id:
+    description: Restore job id (required when kind=restore)
+    required: false
+    default: ""
+  max-attempts:
+    description: Maximum number of polling attempts
+    required: false
+    default: "40"
+  interval-seconds:
+    description: Seconds to wait between attempts
+    required: false
+    default: "5"
+
+outputs:
+  backup-data-path:
+    description: "The 'key' field of the first completed backup (kind=backup only)"
+    value: ${{ steps.poll.outputs.backup-data-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Poll for job completion
+      id: poll
+      shell: bash
+      run: |
+        set -uo pipefail
+        BASE_URL="${{ inputs.base-url }}"
+        KIND="${{ inputs.kind }}"
+        ROUTINE="${{ inputs.routine }}"
+        JOB_ID="${{ inputs.job-id }}"
+        MAX_ATTEMPTS="${{ inputs.max-attempts }}"
+        INTERVAL="${{ inputs.interval-seconds }}"
+
+        if [ "$KIND" = "backup" ]; then
+          if [ -z "$ROUTINE" ]; then
+            echo "::error::'routine' input is required when kind=backup"
+            exit 1
+          fi
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            RESPONSE="$(curl -s "${BASE_URL}/v1/backups/full/${ROUTINE}")"
+            COUNT="$(echo "$RESPONSE" | jq 'length' 2>/dev/null || echo 0)"
+            if [ "$COUNT" -gt 0 ] 2>/dev/null; then
+              KEY="$(echo "$RESPONSE" | jq -r '.[0].key')"
+              echo "Backup completed for routine ${ROUTINE} after attempt ${attempt}/${MAX_ATTEMPTS}: ${KEY}"
+              echo "backup-data-path=${KEY}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: no completed backup for routine ${ROUTINE} yet."
+            sleep "$INTERVAL"
+          done
+          echo "::error::Backup for routine ${ROUTINE} did not complete within $((MAX_ATTEMPTS * INTERVAL))s"
+          exit 1
+
+        elif [ "$KIND" = "restore" ]; then
+          if [ -z "$JOB_ID" ]; then
+            echo "::error::'job-id' input is required when kind=restore"
+            exit 1
+          fi
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            RESPONSE="$(curl -s "${BASE_URL}/v1/restore/status/${JOB_ID}")"
+            STATUS="$(echo "$RESPONSE" | jq -r '.status // empty')"
+            case "$STATUS" in
+              success)
+                echo "Restore job ${JOB_ID} succeeded after attempt ${attempt}/${MAX_ATTEMPTS}."
+                exit 0
+                ;;
+              failure|canceled)
+                echo "::error::Restore job ${JOB_ID} ended with status '${STATUS}': $RESPONSE"
+                exit 1
+                ;;
+              *)
+                echo "Attempt ${attempt}/${MAX_ATTEMPTS}: restore job ${JOB_ID} status='${STATUS:-unknown}'."
+                sleep "$INTERVAL"
+                ;;
+            esac
+          done
+          echo "::error::Restore job ${JOB_ID} did not reach a terminal status within $((MAX_ATTEMPTS * INTERVAL))s"
+          exit 1
+
+        else
+          echo "::error::Unknown kind '${KIND}' (expected 'backup' or 'restore')"
+          exit 1
+        fi

--- a/.github/actions/seed-and-verify-aerospike/action.yml
+++ b/.github/actions/seed-and-verify-aerospike/action.yml
@@ -1,0 +1,108 @@
+name: Seed and verify Aerospike records
+description: >
+  Seeds a deterministic number of records into an Aerospike namespace, or counts existing
+  records, using the official aerospike/aerospike-tools image (aql for writes, asinfo for the
+  authoritative object count) rather than assuming aql/asinfo are present in whatever server
+  image is already running. Works against a bare host:port (local/docker mode) or, when
+  kubectl-namespace is set, against a cluster reached via a short-lived kubectl-run tools pod.
+
+inputs:
+  mode:
+    description: "'seed' to insert records, 'count' to read back the object count"
+    required: true
+  namespace:
+    description: Aerospike namespace to seed/count (e.g. test)
+    required: true
+  set-name:
+    description: Aerospike set name to use for seeded records
+    required: false
+    default: smoketest
+  record-count:
+    description: Number of records to seed (only used when mode=seed)
+    required: false
+    default: "1000"
+  host:
+    description: "Aerospike host:port to connect to (local/docker mode only)"
+    required: false
+    default: "127.0.0.1:3000"
+  kubectl-namespace:
+    description: If set, run against a cluster via a kubectl-run aerospike-tools pod in this k8s namespace instead of docker
+    required: false
+    default: ""
+  aerospike-k8s-host:
+    description: "Aerospike host:port reachable from inside the cluster (kubectl mode only)"
+    required: false
+    default: ""
+
+outputs:
+  record_count:
+    description: Object count reported by asinfo for the namespace (mode=count only)
+    value: ${{ steps.run.outputs.record_count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure tools pod (kubectl mode only)
+      if: inputs.kubectl-namespace != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        NS="${{ inputs.kubectl-namespace }}"
+        if ! kubectl get pod aerospike-tools-verify -n "$NS" >/dev/null 2>&1; then
+          kubectl run aerospike-tools-verify -n "$NS" \
+            --image=aerospike/aerospike-tools:latest \
+            --restart=Never \
+            --command -- sleep 3600
+        fi
+        kubectl wait --for=condition=Ready pod/aerospike-tools-verify -n "$NS" --timeout=120s
+
+    - name: Seed or count records
+      id: run
+      shell: bash
+      run: |
+        set -euo pipefail
+        MODE="${{ inputs.mode }}"
+        NS_AS="${{ inputs.namespace }}"
+        SET_NAME="${{ inputs.set-name }}"
+        COUNT="${{ inputs.record-count }}"
+        KUBECTL_NS="${{ inputs.kubectl-namespace }}"
+
+        if [ -n "$KUBECTL_NS" ]; then
+          AS_HOST="${{ inputs.aerospike-k8s-host }}"
+          run_aql() { kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- aql -h "$AS_HOST" "$@"; }
+          run_asinfo() { kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- asinfo -h "$AS_HOST" "$@"; }
+          cp_in() { kubectl cp "$1" "$KUBECTL_NS/aerospike-tools-verify:$2"; }
+        else
+          AS_HOST="${{ inputs.host }}"
+          run_aql() { docker run --rm --network host -v "$SEED_FILE_HOST:/tmp/seed.aql:ro" aerospike/aerospike-tools:latest aql -h "$AS_HOST" "$@"; }
+          run_asinfo() { docker run --rm --network host aerospike/aerospike-tools:latest asinfo -h "$AS_HOST" "$@"; }
+          cp_in() { :; } # no-op, docker mode mounts the file directly
+        fi
+
+        if [ "$MODE" = "seed" ]; then
+          SEED_FILE_HOST="$(mktemp)"
+          for i in $(seq 1 "$COUNT"); do
+            echo "insert into ${NS_AS}.${SET_NAME} (PK, val) values ('smoke-${i}', ${i})"
+          done > "$SEED_FILE_HOST"
+
+          if [ -n "$KUBECTL_NS" ]; then
+            cp_in "$SEED_FILE_HOST" "/tmp/seed.aql"
+            kubectl exec -n "$KUBECTL_NS" aerospike-tools-verify -- aql -h "$AS_HOST" -f /tmp/seed.aql
+          else
+            run_aql -f /tmp/seed.aql
+          fi
+
+          echo "Seeded ${COUNT} records into ${NS_AS}.${SET_NAME}."
+        elif [ "$MODE" = "count" ]; then
+          RESPONSE="$(run_asinfo -v "namespace/${NS_AS}")"
+          OBJECTS="$(echo "$RESPONSE" | tr ';' '\n' | grep '^objects=' | cut -d= -f2)"
+          if [ -z "$OBJECTS" ]; then
+            echo "::error::Could not parse objects= from asinfo response: $RESPONSE"
+            exit 1
+          fi
+          echo "Namespace ${NS_AS} object count: ${OBJECTS}"
+          echo "record_count=${OBJECTS}" >> "$GITHUB_OUTPUT"
+        else
+          echo "::error::Unknown mode '${MODE}' (expected 'seed' or 'count')"
+          exit 1
+        fi

--- a/.github/actions/wait-for-dockerhub-tag/action.yml
+++ b/.github/actions/wait-for-dockerhub-tag/action.yml
@@ -1,0 +1,56 @@
+name: Wait for DockerHub tag
+description: >
+  Polls DockerHub for a tag's arrival. DockerHub mirroring of a PROD-promoted image happens
+  externally and asynchronously via artifact-publisher (triggered by JFrog's own promotion
+  webhook), so this never hard-fails -- it reports found=true/false and lets the caller decide
+  whether that's a warning or a hard failure.
+
+inputs:
+  image:
+    description: DockerHub image, e.g. aerospike/aerospike-backup-service
+    required: true
+  tag:
+    description: Tag to wait for, e.g. 3.7.0 (without a leading "v")
+    required: true
+  max-attempts:
+    description: Maximum number of polling attempts
+    required: false
+    default: "15"
+  interval-seconds:
+    description: Seconds to wait between attempts
+    required: false
+    default: "60"
+
+outputs:
+  found:
+    description: "'true' if the tag was found within max-attempts, 'false' otherwise"
+    value: ${{ steps.poll.outputs.found }}
+
+runs:
+  using: composite
+  steps:
+    - name: Poll DockerHub for tag
+      id: poll
+      shell: bash
+      run: |
+        set -uo pipefail
+        IMAGE="${{ inputs.image }}"
+        TAG="${{ inputs.tag }}"
+        MAX_ATTEMPTS="${{ inputs.max-attempts }}"
+        INTERVAL="${{ inputs.interval-seconds }}"
+
+        found=false
+        for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+          status="$(curl -s -o /dev/null -w '%{http_code}' "https://hub.docker.com/v2/repositories/${IMAGE}/tags/${TAG}/")"
+          if [ "$status" = "200" ]; then
+            echo "DockerHub tag ${IMAGE}:${TAG} found on attempt ${attempt}/${MAX_ATTEMPTS}."
+            found=true
+            break
+          fi
+          echo "Attempt ${attempt}/${MAX_ATTEMPTS}: ${IMAGE}:${TAG} not found yet (HTTP ${status})."
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            sleep "$INTERVAL"
+          fi
+        done
+
+        echo "found=${found}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/post-release-verify-artifacts.yml
+++ b/.github/workflows/post-release-verify-artifacts.yml
@@ -1,0 +1,551 @@
+# Post-release verification: confirms a published version's artifacts are actually in place,
+# downloadable, correctly checksummed/signed, and installable. Targets the "database" JFrog
+# project (the shared-workflows pipeline) only -- see pre-release.yml/release.yml for the
+# pipeline this verifies. DockerHub checks are best-effort (see verify-dockerhub) since that
+# mirror is populated externally/asynchronously by artifact-publisher, outside this repo's
+# control. SBOM/attestation only exists for the container image today (confirmed by reading
+# aerospike/shared-workflows directly) -- .deb/.rpm/.tgz have none, and this workflow says so
+# explicitly rather than silently skipping or faking that check.
+
+name: Post-Release Verify Artifacts
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version to verify (must match a published GitHub Release, e.g. v3.7.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: aerospike-backup-service
+  DOCKERHUB_IMAGE: aerospike/aerospike-backup-service
+
+jobs:
+  verify-github-release:
+    # ubuntu-22.04, not 24.04: aerospike/shared-workflows' own setup-gpg action hard-fails on any
+    # other Ubuntu version ("This action only supports Ubuntu 22.04"), reflecting a real GnuPG
+    # behavior difference between the two. This job's GPG usage here is much lighter (import a
+    # public key + verify, no signing/agent/pinentry setup), but there's no reason to gamble on
+    # 24.04 compatibility when the org has already established this constraint elsewhere.
+    runs-on: ubuntu-22.04
+    outputs:
+      helm-chart-file: ${{ steps.list.outputs.helm-chart-file }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Confirm release exists and is not a draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release view "${{ inputs.version }}" --json isDraft,tagName --repo "${{ github.repository }}" \
+            | tee release.json
+          if [ "$(jq -r '.isDraft' release.json)" = "true" ]; then
+            echo "::error::Release ${{ inputs.version }} is still a draft."
+            exit 1
+          fi
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p release-assets
+          gh release download "${{ inputs.version }}" --repo "${{ github.repository }}" --dir release-assets --clobber
+          echo "Downloaded assets:"
+          ls -la release-assets
+
+      - name: List helm chart asset
+        id: list
+        run: |
+          cd release-assets
+          chart="$(ls -1 *.tgz 2>/dev/null | head -1 || true)"
+          echo "helm-chart-file=${chart}" >> "$GITHUB_OUTPUT"
+
+      - name: Import GPG public key
+        env:
+          GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
+        run: echo "$GPG_PUBLIC_KEY" | gpg --import
+
+      - name: Verify DEB/RPM checksums and signatures
+        run: |
+          set -euo pipefail
+          cd release-assets
+          fail=0
+          shopt -s nullglob
+          for pkg in *.deb *.rpm; do
+            if [ ! -f "${pkg}.sha256" ]; then
+              echo "::error::Missing ${pkg}.sha256"
+              fail=1
+              continue
+            fi
+            computed="$(sha256sum "$pkg" | awk '{print $1}')"
+            recorded="$(tr -d '[:space:]' < "${pkg}.sha256")"
+            if [ "$computed" != "$recorded" ]; then
+              echo "::error::Checksum mismatch for ${pkg}: computed=${computed} recorded=${recorded}"
+              fail=1
+              continue
+            fi
+            echo "Checksum OK: ${pkg}"
+            if [ -f "${pkg}.sha256.asc" ]; then
+              if gpg --verify "${pkg}.sha256.asc" "${pkg}.sha256" 2>&1; then
+                echo "Signature OK: ${pkg}.sha256"
+              else
+                echo "::error::GPG signature verification failed for ${pkg}.sha256"
+                fail=1
+              fi
+            else
+              echo "::error::Missing ${pkg}.sha256.asc"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Verify Helm chart signature and checksum
+        if: steps.list.outputs.helm-chart-file != ''
+        run: |
+          set -euo pipefail
+          cd release-assets
+          chart="${{ steps.list.outputs.helm-chart-file }}"
+          prov="${chart}.prov"
+          if [ ! -f "$prov" ]; then
+            echo "::error::Missing ${prov}"
+            exit 1
+          fi
+          gpg --verify "$prov"
+          computed="$(sha256sum "$chart" | awk '{print $1}')"
+          recorded="$(gpg --decrypt --output - "$prov" 2>/dev/null | grep -A1 "^files:" | grep "$chart" | sed -n 's/.*sha256:\([0-9a-f]*\).*/\1/p')"
+          if [ -z "$recorded" ]; then
+            echo "::warning::Could not parse recorded sha256 out of ${prov}; skipping cross-check (signature was still verified above)."
+          elif [ "$computed" != "$recorded" ]; then
+            echo "::error::Helm chart checksum mismatch: computed=${computed} recorded(prov)=${recorded}"
+            exit 1
+          else
+            echo "Helm chart checksum OK: ${chart}"
+          fi
+
+      - name: Write checksum summary for downstream jobs
+        run: |
+          cd release-assets
+          python3 - <<'EOF'
+          import glob, hashlib, json
+          out = {}
+          for f in glob.glob("*.deb") + glob.glob("*.rpm") + glob.glob("*.tgz"):
+              h = hashlib.sha256()
+              with open(f, "rb") as fh:
+                  h.update(fh.read())
+              out[f] = h.hexdigest()
+          with open("../checksums.json", "w") as fh:
+              json.dump(out, fh, indent=2)
+          EOF
+          cat ../checksums.json
+
+      - name: Upload verified assets + checksums for downstream jobs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-assets
+          path: |
+            release-assets/
+            checksums.json
+          retention-days: 1
+
+  verify-jfrog-prod:
+    needs: [verify-github-release]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.version }}
+
+      - name: Download verified checksums
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-assets
+
+      - name: Resolve Helm chart version
+        id: helm-version
+        run: |
+          HELM_VERSION="$(yq '.version' helm/aerospike-backup-service/Chart.yaml | tr -d '\n')"
+          echo "HELM_VERSION=${HELM_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Verify DEB/RPM/Helm present in JFrog PROD with matching checksums
+        env:
+          DEB_REPO: ${{ vars.JF_ARTIFACTORY_DEB_PROD }}
+          RPM_REPO: ${{ vars.JF_ARTIFACTORY_RPM_PROD }}
+          HELM_REPO: ${{ vars.JF_ARTIFACTORY_HELM_PROD }}
+          VERSION: ${{ inputs.version }}
+          HELM_VERSION: ${{ steps.helm-version.outputs.HELM_VERSION }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          echo "Searching ${DEB_REPO} for version=${VERSION}..."
+          jf rt search "${DEB_REPO}/**" --props "version=${VERSION}" > deb.json
+          echo "Searching ${RPM_REPO} for version=${VERSION}..."
+          jf rt search "${RPM_REPO}/**" --props "version=${VERSION}" > rpm.json
+          echo "Searching ${HELM_REPO} for version=${HELM_VERSION}..."
+          jf rt search "${HELM_REPO}/**" --props "version=${HELM_VERSION}" > helm.json
+
+          for f in deb.json rpm.json helm.json; do
+            count="$(jq 'length' "$f")"
+            if [ "$count" -eq 0 ]; then
+              echo "::error::No artifacts found in JFrog PROD for $f"
+              fail=1
+            else
+              echo "$f: found $count artifact(s)"
+            fi
+          done
+
+          echo "Cross-checking JFrog-recorded sha256 against the GitHub Release's independently-computed checksums..."
+          jq -s 'add' deb.json rpm.json helm.json > all.json
+          python3 - <<'EOF'
+          import json, sys
+          jfrog = json.load(open("all.json"))
+          local = json.load(open("checksums.json"))
+          jfrog_by_name = {a["path"].rsplit("/", 1)[-1]: a.get("sha256", "") for a in jfrog}
+          mismatches = []
+          for name, sha in local.items():
+              jfrog_sha = jfrog_by_name.get(name)
+              if jfrog_sha is None:
+                  continue  # not every local file is expected in every repo search result
+              if jfrog_sha != sha:
+                  mismatches.append((name, sha, jfrog_sha))
+          if mismatches:
+              for name, local_sha, jfrog_sha in mismatches:
+                  print(f"::error::Checksum mismatch between GitHub Release and JFrog PROD for {name}: github={local_sha} jfrog={jfrog_sha}")
+              sys.exit(1)
+          print("All cross-checked artifacts agree between GitHub Release and JFrog PROD.")
+          EOF
+
+          exit $fail
+
+      - name: Verify container image tag exists in JFrog PROD
+        env:
+          CONTAINER_REPO: ${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          TAG_NO_V="${VERSION#v}"
+          RESPONSE="$(jf rt curl "/api/docker/${CONTAINER_REPO}/v2/${{ env.IMAGE_NAME }}/tags/list")"
+          echo "$RESPONSE" | jq .
+          if echo "$RESPONSE" | jq -e --arg t "$VERSION" '.tags | index($t)' >/dev/null || \
+             echo "$RESPONSE" | jq -e --arg t "$TAG_NO_V" '.tags | index($t)' >/dev/null; then
+            echo "Container image tag found in ${CONTAINER_REPO}."
+          else
+            echo "::error::Neither '${VERSION}' nor '${TAG_NO_V}' found in ${CONTAINER_REPO} tag list."
+            exit 1
+          fi
+
+  verify-dockerhub:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Wait for DockerHub tag
+        id: wait
+        uses: ./.github/actions/wait-for-dockerhub-tag
+        with:
+          image: ${{ env.DOCKERHUB_IMAGE }}
+          tag: ${{ inputs.version }}
+        continue-on-error: true
+
+      - name: Report DockerHub status
+        run: |
+          if [ "${{ steps.wait.outputs.found }}" = "true" ]; then
+            docker buildx imagetools inspect --raw "docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}" | \
+              jq -r '.manifests[]?.platform | "\(.os)/\(.architecture)"' | tee platforms.txt
+            for want in "linux/amd64" "linux/arm64"; do
+              grep -qx "$want" platforms.txt || echo "::warning::DockerHub manifest missing platform ${want}"
+            done
+            echo "### DockerHub: present" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::DockerHub tag ${{ inputs.version }} not found for ${{ env.DOCKERHUB_IMAGE }} within the polling window. artifact-publisher mirroring is external/async -- re-run this workflow later to re-check. Not treating this as a failure."
+            echo "### DockerHub: NOT YET PRESENT (external, async) -- re-run later" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  verify-sbom-attestation:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      attestations: read
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Verify SLSA build-provenance attestation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          gh attestation verify "oci://${IMAGE_REF}" --owner aerospike
+
+      - name: Verify SBOM/provenance OCI referrers are present
+        run: |
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .SBOM}}' | tee sbom.json
+          if [ "$(cat sbom.json)" = "null" ] || [ -z "$(cat sbom.json)" ]; then
+            echo "::error::No SBOM referrer found for ${IMAGE_REF}"
+            exit 1
+          fi
+          echo "SBOM referrer present for ${IMAGE_REF}."
+
+      - name: Report N/A for RPM/DEB/Helm
+        run: |
+          {
+            echo "### SBOM / attestation coverage"
+            echo "| Artifact | SBOM/attestation |"
+            echo "| --- | --- |"
+            echo "| Docker image | verified (SPDX SBOM + SLSA attestation) |"
+            echo "| .deb / .rpm / .tgz | N/A -- no SBOM or attestation is produced anywhere in the build/sign/deploy pipeline for these artifact types (confirmed gap, not a bug in this check) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  verify-oci-labels:
+    needs: [verify-jfrog-prod]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.version }}
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Inspect and verify required labels are present
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Config.Labels}}' | tee labels.json
+          fail=0
+          for key in title description documentation base.name vendor licenses; do
+            val="$(jq -r --arg k "org.opencontainers.image.${key}" '.[$k] // empty' labels.json)"
+            if [ -z "$val" ]; then
+              echo "::error::Missing or empty label org.opencontainers.image.${key}"
+              fail=1
+            else
+              echo "org.opencontainers.image.${key} = ${val}"
+            fi
+          done
+          exit $fail
+
+      - name: Cross-check base.name label against the real Dockerfile
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+          label_base="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .Config.Labels}}' | jq -r '."org.opencontainers.image.base.name"')"
+          dockerfile_from="$(grep -E '^FROM' Dockerfile | tail -1 | awk '{print $2}')"
+          # Resolve ${REGISTRY} the same way pre-release.yml's build-args-json does (REGISTRY=docker.io).
+          resolved_from="${dockerfile_from//\$\{REGISTRY\}/docker.io}"
+          echo "Label base.name:        ${label_base}"
+          echo "Dockerfile FROM (real): ${resolved_from}"
+          if [ "$label_base" != "$resolved_from" ]; then
+            echo "::warning::org.opencontainers.image.base.name ('${label_base}') does not match the Dockerfile's actual final-stage base image ('${resolved_from}'). This is a known, pre-existing metadata bug, not something introduced by this release -- filing/fixing it is a separate task. Not failing this check."
+          else
+            echo "base.name label matches the Dockerfile's actual base image."
+          fi
+
+  package-install:
+    needs: [verify-github-release]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+            family: deb
+            distro_tag: ubuntu24.04
+            image: ubuntu:24.04
+            pkg_arch_token: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            family: deb
+            distro_tag: ubuntu24.04
+            image: ubuntu:24.04
+            pkg_arch_token: arm64
+          - runner: ubuntu-24.04
+            arch: amd64
+            family: rpm
+            distro_tag: amzn2023
+            image: amazonlinux:2023
+            pkg_arch_token: x86_64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+            family: rpm
+            distro_tag: amzn2023
+            image: amazonlinux:2023
+            pkg_arch_token: aarch64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Download verified assets
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Install and run package
+        run: |
+          set -euo pipefail
+          cd release-assets
+          # Both arch variants share the same distro_tag suffix (e.g. *_amd64_ubuntu24.04.deb and
+          # *_arm64_ubuntu24.04.deb both match "*ubuntu24.04.deb"), so filter by the arch token too.
+          pkg="$(ls -1 *.${{ matrix.family }} | grep "${{ matrix.distro_tag }}" | grep "${{ matrix.pkg_arch_token }}")"
+          echo "Testing package: ${pkg}"
+
+          docker run -d --name target --platform "linux/${{ matrix.arch }}" "${{ matrix.image }}" sleep infinity
+          docker cp "$pkg" target:/tmp/package.${{ matrix.family }}
+
+          if [ "${{ matrix.family }}" = "deb" ]; then
+            docker exec target sh -c "apt-get update && apt-get install -y /tmp/package.deb"
+          else
+            docker exec target sh -c "dnf install -y /tmp/package.rpm"
+          fi
+
+          docker exec -d target /usr/bin/aerospike-backup-service -c /etc/aerospike-backup-service/aerospike-backup-service.yml
+
+          for i in $(seq 1 10); do
+            if docker exec target wget -qO- http://localhost:8080/health; then
+              break
+            fi
+            [ "$i" -eq 10 ] && { echo "::error::aerospike-backup-service never became healthy"; exit 1; }
+            sleep 3
+          done
+
+          version_output="$(docker exec target wget -qO- http://localhost:8080/version)"
+          echo "Reported version: ${version_output}"
+          case "$version_output" in
+            *"${{ inputs.version }}"*) echo "Version matches." ;;
+            *) echo "::warning::Reported version '${version_output}' does not obviously contain '${{ inputs.version }}' -- confirm the exact /version response format." ;;
+          esac
+
+      - name: Teardown
+        if: always()
+        run: docker rm -f target || true
+
+  docker-image-install:
+    needs: [verify-jfrog-prod]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Pull image (DockerHub first, JFrog PROD fallback)
+        id: pull
+        run: |
+          set +e
+          if docker pull --platform "linux/${{ matrix.arch }}" "docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}"; then
+            echo "ref=docker.io/${{ env.DOCKERHUB_IMAGE }}:${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DockerHub pull failed (likely still mirroring) -- falling back to JFrog PROD."
+            IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/${{ env.IMAGE_NAME }}:${{ inputs.version }}"
+            docker pull --platform "linux/${{ matrix.arch }}" "$IMAGE_REF"
+            echo "ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run and health-check
+        run: |
+          set -euo pipefail
+          docker run -d --name abs --platform "linux/${{ matrix.arch }}" -p 8080:8080 "${{ steps.pull.outputs.ref }}"
+          for i in $(seq 1 10); do
+            if curl -sf http://localhost:8080/health; then break; fi
+            [ "$i" -eq 10 ] && { echo "::error::Container never became healthy"; docker logs abs; exit 1; }
+            sleep 3
+          done
+          curl -s http://localhost:8080/version
+
+      - name: Teardown
+        if: always()
+        run: docker rm -f abs || true
+
+  summary:
+    needs: [verify-github-release, verify-jfrog-prod, verify-dockerhub, verify-sbom-attestation, verify-oci-labels, package-install, docker-image-install]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Aggregate results
+        run: |
+          {
+            echo "### Post-Release Verification: ${{ inputs.version }}"
+            echo "| Job | Result |"
+            echo "| --- | --- |"
+            echo "| verify-github-release | ${{ needs.verify-github-release.result }} |"
+            echo "| verify-jfrog-prod | ${{ needs.verify-jfrog-prod.result }} |"
+            echo "| verify-dockerhub | ${{ needs.verify-dockerhub.result }} |"
+            echo "| verify-sbom-attestation | ${{ needs.verify-sbom-attestation.result }} |"
+            echo "| verify-oci-labels | ${{ needs.verify-oci-labels.result }} |"
+            echo "| package-install (matrix) | ${{ needs.package-install.result }} |"
+            echo "| docker-image-install (matrix) | ${{ needs.docker-image-install.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/post-release-verify-functional.yml
+++ b/.github/workflows/post-release-verify-functional.yml
@@ -1,0 +1,207 @@
+# Post-release functional smoke test: spins up Aerospike + MinIO, seeds real records, runs the
+# released aerospike-backup-service Docker image against them (reusing the existing
+# build/docker-compose/aerospike-backup-service.yml config as-is), triggers a real backup to
+# MinIO, truncates the namespace, restores, and verifies the record count matches. amd64 only --
+# architecture coverage already lives in post-release-verify-artifacts.yml's install matrix; this
+# workflow is about functional correctness, which isn't architecture-dependent.
+
+name: Post-Release Verify Functional
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version to smoke-test (e.g. v3.7.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RECORD_COUNT: 1000
+  NAMESPACE: test
+  ROUTINE: minioKeepFilesRoutine
+  BUCKET: as-backup-bucket
+
+jobs:
+  backup-restore-smoke-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.version }}
+
+      - name: Login to JFrog
+        uses: step-security/setup-jfrog-cli@53aeacb709fce45d0baf69a13ec3342f7e2d71a9 # v5.1.0
+        env:
+          JF_URL: ${{ vars.JF_ARTIFACTORY_URL }}
+          JF_PROJECT: ${{ vars.JF_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.JF_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JF_OIDC_AUDIENCE }}
+
+      - name: Create shared Docker network
+        run: docker network create abs-smoke-net
+
+      - name: Start Aerospike
+        run: |
+          docker run -d --name aerospike-cluster --network abs-smoke-net \
+            --network-alias aerospike-cluster \
+            -p 3000-3002:3000-3002 \
+            aerospike/aerospike-server-enterprise:8.1
+          for i in $(seq 1 20); do
+            if docker exec aerospike-cluster asinfo -p 3000 -v build >/dev/null 2>&1; then break; fi
+            [ "$i" -eq 20 ] && { echo "::error::Aerospike never became ready"; docker logs aerospike-cluster; exit 1; }
+            sleep 3
+          done
+
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio --network abs-smoke-net \
+            --network-alias minio \
+            -p 9000:9000 -p 9001:9001 \
+            -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data --console-address :9001
+          for i in $(seq 1 20); do
+            if curl -sf http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then break; fi
+            [ "$i" -eq 20 ] && { echo "::error::MinIO never became ready"; docker logs minio; exit 1; }
+            sleep 3
+          done
+          docker run --rm --network abs-smoke-net minio/mc \
+            sh -c "mc alias set myminio http://minio:9000 minioadmin minioadmin && mc mb myminio/${{ env.BUCKET }} && mc anonymous set public myminio/${{ env.BUCKET }}"
+
+      - name: Seed records and verify seed count
+        id: seed
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: seed
+          namespace: ${{ env.NAMESPACE }}
+          record-count: ${{ env.RECORD_COUNT }}
+          host: 127.0.0.1:3000
+
+      - name: Confirm seeded count before proceeding
+        uses: ./.github/actions/seed-and-verify-aerospike
+        id: seed-count
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Fail fast if seeding itself didn't work
+        run: |
+          if [ "${{ steps.seed-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after seeding, got ${{ steps.seed-count.outputs.record_count }}"
+            exit 1
+          fi
+
+      - name: Pull released image and run aerospike-backup-service
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/aerospike-backup-service:${{ inputs.version }}"
+          docker pull "$IMAGE_REF"
+          docker run -d --name abs --network abs-smoke-net \
+            -p 8080:8080 \
+            -v "$(pwd)/build/docker-compose/aerospike-backup-service.yml:/etc/aerospike-backup-service/aerospike-backup-service.yml:ro" \
+            "$IMAGE_REF"
+
+      - name: Wait for aerospike-backup-service to be healthy and ready
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://127.0.0.1:8080/health && curl -sf http://127.0.0.1:8080/ready; then break; fi
+            [ "$i" -eq 20 ] && { echo "::error::ABS never became ready"; docker logs abs; exit 1; }
+            sleep 3
+          done
+
+      - name: Trigger full backup
+        run: |
+          curl -sf -X POST "http://127.0.0.1:8080/v1/backups/full/${{ env.ROUTINE }}"
+
+      - name: Poll for backup completion
+        id: backup
+        uses: ./.github/actions/poll-abs-job
+        with:
+          base-url: http://127.0.0.1:8080
+          kind: backup
+          routine: ${{ env.ROUTINE }}
+
+      - name: Verify backup files landed in MinIO (independent of the ABS API's own say-so)
+        run: |
+          docker run --rm --network abs-smoke-net minio/mc \
+            sh -c "mc alias set myminio http://minio:9000 minioadmin minioadmin && mc ls --recursive myminio/${{ env.BUCKET }}/minioStorage" | tee minio-ls.txt
+          [ -s minio-ls.txt ] || { echo "::error::No objects found under minioStorage in MinIO after backup"; exit 1; }
+
+      - name: Truncate namespace before restore
+        run: |
+          docker run --rm --network host aerospike/aerospike-tools:latest \
+            asinfo -h 127.0.0.1:3000 -v "truncate-namespace:namespace=${{ env.NAMESPACE }}"
+
+      - name: Confirm namespace is empty before restore
+        id: pre-restore-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Fail if truncate didn't work
+        run: |
+          if [ "${{ steps.pre-restore-count.outputs.record_count }}" != "0" ]; then
+            echo "::error::Namespace ${{ env.NAMESPACE }} still has ${{ steps.pre-restore-count.outputs.record_count }} records after truncate -- restore verification would be meaningless"
+            exit 1
+          fi
+
+      - name: Trigger restore
+        id: restore
+        run: |
+          set -euo pipefail
+          RESPONSE="$(curl -sf -X POST "http://127.0.0.1:8080/v1/restore/full" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "destination-name": "absCluster1",
+              "source-name": "minioStorage",
+              "backup-data-path": "${{ steps.backup.outputs.backup-data-path }}",
+              "policy": {}
+            }')"
+          echo "$RESPONSE"
+          JOB_ID="$(echo "$RESPONSE" | jq -r '.["job-id"] // .jobId // .id')"
+          echo "job-id=${JOB_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Poll for restore completion
+        uses: ./.github/actions/poll-abs-job
+        with:
+          base-url: http://127.0.0.1:8080
+          kind: restore
+          job-id: ${{ steps.restore.outputs.job-id }}
+
+      - name: Verify record count matches the original seed
+        id: final-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.NAMESPACE }}
+          host: 127.0.0.1:3000
+
+      - name: Assert final count
+        run: |
+          if [ "${{ steps.final-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after restore, got ${{ steps.final-count.outputs.record_count }}"
+            exit 1
+          fi
+          echo "Backup/restore smoke test passed: ${{ env.RECORD_COUNT }} records survived a full backup+restore round trip."
+
+      - name: Dump ABS logs on failure
+        if: failure()
+        run: docker logs abs || true
+
+      - name: Teardown
+        if: always()
+        run: |
+          docker rm -f abs aerospike-cluster minio 2>/dev/null || true
+          docker network rm abs-smoke-net 2>/dev/null || true

--- a/.github/workflows/post-release-verify-helm.yml
+++ b/.github/workflows/post-release-verify-helm.yml
@@ -1,0 +1,367 @@
+# Post-release Helm smoke test: unlike helm-chart-tests.yml (PR-triggered, builds the chart/image
+# fresh, only does a trivial wget reachability check), this pulls the *released* chart+image from
+# JFrog PROD/GitHub Release, deploys a real MinIO server into the kind cluster (helm-chart-tests.yml
+# only creates a credentials Secret, no actual MinIO), and drives a real backup->restore->record-count
+# check through the REST API via kubectl port-forward. The chart's own trivial test-connection.yaml
+# Helm test hook is left untouched; this workflow adds real validation on top, after ct install
+# succeeds.
+#
+# NOTE: this is the most novel part of the post-release verification suite (new MinIO manifest, new
+# port-forward-based REST trigger against a kind cluster) -- expect to iterate on exact service names
+# and values-file keys during the first real dry run (see docs/development.md verification notes).
+
+name: Post-Release Verify Helm
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Released version to smoke-test (must have a published Helm chart + Docker image, e.g. v3.7.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NAMESPACE: aerospike
+  BUCKET: abs-testing-bucket
+  RECORD_COUNT: 1000
+  ASDB_NAMESPACE: test
+  ROUTINE: minioKeepFilesRoutine
+
+jobs:
+  helm-backup-restore-smoke-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.version }}
+
+      - name: Install yq
+        uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b #v1.3.1
+        with:
+          version: "v4.45.4"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: latest
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+          check-latest: true
+
+      - name: Set up Chart Testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Create Kind Cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      - name: Download released chart and pull released image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "${{ inputs.version }}" --repo "${{ github.repository }}" --pattern '*.tgz' --dir chart-download --clobber
+          CHART_FILE="$(ls -1 chart-download/*.tgz | head -1)"
+          echo "CHART_FILE=${CHART_FILE}" >> "$GITHUB_ENV"
+
+          IMAGE_REF="${{ vars.JF_ARTIFACTORY_REGISTRY_URL }}/${{ vars.JF_ARTIFACTORY_CONTAINER_PROD }}/aerospike-backup-service:${{ inputs.version }}"
+          docker pull "$IMAGE_REF"
+          kind load docker-image "$IMAGE_REF" --name chart-testing
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_ENV"
+
+      # Unchanged from helm-chart-tests.yml: OLM + AKO + AerospikeCluster CR setup is not
+      # release-specific, so it's copied verbatim.
+      - name: Setup Prerequisites (OLM, AKO, AerospikeCluster)
+        run: |
+          echo "Deploying AKO"
+
+          curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.35.0/install.sh | bash -s v0.35.0
+
+          kubectl create -f https://operatorhub.io/install/aerospike-kubernetes-operator.yaml
+          AKO_CSV_NAME="aerospike-kubernetes-operator.$(curl -s https://api.github.com/repos/aerospike/aerospike-kubernetes-operator/releases/latest | jq -r '.tag_name')"
+
+          echo "Waiting for AKO"
+          kubectl wait --for=create "csv/$AKO_CSV_NAME" --namespace operators --timeout=300s
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded "csv/$AKO_CSV_NAME" --namespace operators --timeout=300s
+          kubectl wait --for=condition=Ready pod --all --namespace operators --timeout=300s
+
+          kubectl create namespace ${{ env.NAMESPACE }}
+          kubectl --namespace ${{ env.NAMESPACE }} create serviceaccount aerospike-operator-controller-manager
+          kubectl create clusterrolebinding aerospike-cluster --clusterrole=aerospike-cluster --serviceaccount=${{ env.NAMESPACE }}:aerospike-operator-controller-manager
+
+          kubectl --namespace ${{ env.NAMESPACE }} create secret generic aerospike-secret --from-literal=features.conf="$(echo "${{ secrets.FEATURES_CONF }}")"
+          kubectl --namespace ${{ env.NAMESPACE }} create secret generic minio-credentials --from-file=credentials=<(cat <<EOF
+          [minio]
+          aws_access_key_id=minioadmin
+          aws_secret_access_key=minioadmin
+          EOF
+          )
+
+          ASDB_VERSION="$(curl -s "https://hub.docker.com/v2/repositories/aerospike/aerospike-server/tags?page_size=1024" | jq -r '[.results[].name | select(test("^\\d+\\.\\d+$"))] | sort_by(.) | reverse | .[1]').0"
+
+          cat <<EOF | kubectl apply -f -
+          apiVersion: asdb.aerospike.com/v1
+          kind: AerospikeCluster
+          metadata:
+            name: aerocluster
+            namespace: ${{ env.NAMESPACE }}
+          spec:
+            aerospikeConfig:
+              namespaces:
+                - name: ${{ env.ASDB_NAMESPACE }}
+                  replication-factor: 2
+                  storage-engine:
+                    data-size: 1073741824
+                    type: memory
+              network:
+                fabric:
+                  port: 3001
+                heartbeat:
+                  port: 3002
+                service:
+                  port: 3000
+              service:
+                feature-key-file: /etc/aerospike/secret/features.conf
+            image: "aerospike/aerospike-server-enterprise:${ASDB_VERSION}"
+            podSpec:
+              multiPodPerHost: true
+            size: 2
+            storage:
+              volumes:
+                - aerospike:
+                    path: /etc/aerospike/secret
+                  name: aerospike-config-secret
+                  source:
+                    secret:
+                      secretName: aerospike-secret
+            validationPolicy:
+              skipWorkDirValidate: true
+              skipXdrDlogFileValidate: true
+          EOF
+
+          kubectl wait --for=condition=Ready pod -l app=aerospike-cluster --namespace ${{ env.NAMESPACE }} --timeout=300s || \
+            kubectl wait --for=condition=Ready pod/aerocluster-0-0 pod/aerocluster-0-1 --namespace ${{ env.NAMESPACE }} --timeout=300s
+
+      # New: helm-chart-tests.yml only creates a minio-credentials Secret, no actual MinIO server.
+      - name: Deploy real MinIO
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: minio
+            namespace: ${{ env.NAMESPACE }}
+          spec:
+            replicas: 1
+            selector:
+              matchLabels: { app: minio }
+            template:
+              metadata:
+                labels: { app: minio }
+              spec:
+                containers:
+                  - name: minio
+                    image: minio/minio:latest
+                    args: ["server", "/data"]
+                    env:
+                      - name: MINIO_ROOT_USER
+                        value: minioadmin
+                      - name: MINIO_ROOT_PASSWORD
+                        value: minioadmin
+                    ports:
+                      - containerPort: 9000
+                    readinessProbe:
+                      httpGet: { path: /minio/health/ready, port: 9000 }
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: minio
+            namespace: ${{ env.NAMESPACE }}
+          spec:
+            selector: { app: minio }
+            ports:
+              - port: 9000
+                targetPort: 9000
+          EOF
+          kubectl wait --for=condition=Available deployment/minio --namespace ${{ env.NAMESPACE }} --timeout=180s
+
+          kubectl run mc --image=minio/mc -n ${{ env.NAMESPACE }} --restart=Never --command -- sleep 3600
+          kubectl wait --for=condition=Ready pod/mc -n ${{ env.NAMESPACE }} --timeout=120s
+          kubectl exec -n ${{ env.NAMESPACE }} mc -- sh -c \
+            "mc alias set myminio http://minio:9000 minioadmin minioadmin && mc mb myminio/${{ env.BUCKET }} && mc anonymous set public myminio/${{ env.BUCKET }}"
+
+      - name: Install released chart via chart-testing
+        env:
+          GITHUB_BRANCH: ${{ inputs.version }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          yq eval '. as $item ireduce ({}; .backupServiceConfig = $item)' .github/config/test-chart-abs-conf.yaml > abs-values.yaml
+          cat <<EOF > ct-values.yaml
+          volumes:
+            - name: minio-credentials
+              secret:
+                secretName: minio-credentials
+                optional: false
+          extraSecretVolumeMounts:
+            - name: minio-credentials
+              mountPath: /home/absuser/.aws/credentials
+              readOnly: true
+          image:
+            repository: ${{ env.IMAGE_REF }}
+            pullPolicy: IfNotPresent
+            tag: "${{ inputs.version }}"
+          configmap:
+            create: false
+          EOF
+
+          ct install \
+            --namespace ${{ env.NAMESPACE }} \
+            --charts "${{ env.CHART_FILE }}" \
+            --target-branch "$GITHUB_DEFAULT_BRANCH" \
+            --debug --helm-extra-args="--debug" \
+            --helm-extra-set-args="--values=ct-values.yaml --values=abs-values.yaml"
+
+      - name: Discover ABS service name and pod, wait for readiness
+        id: discover
+        run: |
+          set -euo pipefail
+          SVC="$(kubectl get svc -n ${{ env.NAMESPACE }} -l app.kubernetes.io/name=aerospike-backup-service -o jsonpath='{.items[0].metadata.name}')"
+          echo "svc=${SVC}" >> "$GITHUB_OUTPUT"
+          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=aerospike-backup-service -n ${{ env.NAMESPACE }} --timeout=180s
+
+      - name: Seed records into the AKO-managed Aerospike cluster
+        id: seed
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: seed
+          namespace: ${{ env.ASDB_NAMESPACE }}
+          record-count: ${{ env.RECORD_COUNT }}
+          kubectl-namespace: ${{ env.NAMESPACE }}
+          aerospike-k8s-host: aerocluster-0-0:3000
+
+      - name: Confirm seeded count before proceeding
+        id: seed-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.ASDB_NAMESPACE }}
+          kubectl-namespace: ${{ env.NAMESPACE }}
+          aerospike-k8s-host: aerocluster-0-0:3000
+
+      - name: Fail fast if seeding didn't work
+        run: |
+          if [ "${{ steps.seed-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after seeding, got ${{ steps.seed-count.outputs.record_count }}"
+            exit 1
+          fi
+
+      - name: Port-forward ABS service
+        run: |
+          kubectl port-forward -n ${{ env.NAMESPACE }} svc/${{ steps.discover.outputs.svc }} 8080:8080 &
+          echo $! > port-forward.pid
+          for i in $(seq 1 10); do
+            curl -sf http://127.0.0.1:8080/health && break
+            [ "$i" -eq 10 ] && { echo "::error::port-forward to ABS never became reachable"; exit 1; }
+            sleep 3
+          done
+
+      - name: Trigger full backup
+        run: curl -sf -X POST "http://127.0.0.1:8080/v1/backups/full/${{ env.ROUTINE }}"
+
+      - name: Poll for backup completion
+        id: backup
+        uses: ./.github/actions/poll-abs-job
+        with:
+          base-url: http://127.0.0.1:8080
+          kind: backup
+          routine: ${{ env.ROUTINE }}
+
+      - name: Verify backup files landed in MinIO
+        run: |
+          kubectl exec -n ${{ env.NAMESPACE }} mc -- sh -c "mc ls --recursive myminio/${{ env.BUCKET }}" | tee minio-ls.txt
+          [ -s minio-ls.txt ] || { echo "::error::No objects found in MinIO after backup"; exit 1; }
+
+      - name: Truncate namespace before restore
+        run: |
+          kubectl exec -n ${{ env.NAMESPACE }} aerocluster-0-0 -- \
+            asinfo -v "truncate-namespace:namespace=${{ env.ASDB_NAMESPACE }}"
+
+      - name: Confirm namespace is empty before restore
+        id: pre-restore-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.ASDB_NAMESPACE }}
+          kubectl-namespace: ${{ env.NAMESPACE }}
+          aerospike-k8s-host: aerocluster-0-0:3000
+
+      - name: Fail if truncate didn't work
+        run: |
+          if [ "${{ steps.pre-restore-count.outputs.record_count }}" != "0" ]; then
+            echo "::error::Namespace still has ${{ steps.pre-restore-count.outputs.record_count }} records after truncate"
+            exit 1
+          fi
+
+      - name: Trigger restore
+        id: restore
+        run: |
+          set -euo pipefail
+          RESPONSE="$(curl -sf -X POST "http://127.0.0.1:8080/v1/restore/full" \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "destination-name": "asdb-cluster",
+              "source-name": "minio",
+              "backup-data-path": "${{ steps.backup.outputs.backup-data-path }}",
+              "policy": {}
+            }')"
+          echo "$RESPONSE"
+          JOB_ID="$(echo "$RESPONSE" | jq -r '.["job-id"] // .jobId // .id')"
+          echo "job-id=${JOB_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Poll for restore completion
+        uses: ./.github/actions/poll-abs-job
+        with:
+          base-url: http://127.0.0.1:8080
+          kind: restore
+          job-id: ${{ steps.restore.outputs.job-id }}
+
+      - name: Verify record count matches the original seed
+        id: final-count
+        uses: ./.github/actions/seed-and-verify-aerospike
+        with:
+          mode: count
+          namespace: ${{ env.ASDB_NAMESPACE }}
+          kubectl-namespace: ${{ env.NAMESPACE }}
+          aerospike-k8s-host: aerocluster-0-0:3000
+
+      - name: Assert final count
+        run: |
+          if [ "${{ steps.final-count.outputs.record_count }}" != "${{ env.RECORD_COUNT }}" ]; then
+            echo "::error::Expected ${{ env.RECORD_COUNT }} records after restore, got ${{ steps.final-count.outputs.record_count }}"
+            exit 1
+          fi
+          echo "Helm backup/restore smoke test passed."
+
+      - name: Dump ABS pod logs on failure
+        if: failure()
+        run: kubectl logs -n ${{ env.NAMESPACE }} -l app.kubernetes.io/name=aerospike-backup-service --tail=200 || true
+
+      - name: Teardown
+        if: always()
+        run: |
+          [ -f port-forward.pid ] && kill "$(cat port-forward.pid)" 2>/dev/null || true
+          kind delete cluster --name chart-testing || true


### PR DESCRIPTION
## Summary
- Adds `post-release-verify-artifacts.yml`, `post-release-verify-functional.yml`, `post-release-verify-helm.yml` (plus their composite actions) as `workflow_dispatch`-triggered post-release checks.
- Verifies a published release's artifacts (GitHub Release, JFrog PROD in the `database` project, DockerHub), checksums/signatures, container SBOM/attestation and OCI labels, and does real install + backup/restore smoke tests (Docker and Helm/kind).
- Self-contained -- no dependency on the rest of `switch-to-sharedworkflows`. Landed as its own PR because GitHub only allows dispatching `workflow_dispatch` workflows that exist on the default branch.

## Test plan
- [ ] Merge this PR
- [ ] Dispatch each workflow with a real released version and confirm expected results (JFrog-`database`-scoped checks will only pass for a version actually released through the new pipeline; GitHub Release / DockerHub checks should pass for any real release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)