### PR TITLE
BKRS-389 Fix panic on masking

### DIFF
--- a/internal/log/log_handler_test.go
+++ b/internal/log/log_handler_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/aerospike/aerospike-backup-service/v3/pkg/dto"
+	"github.com/aerospike/aerospike-backup-service/v3/pkg/model"
 	"github.com/reugn/go-quartz/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,4 +56,16 @@ func TestHandlerReplaceAttr_RendersTraceLevel(t *testing.T) {
 	log.Log(t.Context(), slog.Level(logger.LevelTrace), "trace message")
 
 	require.Contains(t, buf.String(), `"level":"TRACE"`)
+}
+
+func TestHandlerReplaceAttr_BackupTime(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: handlerReplaceAttr,
+	}))
+
+	backupTime := model.NewFullBackupTime(time.Now())
+	log.Info("Last existing backup", slog.Any("time", backupTime))
+
+	assert.Contains(t, buf.String(), `"msg":"Last existing backup"`)
 }

--- a/pkg/dto/decoder/masking.go
+++ b/pkg/dto/decoder/masking.go
@@ -3,13 +3,24 @@ package decoder
 import (
 	"log/slog"
 	"reflect"
+	"slices"
 	"time"
 )
 
 var (
-	secretType = reflect.TypeFor[Secret]()
-	timeType   = reflect.TypeFor[time.Time]()
-	errType    = reflect.TypeFor[error]()
+	secretType      = reflect.TypeFor[Secret]()
+	timeType        = reflect.TypeFor[time.Time]()
+	timePtrType     = reflect.PointerTo(timeType)
+	locationType    = reflect.TypeFor[time.Location]()
+	locationPtrType = reflect.PointerTo(locationType)
+	errType         = reflect.TypeFor[error]()
+
+	skipDeepCopyTypes = []reflect.Type{
+		timeType,
+		timePtrType,
+		locationType,
+		locationPtrType,
+	}
 )
 
 // RedactSecrets returns a deep copy of v with all Secret-typed values replaced by redactedSecret.
@@ -43,7 +54,7 @@ func redactValue(v reflect.Value) reflect.Value {
 		return reflect.ValueOf(Secret(s.DisplayString()))
 	}
 
-	if v.Type() == timeType {
+	if shouldSkipDeepCopy(v) {
 		return v
 	}
 
@@ -127,4 +138,8 @@ func setField(dst, src reflect.Value) {
 	if src.Type().ConvertibleTo(dst.Type()) {
 		dst.Set(src.Convert(dst.Type()))
 	}
+}
+
+func shouldSkipDeepCopy(t reflect.Value) bool {
+	return slices.Contains(skipDeepCopyTypes, t.Type())
 }

--- a/pkg/dto/decoder/masking_test.go
+++ b/pkg/dto/decoder/masking_test.go
@@ -191,6 +191,38 @@ func TestRedactSecrets_PreservesTime(t *testing.T) {
 	assert.Equal(t, int64(1000), redacted["routine1"][0].Timestamp)
 }
 
+func TestRedactSecrets_UnexportedTimePointerFields(t *testing.T) {
+	// Mirrors model.BackupTime: unexported *time.Time fields panic when redactValue
+	// tries to deep-copy through reflect without skipping *time.Time.
+	type backupTimeLike struct {
+		full *time.Time
+	}
+
+	now := time.Now()
+	backupTime := &backupTimeLike{full: &now}
+
+	assert.NotPanics(t, func() {
+		RedactSecrets(backupTime)
+	})
+}
+
+func TestRedactSecrets_UnexportedLocationPointerFields(t *testing.T) {
+	// Mirrors model.Location: unexported *time.Location field.
+	type locationLike struct {
+		resolved   *time.Location
+		Configured string
+	}
+
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	location := locationLike{resolved: loc, Configured: "America/New_York"}
+
+	assert.NotPanics(t, func() {
+		RedactSecrets(location)
+	})
+}
+
 // credentialError mirrors aerospike.AerospikeError: exported fields on a type
 // stored behind fmt.Errorf("%w"). slog.Any("error", err) walks that wrapError,
 // whose err field is unexported, then Set panics when copying ResultCode.

--- a/pkg/dto/decoder/merge.go
+++ b/pkg/dto/decoder/merge.go
@@ -73,7 +73,7 @@ func mergeValue(incoming, existing reflect.Value) {
 		return
 	}
 
-	if incoming.Type() == timeType {
+	if shouldSkipDeepCopy(incoming) {
 		return
 	}
 


### PR DESCRIPTION
## What does this change do?

<!-- Summarize the change and why it's needed. Link any related issue. -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (config file, REST API, or CLI flags)
- [ ] Documentation
- [ ] Chore / refactor / CI

## Checklist

- [x] Target branch is `dev`. Only release PRs and hotfixes target `main`; v2 maintenance targets `v2`.
- [x] `make pr` passes locally (tidy, mocks, format, lint, tests, OpenAPI, README generation).
- [x] Tests were added or updated for the change.
- [x] Generated artifacts are committed and up to date (`make generated-check` passes): mocks, OpenAPI spec, README/docs.
- [ ] If this changes the configuration file or REST API in a breaking way, the
      [migration guide](../README.md#migration-guide) is updated.

## Additional context

<!-- Anything else reviewers should know: alternatives considered, follow-up work, screenshots, etc. -->
