### PR TITLE
BKRS-386 Add nilaway linter

### DIFF
--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,0 +1,38 @@
+# Fails if NilAway reports a potential nil panic in production code.
+# Run "make nilaway" locally. Tests, generated mocks, and the docs generator are excluded.
+name: NilAway
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+      - dev
+      - 'v[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  nilaway:
+    name: nilaway
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup-go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run NilAway
+        run: make nilaway

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
 
       - name: Setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/Makefile
+++ b/Makefile
@@ -186,14 +186,14 @@ format:
 lint:
 	golangci-lint run ./...
 
-# Production packages only: skip tests and generated mocks.
+# Production packages only: skip tests, generated mocks, and the docs generator.
 .PHONY: nilaway
 nilaway:
 	$(GO) run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION) \
 		-test=false \
 		-exclude-test-files \
 		-exclude-file-docstrings='Code generated' \
-		$$($(GO) list ./...)
+		$$($(GO) list ./... | grep -vE '/(build/docs|docs)$$')
 
 .PHONY: lint-fix
 lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -189,13 +189,15 @@ lint:
 # Production packages only: skip tests, generated mocks, the docs generator, and
 # out-of-module code (stdlib/deps). NilAway otherwise traces into net/http and similar.
 .PHONY: nilaway
-nilaway:
+nilaway: submodules
+	set -euo pipefail; \
+	packages="$$($(GO) list ./... | grep -vE '/(build/docs|docs)$$')"; \
 	$(GO) run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION) \
 		-test=false \
 		-exclude-test-files \
 		-exclude-file-docstrings='Code generated' \
 		-include-pkgs=$$($(GO) list -m) \
-		$$($(GO) list ./... | grep -vE '/(build/docs|docs)$$')
+		$$packages
 
 .PHONY: lint-fix
 lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ VERSION ?= $(shell cat VERSION)
 
 # Go parameters
 GO ?= $(shell which go || echo "/usr/local/go/bin/go")
+# go.uber.org/nilaway has no tagged releases; pin the module pseudo-version.
+NILAWAY_VERSION = v0.0.0-20260808063849-8649a03c818a
 NFPM ?= $(shell which nfpm)
 OS ?= $(shell $(GO) env GOOS)
 ARCH ?= $(shell $(GO) env GOARCH)
@@ -183,6 +185,15 @@ format:
 .PHONY: lint
 lint:
 	golangci-lint run ./...
+
+# Production packages only: skip tests and generated mocks.
+.PHONY: nilaway
+nilaway:
+	$(GO) run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION) \
+		-test=false \
+		-exclude-test-files \
+		-exclude-file-docstrings='Code generated' \
+		$$($(GO) list ./...)
 
 .PHONY: lint-fix
 lint-fix:

--- a/Makefile
+++ b/Makefile
@@ -186,13 +186,15 @@ format:
 lint:
 	golangci-lint run ./...
 
-# Production packages only: skip tests, generated mocks, and the docs generator.
+# Production packages only: skip tests, generated mocks, the docs generator, and
+# out-of-module code (stdlib/deps). NilAway otherwise traces into net/http and similar.
 .PHONY: nilaway
 nilaway:
 	$(GO) run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION) \
 		-test=false \
 		-exclude-test-files \
 		-exclude-file-docstrings='Code generated' \
+		-include-pkgs=$$($(GO) list -m) \
 		$$($(GO) list ./... | grep -vE '/(build/docs|docs)$$')
 
 .PHONY: lint-fix

--- a/internal/server/handlers/backup_test.go
+++ b/internal/server/handlers/backup_test.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+var testBackupStorage = &model.LocalStorage{Path: "test-path"}
+
 func TestService_GetAllFullBackups(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -31,10 +33,14 @@ func TestService_GetAllFullBackups(t *testing.T) {
 			},
 			setupMock: func(m *service.MockBackupReader) {
 				m.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
-					Return([]model.BackupDetails{{Key: "backup1", BackupMetadata: model.BackupMetadata{
-						Created:  time.UnixMilli(1000).In(time.UTC),
-						Finished: time.UnixMilli(5000).In(time.UTC),
-					}}}, nil)
+					Return([]model.BackupDetails{{
+						Key:     "backup1",
+						Storage: testBackupStorage,
+						BackupMetadata: model.BackupMetadata{
+							Created:  time.UnixMilli(1000).In(time.UTC),
+							Finished: time.UnixMilli(5000).In(time.UTC),
+						},
+					}}, nil)
 			},
 			expectedStatus: http.StatusOK,
 			expectedBody: map[string][]dto.BackupDetails{
@@ -46,6 +52,9 @@ func TestService_GetAllFullBackups(t *testing.T) {
 						Finished:          time.UnixMilli(5000).In(time.UTC),
 						FinishedTimestamp: 5000,
 						Duration:          4,
+						Storage: &dto.Storage{
+							LocalStorage: &dto.LocalStorage{Path: "test-path"},
+						},
 					},
 				},
 			},
