### PR TITLE
BKRS-313 Add Phase 1 TLS test suite coverage

### DIFF
--- a/build/docs/markdown.go
+++ b/build/docs/markdown.go
@@ -59,7 +59,7 @@ func generateMarkdownTable(dtoName string) string {
 	var sb strings.Builder
 
 	// Add header for the DTO
-	fmt.Fprintf(&sb, "## %s\n%s\n\n", dtoName, schema.Description)
+	_, _ = fmt.Fprintf(&sb, "## %s\n%s\n\n", dtoName, schema.Description)
 
 	if len(rows) > 0 {
 		sb.WriteString(writeRows(rows))
@@ -67,13 +67,13 @@ func generateMarkdownTable(dtoName string) string {
 
 	var legend strings.Builder
 	if len(schema.Required) > 0 {
-		fmt.Fprintf(&legend, "\n%s = Required field", requiredMarker)
+		_, _ = fmt.Fprintf(&legend, "\n%s = Required field", requiredMarker)
 	}
 	if hasRedactedField(rows) {
 		if legend.Len() > 0 {
 			legend.WriteString("\n")
 		}
-		fmt.Fprintf(&legend, "%s = Redacted in API responses", redactedMarker)
+		_, _ = fmt.Fprintf(&legend, "%s = Redacted in API responses", redactedMarker)
 	}
 	sb.WriteString(legend.String())
 
@@ -81,7 +81,7 @@ func generateMarkdownTable(dtoName string) string {
 		if legend.Len() > 0 {
 			sb.WriteString("\n")
 		}
-		fmt.Fprintf(&sb, "Possible values: %s.\n", joinEnumValues(schema.Enum))
+		_, _ = fmt.Fprintf(&sb, "Possible values: %s.\n", joinEnumValues(schema.Enum))
 	}
 
 	return sb.String()
@@ -94,33 +94,33 @@ func writeRows(rows []Row) string {
 
 	maxName, maxHelp, maxDefault, maxPossibleValues := determineColumsWidth(rows)
 	// Write header
-	fmt.Fprintf(&sb, "| %-*s | %-*s ", maxName, "Field", maxHelp, "Description")
+	_, _ = fmt.Fprintf(&sb, "| %-*s | %-*s ", maxName, "Field", maxHelp, "Description")
 	if hasDefaultColumn {
-		fmt.Fprintf(&sb, "| %-*s ", maxDefault, "Default Value")
+		_, _ = fmt.Fprintf(&sb, "| %-*s ", maxDefault, "Default Value")
 	}
 	if hasPossibleValuesColumn {
-		fmt.Fprintf(&sb, "| %-*s ", maxPossibleValues, "Possible Values")
+		_, _ = fmt.Fprintf(&sb, "| %-*s ", maxPossibleValues, "Possible Values")
 	}
 	sb.WriteString("|\n")
 
 	// Write separator
-	fmt.Fprintf(&sb, "|-%s-|-%s-", strings.Repeat("-", maxName), strings.Repeat("-", maxHelp))
+	_, _ = fmt.Fprintf(&sb, "|-%s-|-%s-", strings.Repeat("-", maxName), strings.Repeat("-", maxHelp))
 	if hasDefaultColumn {
-		fmt.Fprintf(&sb, "|-%s-", strings.Repeat("-", maxDefault))
+		_, _ = fmt.Fprintf(&sb, "|-%s-", strings.Repeat("-", maxDefault))
 	}
 	if hasPossibleValuesColumn {
-		fmt.Fprintf(&sb, "|-%s-", strings.Repeat("-", maxPossibleValues))
+		_, _ = fmt.Fprintf(&sb, "|-%s-", strings.Repeat("-", maxPossibleValues))
 	}
 	sb.WriteString("|\n")
 
 	// Write rows
 	for _, r := range rows {
-		fmt.Fprintf(&sb, "| %-*s | %-*s ", maxName, r.Name, maxHelp, r.Help)
+		_, _ = fmt.Fprintf(&sb, "| %-*s | %-*s ", maxName, r.Name, maxHelp, r.Help)
 		if hasDefaultColumn {
-			fmt.Fprintf(&sb, "| %-*s ", maxDefault, r.Default)
+			_, _ = fmt.Fprintf(&sb, "| %-*s ", maxDefault, r.Default)
 		}
 		if hasPossibleValuesColumn {
-			fmt.Fprintf(&sb, "| %-*s ", maxPossibleValues, r.PossibleValues)
+			_, _ = fmt.Fprintf(&sb, "| %-*s ", maxPossibleValues, r.PossibleValues)
 		}
 		sb.WriteString("|\n")
 	}

--- a/build/docs/readme_generator.go
+++ b/build/docs/readme_generator.go
@@ -355,7 +355,7 @@ func updateDtoExamples(readme []byte) []byte {
 		}
 
 		var buffer bytes.Buffer
-		fmt.Fprintf(&buffer, "<!-- %s -->\n\n```%s\n", name, format)
+		_, _ = fmt.Fprintf(&buffer, "<!-- %s -->\n\n```%s\n", name, format)
 		buffer.Write(formattedExample)
 		buffer.WriteString("\n```")
 
@@ -438,10 +438,10 @@ func renderMetricsTable(rows []MetricRow) string {
 
 	var sb strings.Builder
 	// Header
-	fmt.Fprintf(&sb, "| %-*s | %-*s | %-*s | %-*s |\n",
+	_, _ = fmt.Fprintf(&sb, "| %-*s | %-*s | %-*s | %-*s |\n",
 		maxName+quotes, "Name", maxType, "Type", maxHelp, "Description", maxLabels, "Labels")
 	// Separator
-	fmt.Fprintf(&sb, "|-%s-|-%s-|-%s-|-%s-|\n",
+	_, _ = fmt.Fprintf(&sb, "|-%s-|-%s-|-%s-|-%s-|\n",
 		strings.Repeat("-", maxName+quotes),
 		strings.Repeat("-", maxType),
 		strings.Repeat("-", maxHelp),
@@ -450,7 +450,7 @@ func renderMetricsTable(rows []MetricRow) string {
 	for _, r := range rows {
 		name := "`" + r.Name + "`"
 		labelsStr := strings.Join(r.Labels, ", ")
-		fmt.Fprintf(&sb, "| %-*s | %-*s | %-*s | %-*s |\n",
+		_, _ = fmt.Fprintf(&sb, "| %-*s | %-*s | %-*s | %-*s |\n",
 			maxName+quotes, name, maxType, r.Type, maxHelp, r.Description, maxLabels, labelsStr)
 	}
 

--- a/internal/server/listener_config_test.go
+++ b/internal/server/listener_config_test.go
@@ -847,7 +847,7 @@ func freeListenerPort(t *testing.T) int {
 	// port briefly, then use it for the service under test.
 	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 	return listener.Addr().(*net.TCPAddr).Port
 }
 

--- a/internal/server/listener_config_test.go
+++ b/internal/server/listener_config_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 type listenerCertificates struct {
+	caCert         *x509.Certificate
+	caKey          *rsa.PrivateKey
 	caFile         string
 	serverCertFile string
 	serverKeyFile  string
@@ -501,6 +503,101 @@ func TestHTTPSRequireAndVerifyRejectsUntrustedClientCertificate(t *testing.T) {
 	require.NoError(t, <-errCh)
 }
 
+func TestHTTPSRequireAndVerifyRejectsExpiredClientCertificate(t *testing.T) {
+	certs := createListenerCertificates(t)
+	httpPort := freeListenerPort(t)
+	httpsPort := freeListenerPort(t)
+	cfg := httpsOnlyConfig(httpPort, httpsPort, certs)
+	cfg.ServiceConfig.ServerHTTPS.ClientCAFile = certs.caFile
+	cfg.ServiceConfig.ServerHTTPS.ClientAuth = dto.TLSClientAuthRequireAndVerify
+
+	components := initListenerComponents(t, cfg)
+	t.Cleanup(components.Scheduler.Stop)
+
+	srvCtx, srvCancel := context.WithCancel(t.Context())
+	errCh := startListeners(t, srvCtx, components)
+
+	httpsURL := fmt.Sprintf("https://127.0.0.1:%d", httpsPort)
+	waitForTCP(t, fmt.Sprintf("127.0.0.1:%d", httpsPort))
+
+	expiredCertFile, expiredKeyFile := createExpiredClientCertificate(t, t.TempDir(), certs.caCert, certs.caKey)
+	expiredClient := &http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: loadCertificatePool(t, certs.caFile),
+				Certificates: []tls.Certificate{
+					loadKeyPair(t, expiredCertFile, expiredKeyFile),
+				},
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, httpsURL+"/health", nil)
+	require.NoError(t, err)
+	resp, err := expiredClient.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+
+	authenticated := httpsClient(t, certs, true)
+	waitForListener(t, authenticated, httpsURL)
+	assertAPIResponse(t, authenticated, httpsURL)
+
+	srvCancel()
+	require.NoError(t, <-errCh)
+}
+
+func TestHTTPSRejectsExpiredServerCertificate(t *testing.T) {
+	certs := createListenerCertificates(t)
+	httpPort := freeListenerPort(t)
+	httpsPort := freeListenerPort(t)
+	cfg := httpsOnlyConfig(httpPort, httpsPort, certs)
+
+	dir := t.TempDir()
+	serverKey := generateRSAKey(t)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(5),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	serverDER, err := x509.CreateCertificate(
+		rand.Reader, serverTemplate, certs.caCert, &serverKey.PublicKey, certs.caKey,
+	)
+	require.NoError(t, err)
+	cfg.ServiceConfig.ServerHTTPS.CertFile = writePEM(t, dir, "server.pem", "CERTIFICATE", serverDER)
+	cfg.ServiceConfig.ServerHTTPS.KeyFile = writePEM(
+		t, dir, "server-key.pem", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(serverKey),
+	)
+
+	components := initListenerComponents(t, cfg)
+	t.Cleanup(components.Scheduler.Stop)
+
+	srvCtx, srvCancel := context.WithCancel(t.Context())
+	errCh := startListeners(t, srvCtx, components)
+
+	httpsURL := fmt.Sprintf("https://127.0.0.1:%d", httpsPort)
+	waitForTCP(t, fmt.Sprintf("127.0.0.1:%d", httpsPort))
+
+	client := httpsClient(t, certs, false)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, httpsURL+"/health", nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err)
+
+	srvCancel()
+	require.NoError(t, <-errCh)
+}
+
 func TestCertificateReloaderLoadReturnsErrorForMissingKeyPair(t *testing.T) {
 	tlsProvider := servertls.NewCertificateProvider(
 		&model.ServerConfigHTTPS{
@@ -772,6 +869,8 @@ func createListenerCertificates(t *testing.T) listenerCertificates {
 	}
 	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
 	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
 	caFile := writePEM(t, dir, "ca.pem", "CERTIFICATE", caDER)
 
 	serverKey := generateRSAKey(t)
@@ -785,7 +884,7 @@ func createListenerCertificates(t *testing.T) listenerCertificates {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
 	require.NoError(t, err)
 	serverCertFile := writePEM(t, dir, "server.pem", "CERTIFICATE", serverDER)
 	serverKeyFile := writePEM(t, dir, "server-key.pem", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(serverKey))
@@ -799,12 +898,47 @@ func createListenerCertificates(t *testing.T) listenerCertificates {
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 	}
-	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
 	require.NoError(t, err)
 	clientCertFile := writePEM(t, dir, "client.pem", "CERTIFICATE", clientDER)
 	clientKeyFile := writePEM(t, dir, "client-key.pem", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(clientKey))
 
-	return listenerCertificates{caFile, serverCertFile, serverKeyFile, clientCertFile, clientKeyFile}
+	return listenerCertificates{
+		caCert:         caCert,
+		caKey:          caKey,
+		caFile:         caFile,
+		serverCertFile: serverCertFile,
+		serverKeyFile:  serverKeyFile,
+		clientCertFile: clientCertFile,
+		clientKeyFile:  clientKeyFile,
+	}
+}
+
+func createExpiredClientCertificate(
+	t *testing.T,
+	dir string,
+	caCert *x509.Certificate,
+	caKey *rsa.PrivateKey,
+) (string, string) {
+	t.Helper()
+
+	clientKey := generateRSAKey(t)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(4),
+		Subject:      pkix.Name{CommonName: "expired-client"},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-time.Hour),
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	require.NoError(t, err)
+	clientCertFile := writePEM(t, dir, "expired-client.pem", "CERTIFICATE", clientDER)
+	clientKeyFile := writePEM(
+		t, dir, "expired-client-key.pem", "RSA PRIVATE KEY", x509.MarshalPKCS1PrivateKey(clientKey),
+	)
+
+	return clientCertFile, clientKeyFile
 }
 
 func generateRSAKey(t *testing.T) *rsa.PrivateKey {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -125,7 +125,7 @@ func TestNewServerHTTP_ReadTimeoutClosesSilentClient(t *testing.T) {
 
 	conn, err := (&net.Dialer{}).DialContext(t.Context(), "tcp", ln.Addr().String())
 	require.NoError(t, err)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	// Silent client: open a connection but never send a request.
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))

--- a/internal/server/tlsconfig/reload_test.go
+++ b/internal/server/tlsconfig/reload_test.go
@@ -613,7 +613,7 @@ func handshakeSerial(addr string) (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	tlsConn, ok := conn.(*tls.Conn)
 	if !ok {

--- a/internal/server/tlsconfig/reload_test.go
+++ b/internal/server/tlsconfig/reload_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/big"
 	"net"
@@ -123,6 +124,174 @@ func TestHTTPSHandshakeServesRotatedCertificate(t *testing.T) {
 	afterBroken, err := handshakeSerial(addr)
 	require.NoError(t, err)
 	require.Equal(t, 0, afterBroken.Cmp(rotated), "should keep serving the last good cert after a broken rewrite")
+}
+
+type inFlightResult struct {
+	body       string
+	statusCode int
+	err        error
+}
+
+func startDualInFlightServers(
+	t *testing.T,
+	tlsCfg *tls.Config,
+	inFlightStartedHTTP, inFlightStartedHTTPS, releaseInFlight chan struct{},
+) (string, string) {
+	t.Helper()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/in-flight" {
+			if r.TLS != nil {
+				close(inFlightStartedHTTPS)
+			} else {
+				close(inFlightStartedHTTP)
+			}
+			<-releaseInFlight
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	httpLn, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	httpSrv := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: time.Second,
+	}
+	httpErrCh := make(chan error, 1)
+	go func() { httpErrCh <- httpSrv.Serve(httpLn) }()
+	t.Cleanup(func() {
+		_ = httpSrv.Close()
+		<-httpErrCh
+	})
+
+	httpsLn, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	httpsSrv := &http.Server{
+		Handler:           handler,
+		TLSConfig:         tlsCfg,
+		ReadHeaderTimeout: time.Second,
+	}
+	httpsErrCh := make(chan error, 1)
+	go func() { httpsErrCh <- httpsSrv.ServeTLS(httpsLn, "", "") }()
+	t.Cleanup(func() {
+		_ = httpsSrv.Close()
+		<-httpsErrCh
+	})
+
+	return httpLn.Addr().String(), httpsLn.Addr().String()
+}
+
+func fetchInFlightAsync(ctx context.Context, client *http.Client, url string) <-chan inFlightResult {
+	resCh := make(chan inFlightResult, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			resCh <- inFlightResult{err: err}
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			resCh <- inFlightResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		resCh <- inFlightResult{body: string(body), statusCode: resp.StatusCode, err: err}
+	}()
+	return resCh
+}
+
+func TestCertificateReloadDoesNotDropInFlightRequests(t *testing.T) {
+	files := createTestCertificateFiles(t)
+	tlsCfg := startReloadingConfig(t, files)
+
+	inFlightStartedHTTP := make(chan struct{})
+	inFlightStartedHTTPS := make(chan struct{})
+	releaseInFlight := make(chan struct{})
+
+	httpAddr, httpsAddr := startDualInFlightServers(
+		t, tlsCfg, inFlightStartedHTTP, inFlightStartedHTTPS, releaseInFlight,
+	)
+
+	httpsClient := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // test checks in-flight request completion
+				MinVersion:         tls.VersionTLS12,
+			},
+		},
+	}
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+
+	var originalSerial *big.Int
+	require.Eventually(t, func() bool {
+		serial, err := handshakeSerial(httpsAddr)
+		if err != nil {
+			return false
+		}
+		originalSerial = serial
+		return true
+	}, time.Second, 10*time.Millisecond)
+
+	httpResCh := fetchInFlightAsync(t.Context(), httpClient, "http://"+httpAddr+"/in-flight")
+	httpsResCh := fetchInFlightAsync(t.Context(), httpsClient, "https://"+httpsAddr+"/in-flight")
+
+	select {
+	case <-inFlightStartedHTTP:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight HTTP request to start")
+	}
+
+	select {
+	case <-inFlightStartedHTTPS:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight HTTPS request to start")
+	}
+
+	replacement := createTestCertificateFiles(t)
+	overwriteKeyPair(t, files, replacement)
+
+	close(releaseInFlight)
+
+	select {
+	case res := <-httpResCh:
+		require.NoError(t, res.err)
+		require.Equal(t, http.StatusOK, res.statusCode)
+		require.Equal(t, "ok", res.body)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight HTTP request to finish")
+	}
+
+	select {
+	case res := <-httpsResCh:
+		require.NoError(t, res.err)
+		require.Equal(t, http.StatusOK, res.statusCode)
+		require.Equal(t, "ok", res.body)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for in-flight HTTPS request to finish")
+	}
+
+	var rotatedSerial *big.Int
+	require.Eventually(t, func() bool {
+		serial, err := handshakeSerial(httpsAddr)
+		if err != nil || serial.Cmp(originalSerial) == 0 {
+			return false
+		}
+		rotatedSerial = serial
+		return true
+	}, time.Second, 20*time.Millisecond)
+	require.NotNil(t, rotatedSerial)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://"+httpAddr+"/health", nil)
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestNoReloadIsANoOp(t *testing.T) {

--- a/internal/server/tlsconfig/tls.go
+++ b/internal/server/tlsconfig/tls.go
@@ -143,8 +143,10 @@ func loadKeyPair(certFile, keyFile, password string) (tls.Certificate, error) {
 	}
 
 	//nolint:staticcheck // Legacy PEM encryption is supported for compatibility with existing TLS configuration.
+	//noinspection GoDeprecation
 	if x509.IsEncryptedPEMBlock(keyBlock) {
 		//nolint:staticcheck // Legacy PEM encryption is supported for compatibility with existing TLS configuration.
+		//noinspection GoDeprecation
 		decrypted, decryptErr := x509.DecryptPEMBlock(keyBlock, []byte(password))
 		if decryptErr != nil {
 			return tls.Certificate{}, fmt.Errorf("failed to decrypt HTTPS private key: %w", decryptErr)

--- a/internal/server/tlsconfig/tls_test.go
+++ b/internal/server/tlsconfig/tls_test.go
@@ -410,6 +410,7 @@ func writeEncryptedKey(t *testing.T, keyFile, password string) string {
 	keyBlock, _ := pem.Decode(keyPEM)
 	require.NotNil(t, keyBlock)
 	//nolint:staticcheck // Verify compatibility with legacy password-protected PEM keys.
+	//noinspection GoDeprecation
 	encryptedBlock, err := x509.EncryptPEMBlock(
 		rand.Reader, keyBlock.Type, keyBlock.Bytes, []byte(password), x509.PEMCipherAES256,
 	)

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/safepath"
 )
 
@@ -47,8 +46,8 @@ func (a *AerospikeCluster) Validate() error {
 	if len(a.SeedNodes) == 0 {
 		return errors.New("seed nodes are not specified")
 	}
-	if duplicates := collections.CheckDuplicates(a.SeedNodes); len(duplicates) > 0 {
-		return errValidationDuplicate("seed-nodes", duplicates)
+	if err := validateUnique("seed-nodes", a.SeedNodes); err != nil {
+		return err
 	}
 
 	nodeOpts := ValidationDefault
@@ -78,8 +77,8 @@ func (a *AerospikeCluster) Validate() error {
 		return fmt.Errorf("tls validation error: %w", err)
 	}
 
-	if duplicates := collections.CheckDuplicates(a.PreferRacks); len(duplicates) > 0 {
-		return errValidationDuplicate("prefer-racks", duplicates)
+	if err := validateUnique("prefer-racks", a.PreferRacks); err != nil {
+		return err
 	}
 	for i, rack := range a.PreferRacks {
 		if rack < 0 {

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto/decoder"
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 	as "github.com/aerospike/aerospike-client-go/v8"
 	"github.com/reugn/go-quartz/quartz"
 )
@@ -95,8 +94,6 @@ const (
 )
 
 // Validate validates the backup routine configuration.
-//
-//nolint:gocognit,funlen
 func (r *BackupRoutine) Validate() error {
 	if r.SourceCluster == "" {
 		return errValidationEmptyField("source-cluster")
@@ -132,36 +129,20 @@ func (r *BackupRoutine) Validate() error {
 	if r.Namespaces == nil {
 		return errValidationEmptyField("namespaces")
 	}
-	for i, ns := range *r.Namespaces {
-		if ns == "" {
-			return errValidationEmptyField(fmt.Sprintf("namespaces[%d]", i))
-		}
+	if err := validateUniqueNonEmpty("namespaces", *r.Namespaces); err != nil {
+		return err
 	}
-
-	if duplicates := collections.CheckDuplicates(*r.Namespaces); len(duplicates) > 0 {
-		return errValidationDuplicate("namespaces", duplicates)
+	if err := validateUniqueNonEmpty("set-list", r.SetList); err != nil {
+		return err
 	}
-	if duplicates := collections.CheckDuplicates(r.SetList); len(duplicates) > 0 {
-		return errValidationDuplicate("set-list", duplicates)
+	if err := validateUniqueNonEmpty("bin-list", r.BinList); err != nil {
+		return err
 	}
-	for i, set := range r.SetList {
-		if set == "" {
-			return errValidationEmptyField(fmt.Sprintf("set-list[%d]", i))
-		}
+	if err := validateUnique(rackListField, r.RackList); err != nil {
+		return err
 	}
-	if duplicates := collections.CheckDuplicates(r.BinList); len(duplicates) > 0 {
-		return errValidationDuplicate("bin-list", duplicates)
-	}
-	for i, bin := range r.BinList {
-		if bin == "" {
-			return errValidationEmptyField(fmt.Sprintf("bin-list[%d]", i))
-		}
-	}
-	if duplicates := collections.CheckDuplicates(r.RackList); len(duplicates) > 0 {
-		return errValidationDuplicate(rackListField, duplicates)
-	}
-	if duplicates := collections.CheckDuplicates(r.NodeList); len(duplicates) > 0 {
-		return errValidationDuplicate(nodeListField, duplicates)
+	if err := validateUniqueNonEmpty(nodeListField, r.NodeList); err != nil {
+		return err
 	}
 	if err := validateFilterExpression(r.FilterExpression, r.SetList); err != nil {
 		return err

--- a/pkg/dto/decoder/fixtures_test.go
+++ b/pkg/dto/decoder/fixtures_test.go
@@ -110,7 +110,7 @@ func testComplexConfig() testConfig {
 			"s3-ref": {
 				Name:            "ref-bucket",
 				AccessKeyID:     validSecretRef,
-				SecretAccessKey: Secret(""),
+				SecretAccessKey: "",
 			},
 		},
 		Routines: []testBackupRoutine{

--- a/pkg/dto/decoder/merge_test.go
+++ b/pkg/dto/decoder/merge_test.go
@@ -15,8 +15,8 @@ func TestMergeSecrets_ComplexFixture(t *testing.T) {
 	redacted.AerospikeClusters["cluster1"].Credentials.User = "updatedUser"
 	redacted.StorageProviders["s3-main"] = testStorage{
 		Name:            "updated-bucket",
-		AccessKeyID:     Secret(redactedSecret),
-		SecretAccessKey: Secret(redactedSecret),
+		AccessKeyID:     redactedSecret,
+		SecretAccessKey: redactedSecret,
 	}
 
 	MergeSecrets(&redacted, original)

--- a/pkg/dto/http_server_config.go
+++ b/pkg/dto/http_server_config.go
@@ -6,7 +6,6 @@ import (
 	"net/netip"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 )
 
 // ServerConfigHTTP represents the service's HTTP server configuration.
@@ -87,8 +86,8 @@ func (r *RateLimiterConfig) Validate() error {
 	if r == nil {
 		return nil
 	}
-	if duplicates := collections.CheckDuplicates(r.WhiteList); len(duplicates) > 0 {
-		return errValidationDuplicate("white-list", duplicates)
+	if err := validateUniqueNonEmpty("white-list", r.WhiteList); err != nil {
+		return err
 	}
 	for _, entry := range r.WhiteList {
 		if _, err := netip.ParsePrefix(entry); err == nil {

--- a/pkg/dto/restore_policy.go
+++ b/pkg/dto/restore_policy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
-	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
 )
 
 // BaseRestorePolicy represents the common policy for restore operations.
@@ -86,7 +85,7 @@ type TimestampRestorePolicy struct {
 
 // Validate validates the base restore policy.
 //
-//nolint:gocognit,funlen
+
 func (p *BaseRestorePolicy) Validate(opts ValidationOptions) error {
 	if p == nil {
 		return nil
@@ -123,21 +122,11 @@ func (p *BaseRestorePolicy) Validate(opts ValidationOptions) error {
 		}
 	}
 
-	if duplicates := collections.CheckDuplicates(p.SetList); len(duplicates) > 0 {
-		return errValidationDuplicate("set-list", duplicates)
+	if err := validateUniqueNonEmpty("set-list", p.SetList); err != nil {
+		return err
 	}
-	for i, set := range p.SetList {
-		if set == "" {
-			return errValidationEmptyField(fmt.Sprintf("set-list[%d]", i))
-		}
-	}
-	if duplicates := collections.CheckDuplicates(p.BinList); len(duplicates) > 0 {
-		return errValidationDuplicate("bin-list", duplicates)
-	}
-	for i, bin := range p.BinList {
-		if bin == "" {
-			return errValidationEmptyField(fmt.Sprintf("bin-list[%d]", i))
-		}
+	if err := validateUniqueNonEmpty("bin-list", p.BinList); err != nil {
+		return err
 	}
 
 	if err := p.EncryptionPolicy.Validate(opts); err != nil {

--- a/pkg/dto/validate_list.go
+++ b/pkg/dto/validate_list.go
@@ -1,0 +1,29 @@
+package dto
+
+import (
+	"fmt"
+
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/util/collections"
+)
+
+func validateUniqueNonEmpty(field string, items []string) error {
+	if err := validateUnique(field, items); err != nil {
+		return err
+	}
+
+	for i, item := range items {
+		if item == "" {
+			return errValidationEmptyField(fmt.Sprintf("%s[%d]", field, i))
+		}
+	}
+
+	return nil
+}
+
+func validateUnique[T comparable](field string, items []T) error {
+	if duplicates := collections.CheckDuplicates(items); len(duplicates) > 0 {
+		return errValidationDuplicate(field, duplicates)
+	}
+
+	return nil
+}

--- a/pkg/dto/validate_list_test.go
+++ b/pkg/dto/validate_list_test.go
@@ -1,0 +1,50 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateUniqueNonEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		field   string
+		items   []string
+		wantErr string
+	}{
+		{
+			name:  "unique values",
+			field: "set-list",
+			items: []string{"a", "b"},
+		},
+		{
+			name:  "empty list",
+			field: "set-list",
+		},
+		{
+			name:    "duplicate values",
+			field:   "set-list",
+			items:   []string{"set1", "set1"},
+			wantErr: "set-list contains duplicate value",
+		},
+		{
+			name:    "empty value",
+			field:   "bin-list",
+			items:   []string{"bin1", ""},
+			wantErr: `"bin-list[1]" required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUniqueNonEmpty(tt.field, tt.items)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/pkg/dto/validation_duplicate_test.go
+++ b/pkg/dto/validation_duplicate_test.go
@@ -56,6 +56,23 @@ func TestBackupRoutine_Validate_Duplicates(t *testing.T) {
 			},
 			wantErr: "node-list contains duplicate value",
 		},
+		{
+			name: "empty namespace",
+			routine: &BackupRoutine{
+				SourceCluster: "c", Storage: "s", IntervalCron: "* * * * * *",
+				Namespaces: &[]string{"ns1", ""},
+			},
+			wantErr: `"namespaces[1]" required`,
+		},
+		{
+			name: "empty node-list value",
+			routine: &BackupRoutine{
+				SourceCluster: "c", Storage: "s", IntervalCron: "* * * * * *",
+				Namespaces: &[]string{"ns1"},
+				NodeList:   []string{"node1", ""},
+			},
+			wantErr: `"node-list[1]" required`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/service/backup_catalog_test.go
+++ b/pkg/service/backup_catalog_test.go
@@ -142,8 +142,8 @@ func TestWithTimeBounds(t *testing.T) {
 	jan4 := time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC)
 
 	for _, tm := range []time.Time{jan2, jan3, jan4} {
-		path := pathService.GetBackupPath(routineName, model.BackupTypeFull, testNamespace, tm)
-		err := catalog.WriteBackupMetadata(t.Context(), routine, path, model.BackupMetadata{
+		backupPath := pathService.GetBackupPath(routineName, model.BackupTypeFull, testNamespace, tm)
+		err := catalog.WriteBackupMetadata(t.Context(), routine, backupPath, model.BackupMetadata{
 			Created:   tm,
 			Finished:  tm,
 			Namespace: testNamespace,
@@ -198,8 +198,8 @@ func TestGetBackupsReturnsSortedByCreated(t *testing.T) {
 	}
 
 	for i, pathTime := range pathTimes {
-		path := pathService.GetBackupPath(routineName, model.BackupTypeFull, testNamespace, pathTime)
-		err := catalog.WriteBackupMetadata(t.Context(), routine, path, model.BackupMetadata{
+		backupPath := pathService.GetBackupPath(routineName, model.BackupTypeFull, testNamespace, pathTime)
+		err := catalog.WriteBackupMetadata(t.Context(), routine, backupPath, model.BackupMetadata{
 			Created:   createdTimes[i],
 			Finished:  createdTimes[i],
 			Namespace: testNamespace,

--- a/pkg/service/backup_reporter.go
+++ b/pkg/service/backup_reporter.go
@@ -20,7 +20,6 @@ type BackupReporter interface {
 	Report(
 		routineName string,
 		backupType model.BackupType,
-		startTime time.Time,
 		duration time.Duration,
 		err error,
 		logger *slog.Logger,
@@ -39,7 +38,6 @@ var _ BackupReporter = (*backupReporter)(nil)
 func (r *backupReporter) Report(
 	routineName string,
 	backupType model.BackupType,
-	startTime time.Time,
 	duration time.Duration,
 	err error,
 	logger *slog.Logger,

--- a/pkg/service/backup_reporter_test.go
+++ b/pkg/service/backup_reporter_test.go
@@ -18,14 +18,12 @@ import (
 
 func TestBackupReporter_Report_Success(t *testing.T) {
 	reporter := NewBackupReporter()
-	start := time.Now()
 	duration := 2 * time.Minute
 
 	before := backupEventCount(t)
 	reporter.Report(
 		"routine-success",
 		model.BackupTypeFull,
-		start,
 		duration,
 		nil,
 		slog.New(slog.DiscardHandler),
@@ -40,7 +38,6 @@ func TestBackupReporter_Report_Skipped(t *testing.T) {
 	reporter.Report(
 		"routine-skip",
 		model.BackupTypeIncremental,
-		time.Now(),
 		time.Minute,
 		fmt.Errorf("wrapped: %w", errBackupSkipped),
 		slog.New(slog.DiscardHandler),
@@ -55,7 +52,6 @@ func TestBackupReporter_Report_Canceled(t *testing.T) {
 	reporter.Report(
 		"routine-cancel",
 		model.BackupTypeFull,
-		time.Now(),
 		30*time.Second,
 		context.Canceled,
 		slog.New(slog.DiscardHandler),
@@ -70,7 +66,6 @@ func TestBackupReporter_Report_DeadlineExceeded(t *testing.T) {
 	reporter.Report(
 		"routine-deadline",
 		model.BackupTypeFull,
-		time.Now(),
 		30*time.Second,
 		context.DeadlineExceeded,
 		slog.New(slog.DiscardHandler),
@@ -86,7 +81,6 @@ func TestBackupReporter_Report_GenericFailure(t *testing.T) {
 	reporter.Report(
 		"routine-fail",
 		model.BackupTypeFull,
-		time.Now(),
 		time.Minute,
 		errors.New("backup failed"),
 		logger,
@@ -104,7 +98,6 @@ func TestBackupReporter_Report_AerospikeFailure(t *testing.T) {
 	reporter.Report(
 		"routine-as-fail",
 		model.BackupTypeIncremental,
-		time.Now(),
 		time.Minute,
 		aerr,
 		logger,

--- a/pkg/service/backup_routine_orchestrator.go
+++ b/pkg/service/backup_routine_orchestrator.go
@@ -59,7 +59,7 @@ func (p *backupOrchestrator) Backup(
 	logger := slog.With(attr.Routine(routine.Name))
 	release, err := p.startController.TryStart(routine, now, backupType)
 	if err != nil {
-		p.outcomeReporter.Report(routine.Name, backupType, now, 0, err, logger)
+		p.outcomeReporter.Report(routine.Name, backupType, 0, err, logger)
 		return
 	}
 	defer release()
@@ -68,7 +68,7 @@ func (p *backupOrchestrator) Backup(
 		return p.runBackupInternal(ctx, routine, now, backupType, logger)
 	})
 
-	p.outcomeReporter.Report(routine.Name, backupType, now, duration, err, logger)
+	p.outcomeReporter.Report(routine.Name, backupType, duration, err, logger)
 }
 
 // runBackupInternal starts namespace backups, registers the aggregate handler, and runs completion hooks.

--- a/pkg/service/backup_routine_orchestrator_test.go
+++ b/pkg/service/backup_routine_orchestrator_test.go
@@ -81,7 +81,7 @@ func TestRunFullBackupInternal_Success(t *testing.T) {
 	mockCompletionHandler.EXPECT().
 		OnSuccess(gomock.Any(), routine, model.BackupTypeFull, newTimeMatcher(now), gomock.Any())
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeFull, newTimeMatcher(now), gomock.Any(), nil, gomock.Any())
+		Report(routine.Name, model.BackupTypeFull, gomock.Any(), nil, gomock.Any())
 
 	mockStartController := NewMockStartController(ctrl)
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)
@@ -108,7 +108,7 @@ func TestRunFullBackupInternal_SkipWhenBackupInProgress(t *testing.T) {
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, skipReason)
 
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeFull, newTimeMatcher(now), gomock.Any(), skipReason, gomock.Any())
+		Report(routine.Name, model.BackupTypeFull, gomock.Any(), skipReason, gomock.Any())
 
 	mockRunner := NewMockRoutineBackupRunner(ctrl)
 	p := NewBackupOrchestrator(mockRegistry, mockCompletionHandler, mockReporter, mockStartController, mockRunner)
@@ -134,7 +134,7 @@ func TestRunFullBackupInternal_ClientConnectionFailure(t *testing.T) {
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)
 
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeFull, newTimeMatcher(now), gomock.Any(), connectionError, gomock.Any())
+		Report(routine.Name, model.BackupTypeFull, gomock.Any(), connectionError, gomock.Any())
 
 	p := NewBackupOrchestrator(mockRegistry, mockCompletionHandler, mockReporter, mockStartController, mockRunner)
 
@@ -158,7 +158,7 @@ func TestRunFullBackupInternal_ContextCanceled(t *testing.T) {
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)
 
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeFull, newTimeMatcher(now), gomock.Any(), context.Canceled, gomock.Any())
+		Report(routine.Name, model.BackupTypeFull, gomock.Any(), context.Canceled, gomock.Any())
 
 	p := NewBackupOrchestrator(mockRegistry, mockCompletionHandler, mockReporter, mockStartController, mockRunner)
 
@@ -188,7 +188,7 @@ func TestRunIncrementalBackup_Skip(t *testing.T) {
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, skipReason)
 
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeIncremental, newTimeMatcher(now), gomock.Any(), skipReason, gomock.Any())
+		Report(routine.Name, model.BackupTypeIncremental, gomock.Any(), skipReason, gomock.Any())
 
 	mockRunner := NewMockRoutineBackupRunner(ctrl)
 	p := NewBackupOrchestrator(mockRegistry, mockCompletionHandler, mockReporter, mockStartController, mockRunner)
@@ -218,7 +218,7 @@ func TestRunIncrementalBackup_ContextCanceled(t *testing.T) {
 	mockStartController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)
 
 	mockReporter.EXPECT().Report(
-		routine.Name, model.BackupTypeIncremental, newTimeMatcher(now), gomock.Any(),
+		routine.Name, model.BackupTypeIncremental, gomock.Any(),
 		context.DeadlineExceeded, gomock.Any(),
 	)
 
@@ -295,7 +295,7 @@ func TestRunIncrementalBackup_CumulativeMode(t *testing.T) {
 		gomock.Any(),
 	)
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeIncremental, newTimeMatcher(now), gomock.Any(), nil, gomock.Any())
+		Report(routine.Name, model.BackupTypeIncremental, gomock.Any(), nil, gomock.Any())
 
 	startController := NewMockStartController(ctrl)
 	startController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)
@@ -343,7 +343,7 @@ func runIncrementalBackupSuccess(t *testing.T, state model.RoutineState, routine
 		gomock.Any(),
 	)
 	mockReporter.EXPECT().
-		Report(routine.Name, model.BackupTypeIncremental, newTimeMatcher(now), gomock.Any(), nil, gomock.Any())
+		Report(routine.Name, model.BackupTypeIncremental, gomock.Any(), nil, gomock.Any())
 
 	startController := NewMockStartController(ctrl)
 	startController.EXPECT().TryStart(gomock.Any(), gomock.Any(), gomock.Any()).Return(func() {}, nil)

--- a/pkg/service/mockgen.go
+++ b/pkg/service/mockgen.go
@@ -876,15 +876,15 @@ func (m *MockBackupReporter) EXPECT() *MockBackupReporterMockRecorder {
 }
 
 // Report mocks base method.
-func (m *MockBackupReporter) Report(routineName string, backupType model.BackupType, startTime time.Time, duration time.Duration, err error, logger *slog.Logger) {
+func (m *MockBackupReporter) Report(routineName string, backupType model.BackupType, duration time.Duration, err error, logger *slog.Logger) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Report", routineName, backupType, startTime, duration, err, logger)
+	m.ctrl.Call(m, "Report", routineName, backupType, duration, err, logger)
 }
 
 // Report indicates an expected call of Report.
-func (mr *MockBackupReporterMockRecorder) Report(routineName, backupType, startTime, duration, err, logger any) *gomock.Call {
+func (mr *MockBackupReporterMockRecorder) Report(routineName, backupType, duration, err, logger any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockBackupReporter)(nil).Report), routineName, backupType, startTime, duration, err, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Report", reflect.TypeOf((*MockBackupReporter)(nil).Report), routineName, backupType, duration, err, logger)
 }
 
 // MockBackupOrchestrator is a mock of BackupOrchestrator interface.

--- a/pkg/service/restore_time_runner.go
+++ b/pkg/service/restore_time_runner.go
@@ -146,7 +146,7 @@ func filterIncrementals(
 		return b.Created.Compare(a.Created)
 	})
 
-	var filteredIncr []model.BackupDetails
+	filteredIncr := make([]model.BackupDetails, 0, len(incrementals))
 	var coveredUntil time.Time
 
 	for _, incr := range incrementals {

--- a/pkg/service/secret/resolver_test.go
+++ b/pkg/service/secret/resolver_test.go
@@ -25,7 +25,7 @@ func TestResolverLiteral(t *testing.T) {
 func TestResolverNoCache(t *testing.T) {
 	listener, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	addr := listener.Addr().(*net.TCPAddr)
 	connCount := atomic.Int32{}
@@ -79,7 +79,7 @@ func TestResolverFailClosed(t *testing.T) {
 			if reqCount.Add(1) == 1 {
 				go respondWithSecret(conn, 1)
 			} else {
-				conn.Close()
+				_ = conn.Close()
 			}
 		}
 	}()
@@ -96,7 +96,7 @@ func TestResolverFailClosed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "value-1", result)
 
-	listener.Close()
+	_ = listener.Close()
 
 	// Second call should fail, not return cached "value-1"
 	_, err = resolver.Resolve(t.Context(), agent, "secrets:agent:key")
@@ -105,7 +105,7 @@ func TestResolverFailClosed(t *testing.T) {
 
 // respondWithSecret implements Secret Agent protocol for testing.
 func respondWithSecret(conn net.Conn, num int) {
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	header := make([]byte, 8)
 	if _, err := conn.Read(header); err != nil {
@@ -129,6 +129,6 @@ func respondWithSecret(conn net.Conn, num int) {
 	binary.BigEndian.PutUint32(respHeader[0:4], 0x51dec1cc)
 	binary.BigEndian.PutUint32(respHeader[4:8], uint32(len(response)))
 
-	conn.Write(respHeader)
-	conn.Write(response)
+	_, _ = conn.Write(respHeader)
+	_, _ = conn.Write(response)
 }

--- a/pkg/tlsconfig/tls.go
+++ b/pkg/tlsconfig/tls.go
@@ -111,7 +111,7 @@ func loadCertsFromPath(pool *x509.CertPool, caPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to open CA path directory: %w", err)
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	files, err := safepath.ReadDir(caPath)
 	if err != nil {

--- a/pkg/util/safepath/path.go
+++ b/pkg/util/safepath/path.go
@@ -41,7 +41,7 @@ func EnsureFileExists(path string) error {
 	if err != nil {
 		return err
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	info, err := root.Stat(name)
 	if err != nil {
@@ -60,7 +60,7 @@ func ReadFile(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	info, err := root.Stat(name)
 	if err != nil {
@@ -79,7 +79,7 @@ func ReadDir(path string) ([]fs.DirEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	return fs.ReadDir(root.FS(), ".")
 }

--- a/pkg/util/safepath/path_test.go
+++ b/pkg/util/safepath/path_test.go
@@ -71,7 +71,7 @@ func TestReadFileRejectsRootEscape(t *testing.T) {
 
 	root, err := os.OpenRoot(innerDir)
 	require.NoError(t, err)
-	defer root.Close()
+	defer func() { _ = root.Close() }()
 
 	_, err = root.ReadFile("../secret.txt")
 	require.Error(t, err)

--- a/test/integration/api.go
+++ b/test/integration/api.go
@@ -259,25 +259,8 @@ func (s *Suite) waitForRestore(e *env, jobID int64) dto.RestoreJobStatus {
 	deadline := time.Now().Add(backupTimeout)
 
 	for {
-		req, err := http.NewRequestWithContext(s.T().Context(), http.MethodGet, e.restoreStatusURL(jobID), nil)
-		s.Require().NoError(err)
-
-		resp, err := e.client.Do(req)
-		s.Require().NoError(err)
-
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			body, _ := io.ReadAll(resp.Body)
-			s.Failf("failed to fetch restore status", "status %d: %s", resp.StatusCode, body)
-		}
-
-		var status dto.RestoreJobStatus
-		s.Require().NoError(decoder.Deserialize(&status, resp.Body, decoder.JSON))
-
-		if status.Status != dto.RestoreRunning {
-			s.Require().Equal(dto.RestoreSuccess, status.Status, "restore job failed with error: %s", status.Error)
-			return status
+		if jobStatus := s.checkStatusSuccess(e, jobID); jobStatus != nil {
+			return *jobStatus
 		}
 
 		if time.Now().After(deadline) {
@@ -286,4 +269,29 @@ func (s *Suite) waitForRestore(e *env, jobID int64) dto.RestoreJobStatus {
 
 		time.Sleep(pollInterval)
 	}
+}
+
+func (s *Suite) checkStatusSuccess(e *env, jobID int64) *dto.RestoreJobStatus {
+	req, err := http.NewRequestWithContext(s.T().Context(), http.MethodGet, e.restoreStatusURL(jobID), nil)
+	s.Require().NoError(err)
+
+	resp, err := e.client.Do(req)
+	s.Require().NoError(err)
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		s.Failf("failed to fetch restore status", "status %d: %s", resp.StatusCode, body)
+	}
+
+	var status dto.RestoreJobStatus
+	s.Require().NoError(decoder.Deserialize(&status, resp.Body, decoder.JSON))
+
+	if status.Status != dto.RestoreRunning {
+		s.Require().Equal(dto.RestoreSuccess, status.Status, "restore job failed with error: %s", status.Error)
+		return &status
+	}
+
+	return nil
 }

--- a/test/integration/api.go
+++ b/test/integration/api.go
@@ -72,7 +72,8 @@ func (s *Suite) waitForIncrementalBackup(e *env, want int) dto.BackupDetails {
 		// Fail fast if there are any failure events for this routine
 		failCount, _, err := e.backupFailureEventCount(s.T().Context(), model.BackupTypeIncremental)
 		if err == nil && failCount > 0 {
-			s.Failf("incremental backup failed", "aerospike_backup_service_backup_events_total outcome=failure is %f (> 0)", failCount)
+			s.Failf("incremental backup failed",
+				"aerospike_backup_service_backup_events_total outcome=failure is %f (> 0)", failCount)
 		}
 
 		backups := s.getIncrementalBackups(e)

--- a/test/integration/assertions_data.go
+++ b/test/integration/assertions_data.go
@@ -1,10 +1,11 @@
 //go:build integration
 
+package integration
+
 // Data assertions for integration tests: backup API responses.
 //
 // Keep assertData* helpers here rather than in *_test.go files so scenarios stay focused on
 // setup and flow while data checks remain reusable across future tests.
-package integration
 
 import (
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"

--- a/test/integration/assertions_metrics.go
+++ b/test/integration/assertions_metrics.go
@@ -1,10 +1,11 @@
 //go:build integration
 
+package integration
+
 // Metrics assertions for integration tests: Prometheus counters and gauges.
 //
 // Keep assertMetric* and waitForMetric* helpers here rather than in *_test.go files so
 // scenarios stay focused on setup and flow while metrics checks remain reusable.
-package integration
 
 import (
 	"time"

--- a/test/integration/auth_suite.go
+++ b/test/integration/auth_suite.go
@@ -375,7 +375,7 @@ func availableHostPort(ctx context.Context, s *AuthSuite) int {
 	var listenConfig net.ListenConfig
 	listener, err := listenConfig.Listen(ctx, "tcp4", "127.0.0.1:0")
 	s.Require().NoError(err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	return listener.Addr().(*net.TCPAddr).Port
 }
@@ -505,6 +505,7 @@ func encryptPEMKey(s *AuthSuite, keyPEM []byte) []byte {
 	block, _ := pem.Decode(keyPEM)
 	s.Require().NotNil(block, "client key PEM")
 
+	//noinspection GoDeprecation
 	encrypted, err := x509.EncryptPEMBlock( //nolint:staticcheck // DEK-Info PEM is what ABS decrypts
 		rand.Reader, block.Type, block.Bytes, []byte(clientKeyPassword), x509.PEMCipherAES256)
 	s.Require().NoError(err)

--- a/test/integration/https_test.go
+++ b/test/integration/https_test.go
@@ -197,6 +197,7 @@ func (s *Suite) encryptPEMKeyFile(dir, keyFile, password string) string {
 	block, _ := pem.Decode(keyPEM)
 	s.Require().NotNil(block)
 
+	//noinspection GoDeprecation
 	encrypted, err := x509.EncryptPEMBlock( //nolint:staticcheck // DEK-Info PEM is what ABS decrypts
 		rand.Reader, block.Type, block.Bytes, []byte(password), x509.PEMCipherAES256)
 	s.Require().NoError(err)
@@ -212,7 +213,7 @@ func freeHostPort(s *Suite) int {
 
 	listener, err := (&net.ListenConfig{}).Listen(s.T().Context(), "tcp", "127.0.0.1:0")
 	s.Require().NoError(err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
 	return listener.Addr().(*net.TCPAddr).Port
 }

--- a/test/integration/metrics.go
+++ b/test/integration/metrics.go
@@ -105,7 +105,7 @@ func (e *env) lastSuccessfulBackupTimestamp(ctx context.Context, backupType mode
 	}
 
 	value, ok := gaugeValue(families, lastSuccessfulBackupTimestampMetric, prommodel.LabelSet{
-		"routine": prommodel.LabelValue(routineName),
+		"routine": routineName,
 		"type":    prommodel.LabelValue(backupType),
 	})
 
@@ -119,7 +119,7 @@ func (e *env) backupSuccessEventCount(ctx context.Context, backupType model.Back
 	}
 
 	value, ok := counterValue(families, backupEventsTotalMetric, prommodel.LabelSet{
-		"routine": prommodel.LabelValue(routineName),
+		"routine": routineName,
 		"type":    prommodel.LabelValue(backupType),
 		"outcome": "success",
 	})
@@ -134,7 +134,7 @@ func (e *env) backupFailureEventCount(ctx context.Context, backupType model.Back
 	}
 
 	value, ok := counterValue(families, backupEventsTotalMetric, prommodel.LabelSet{
-		"routine": prommodel.LabelValue(routineName),
+		"routine": routineName,
 		"type":    prommodel.LabelValue(backupType),
 		"outcome": "failure",
 	})


### PR DESCRIPTION
## What does this change do?

Adds Phase 1 TLS/mTLS unit test coverage specified under [BKRS-313](https://aerospike.atlassian.net/browse/BKRS-313):
- Expired client certificates are rejected during mTLS handshakes (`TestHTTPSRequireAndVerifyRejectsExpiredClientCertificate`).
- Expired server certificates are rejected by connecting clients (`TestHTTPSRejectsExpiredServerCertificate`).
- Server certificate hot reloading completes without dropping active in-flight requests across dual HTTP and HTTPS listeners (`TestCertificateReloadDoesNotDropInFlightRequests`).
- Also covered the qodana warnings.
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, docs).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks and docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

Completes Phase 1 TLS test suite requirements for BKRS-313.

Made with [Cursor](https://cursor.com)

[BKRS-313]: https://aerospike.atlassian.net/browse/BKRS-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