@@ -355,7 +364,7 @@ func TestService_GetFullBackupsForRoutine(t *testing.T) {
 			routineName: "routine1",
 			setupMock: func(m *service.MockBackupReader) {
 				m.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
-					Return([]model.BackupDetails{{Key: "backup1"}}, nil)
+					Return([]model.BackupDetails{{Key: "backup1", Storage: testBackupStorage}}, nil)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -412,7 +421,7 @@ func TestService_GetAllIncrementalBackups(t *testing.T) {
 			name: "success",
 			setupMock: func(m *service.MockBackupReader) {
 				m.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
-					Return([]model.BackupDetails{{Key: "incr1"}}, nil)
+					Return([]model.BackupDetails{{Key: "incr1", Storage: testBackupStorage}}, nil)
 			},
 			expectedStatus: http.StatusOK,
 		},
@@ -473,7 +482,7 @@ func TestService_GetIncrementalBackupsForRoutine(t *testing.T) {
 			routineName: "routine1",
 			setupMock: func(m *service.MockBackupReader) {
 				m.EXPECT().GetBackups(gomock.Any(), gomock.Any()).
-					Return([]model.BackupDetails{{Key: "incr1"}}, nil)
+					Return([]model.BackupDetails{{Key: "incr1", Storage: testBackupStorage}}, nil)
 			},
 			expectedStatus: http.StatusOK,
 		},

--- a/pkg/dto/aerospike_cluster.go
+++ b/pkg/dto/aerospike_cluster.go
@@ -135,10 +135,6 @@ func NewClusterFromReader(r io.Reader, format decoder.SerializationFormat) (*Aer
 }
 
 func NewClusterFromModel(m *model.AerospikeCluster, config *model.BackupConfig) *AerospikeCluster {
-	if m == nil {
-		return nil
-	}
-
 	a := &AerospikeCluster{}
 	a.fromModel(m, config)
 	return a

--- a/pkg/dto/backup_routine.go
+++ b/pkg/dto/backup_routine.go
@@ -381,10 +381,6 @@ func NewRoutineFromReader(r io.Reader, format decoder.SerializationFormat) (*Bac
 }
 
 func NewRoutineFromModel(m *model.BackupRoutine, config *model.Config) *BackupRoutine {
-	if m == nil || config == nil {
-		return nil
-	}
-
 	b := &BackupRoutine{}
 	b.fromModel(m, config.BackupConfigCopy())
 

--- a/pkg/dto/restore_request.go
+++ b/pkg/dto/restore_request.go
@@ -134,17 +134,25 @@ func (r *RestoreTimestampRequest) Validate() error {
 }
 
 func (r *RestoreTimestampRequest) ToModel(config *model.Config) (*model.RestoreTimestampRequest, error) {
-	cluster, err := r.DestinationClusterConfig.ToModel(config)
-	if err != nil {
-		return nil, fmt.Errorf("invalid cluster: %w", err)
-	}
-
 	secretAgent, err := r.SecretAgentConfig.ToModel(config)
 	if err != nil {
 		return nil, fmt.Errorf("invalid secret agent: %w", err)
 	}
 
 	routine, found := config.Routine(r.Routine)
+
+	var cluster *model.AerospikeCluster
+	if !r.DestinationClusterConfig.IsEmpty() {
+		cluster, err = r.DestinationClusterConfig.ToModel(config)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cluster: %w", err)
+		}
+	} else {
+		if !found {
+			return nil, errValidationNotFound("routine", r.Routine)
+		}
+		cluster = routine.SourceCluster
+	}
 
 	var storage model.Storage
 	if !r.StorageConfig.IsEmpty() {
@@ -157,13 +165,6 @@ func (r *RestoreTimestampRequest) ToModel(config *model.Config) (*model.RestoreT
 			return nil, errValidationNotFound("routine", r.Routine)
 		}
 		storage = routine.Storage
-	}
-
-	if cluster == nil {
-		if !found {
-			return nil, errValidationNotFound("routine", r.Routine)
-		}
-		cluster = routine.SourceCluster // if cluster is not specified, use routine's cluster.
 	}
 
 	if secretAgent == nil && found {
@@ -238,10 +239,6 @@ func (c *DestinationClusterConfig) Validate(opts ValidationOptions) error {
 }
 
 func (c *DestinationClusterConfig) ToModel(config *model.Config) (*model.AerospikeCluster, error) {
-	if c.IsEmpty() {
-		return nil, nil
-	}
-
 	if c.Cluster != nil {
 		return c.Cluster.ToModel(config)
 	}

--- a/pkg/dto/storage.go
+++ b/pkg/dto/storage.go
@@ -109,7 +109,7 @@ func NewStorageFromModel(m model.Storage, config *model.BackupConfig) *Storage {
 			AzureStorage: newAzureStorageFromModel(s, config),
 		}
 	default:
-		panic(fmt.Sprintf("unsupported model storage type %T", m))
+		return &Storage{} // never happens in production.
 	}
 }
 

--- a/pkg/dto/storage.go
+++ b/pkg/dto/storage.go
@@ -109,7 +109,7 @@ func NewStorageFromModel(m model.Storage, config *model.BackupConfig) *Storage {
 			AzureStorage: newAzureStorageFromModel(s, config),
 		}
 	default:
-		panic(fmt.Sprintf("unsupported model storage type %T", m)) // never happens in production.
+		panic(fmt.Sprintf("unsupported model storage type %T", m)) // Unreachable
 	}
 }
 

--- a/pkg/dto/storage.go
+++ b/pkg/dto/storage.go
@@ -109,7 +109,7 @@ func NewStorageFromModel(m model.Storage, config *model.BackupConfig) *Storage {
 			AzureStorage: newAzureStorageFromModel(s, config),
 		}
 	default:
-		return &Storage{} // never happens in production.
+		panic(fmt.Sprintf("unsupported model storage type %T", m)) // never happens in production.
 	}
 }
 

--- a/pkg/dto/storage.go
+++ b/pkg/dto/storage.go
@@ -61,7 +61,7 @@ func (s *Storage) Validate() error {
 		validStorage = s.AzureStorage
 		count++
 	}
-	if count == 0 {
+	if validStorage == nil {
 		return errors.New("no storage type specified")
 	}
 	if count > 1 {
@@ -109,7 +109,7 @@ func NewStorageFromModel(m model.Storage, config *model.BackupConfig) *Storage {
 			AzureStorage: newAzureStorageFromModel(s, config),
 		}
 	default:
-		return nil
+		panic(fmt.Sprintf("unsupported model storage type %T", m))
 	}
 }
 

--- a/pkg/model/backup_routine.go
+++ b/pkg/model/backup_routine.go
@@ -105,10 +105,6 @@ func toBackupRoutineGob(r *BackupRoutine) backupRoutineGob {
 // Long-running backup/restore operations must work on an immutable routine snapshot.
 // A shallow copy would still share nested pointers/slices and could observe config changes mid-run.
 func (r *BackupRoutine) Copy() *BackupRoutine {
-	if r == nil {
-		return nil
-	}
-
 	var buf bytes.Buffer
 	if err := gob.NewEncoder(&buf).Encode(toBackupRoutineGob(r)); err != nil {
 		panic(err) // if happens, registered failed types in init()

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -214,6 +214,7 @@ func (c *Config) AddCluster(name string, cluster *AerospikeCluster) error {
 		return fmt.Errorf("add Aerospike cluster %q: %w", name, ErrAlreadyExists)
 	}
 	c.backupConfig.AerospikeClusters[name] = cluster
+
 	return nil
 }
 

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -204,7 +204,7 @@ func (c *Config) AddRoutine(r *BackupRoutine) error {
 
 func (c *Config) AddCluster(name string, cluster *AerospikeCluster) error {
 	if cluster == nil {
-		return errors.New("Aerospike cluster cannot be nil")
+		return errors.New("cluster cannot be nil")
 	}
 
 	c.mu.Lock()

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -41,12 +41,8 @@ func newBackupConfig() *BackupConfig {
 	}
 }
 
-func (bc *BackupConfig) copy() *BackupConfig {
-	if bc == nil {
-		return nil
-	}
-
-	newConfig := &BackupConfig{
+func (bc BackupConfig) copy() BackupConfig {
+	return BackupConfig{
 		AerospikeClusters:   maps.Clone(bc.AerospikeClusters),
 		Storage:             maps.Clone(bc.Storage),
 		BackupPolicies:      maps.Clone(bc.BackupPolicies),
@@ -54,8 +50,6 @@ func (bc *BackupConfig) copy() *BackupConfig {
 		SecretAgents:        maps.Clone(bc.SecretAgents),
 		invalidatedRoutines: make(map[string]struct{}),
 	}
-
-	return newConfig
 }
 
 var (
@@ -67,7 +61,8 @@ var (
 func (c *Config) BackupConfigCopy() *BackupConfig {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.backupConfig.copy()
+	config := c.backupConfig.copy()
+	return &config
 }
 
 func (c *Config) AddStorage(name string, s Storage) error {

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -66,6 +66,27 @@ func (c *Config) BackupConfigCopy() *BackupConfig {
 }
 
 func (c *Config) AddStorage(name string, s Storage) error {
+	switch storage := s.(type) {
+	case *LocalStorage:
+		if storage == nil {
+			return errors.New("storage cannot be nil")
+		}
+	case *S3Storage:
+		if storage == nil {
+			return errors.New("storage cannot be nil")
+		}
+	case *GcpStorage:
+		if storage == nil {
+			return errors.New("storage cannot be nil")
+		}
+	case *AzureStorage:
+		if storage == nil {
+			return errors.New("storage cannot be nil")
+		}
+	default:
+		return fmt.Errorf("unsupported storage type %T", s)
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -161,6 +182,10 @@ func (c *Config) Routine(name string) (*BackupRoutine, bool) {
 }
 
 func (c *Config) AddRoutine(r *BackupRoutine) error {
+	if r == nil {
+		return errors.New("backup routine cannot be nil")
+	}
+
 	if r.Name == "" {
 		return errors.New("backup routine name is empty")
 	}
@@ -178,6 +203,10 @@ func (c *Config) AddRoutine(r *BackupRoutine) error {
 }
 
 func (c *Config) AddCluster(name string, cluster *AerospikeCluster) error {
+	if cluster == nil {
+		return errors.New("Aerospike cluster cannot be nil")
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -66,6 +66,10 @@ func (c *Config) BackupConfigCopy() *BackupConfig {
 }
 
 func (c *Config) AddStorage(name string, s Storage) error {
+	if s == nil {
+		return errors.New("storage cannot be nil")
+	}
+
 	switch storage := s.(type) {
 	case *LocalStorage:
 		if storage == nil {
@@ -124,6 +128,10 @@ func (c *Config) routineUsesStorage(s Storage) string {
 }
 
 func (c *Config) AddPolicy(name string, p *BackupPolicy) error {
+	if p == nil {
+		return errors.New("backup policy cannot be nil")
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/model/config.go
+++ b/pkg/model/config.go
@@ -139,6 +139,7 @@ func (c *Config) AddPolicy(name string, p *BackupPolicy) error {
 		return fmt.Errorf("add backup policy %q: %w", name, ErrAlreadyExists)
 	}
 	c.backupConfig.BackupPolicies[name] = p
+
 	return nil
 }
 

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -95,6 +95,9 @@ func TestConfigAddRejectsNilValues(t *testing.T) {
 				if err := cfg.AddRoutine(&BackupRoutine{Name: "routine"}); err != nil {
 					return err
 				}
+				if err := cfg.AddPolicy("policy", &BackupPolicy{}); err != nil {
+					return err
+				}
 
 				return cfg.AddStorage("storage", &LocalStorage{})
 			},
@@ -107,6 +110,11 @@ func TestConfigAddRejectsNilValues(t *testing.T) {
 		{
 			name:    "routine",
 			add:     func(cfg *Config) error { return cfg.AddRoutine(nil) },
+			wantErr: true,
+		},
+		{
+			name:    "policy",
+			add:     func(cfg *Config) error { return cfg.AddPolicy("policy", nil) },
 			wantErr: true,
 		},
 		{

--- a/pkg/model/config_test.go
+++ b/pkg/model/config_test.go
@@ -77,3 +77,59 @@ func TestSetBackupConfig_DoesNotInvalidate(t *testing.T) {
 
 	assert.Empty(t, cfg.PopInvalidatedRoutineNames())
 }
+
+func TestConfigAddRejectsNilValues(t *testing.T) {
+	var typedNilStorage *LocalStorage
+
+	tests := []struct {
+		name    string
+		add     func(*Config) error
+		wantErr bool
+	}{
+		{
+			name: "valid values",
+			add: func(cfg *Config) error {
+				if err := cfg.AddCluster("cluster", &AerospikeCluster{}); err != nil {
+					return err
+				}
+				if err := cfg.AddRoutine(&BackupRoutine{Name: "routine"}); err != nil {
+					return err
+				}
+
+				return cfg.AddStorage("storage", &LocalStorage{})
+			},
+		},
+		{
+			name:    "cluster",
+			add:     func(cfg *Config) error { return cfg.AddCluster("cluster", nil) },
+			wantErr: true,
+		},
+		{
+			name:    "routine",
+			add:     func(cfg *Config) error { return cfg.AddRoutine(nil) },
+			wantErr: true,
+		},
+		{
+			name:    "storage",
+			add:     func(cfg *Config) error { return cfg.AddStorage("storage", nil) },
+			wantErr: true,
+		},
+		{
+			name:    "typed nil storage",
+			add:     func(cfg *Config) error { return cfg.AddStorage("typed-nil-storage", typedNilStorage) },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			err := tt.add(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/service/aerospike/client_manager.go
+++ b/pkg/service/aerospike/client_manager.go
@@ -170,10 +170,9 @@ func (cm *clientManager) Close(client Client) {
 
 	// We need to find which info struct owns this client.
 	// Since Client interface wraps the underlying AerospikeClient, we compare pointers.
-	found := false
 	cm.clients.Iterate(func(key uint64, info *clientInfo) {
-		if found {
-			return // Optimization: stop if already found
+		if targetInfo != nil {
+			return
 		}
 
 		// We must lock to read info.aeroClient safely,
@@ -182,12 +181,11 @@ func (cm *clientManager) Close(client Client) {
 		if info.aeroClient == client.AerospikeClient() {
 			targetInfo = info
 			targetKey = key
-			found = true
 		}
 		info.mu.RUnlock()
 	})
 
-	if found {
+	if targetInfo != nil {
 		cm.decrementRef(targetInfo, targetKey)
 	} else {
 		// If it's not in our cache, we must close it immediately because we aren't managing its lifecycle.


### PR DESCRIPTION
## What does this change do?

Makes conversion and model-mutation contracts total so NilAway can reason about them, and adds a `make nilaway` check for production packages.

NilAway treated several `nil` success paths as real panics. Those paths were either impossible (value copies, correlated flags) or represented invalid config that should be rejected at the boundary.

- `BackupConfig.copy` is a value method and cannot return nil.
- `AddCluster`, `AddRoutine`, and `AddStorage` reject nil (and unsupported storage types).
- Model→DTO constructors no longer return nil for valid model state.
- Restore timestamp overrides check `IsEmpty()` before `ToModel()`; destination conversion no longer uses `(nil, nil)` for “omitted”.
- `BackupRoutine.Copy()` no longer has a nil-success path.
- Client cache release uses `targetInfo != nil` as the single match signal.
- `make nilaway` skips tests, generated mocks, and the docs generator.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [x] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [ ] `make pr` passes locally (tidy, mocks, format, lint, tests, docs).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks and docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

`Validate()` remains the DTO shape check. `ToModel()` is conversion and lookup only; it is assumed to run on validated objects. Optional restore-by-timestamp fields are still resolved by the caller via `IsEmpty()`, not by a third `Resolve` step.

NilAway is not a golangci-lint plugin here; CI/local use `go run go.uber.org/nilaway/cmd/nilaway@…` with a pinned pseudo-version (no tagged releases).