### PR TITLE
BKRS-393 Reject literal "[secret]" sentinel on new entities

### DIFF
--- a/internal/server/api_contract_test.go
+++ b/internal/server/api_contract_test.go
@@ -270,3 +270,42 @@ func keysOf(m map[string]any) []string {
 
 	return keys
 }
+
+// TestUnconfiguredService_SentinelSecretValidation tests that creating new entities with
+// redacted secret sentinels is rejected with a 400 error.
+func TestUnconfiguredService_SentinelSecretValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		body        string
+		wantStatus  int
+		wantBodyReg string
+	}{
+		{
+			name:        "new cluster with redacted password sentinel",
+			method:      http.MethodPost,
+			path:        "/v1/config/clusters/newcluster",
+			body:        "{\"seed-nodes\":[{\"host-name\":\"localhost\",\"port\":3000}],\"credentials\":{\"user\":\"admin\",\"password\":\"[secret]\"}}",
+			wantStatus:  http.StatusBadRequest,
+			wantBodyReg: "cannot use redacted secret.*for a new entity",
+		},
+		{
+			name:        "new storage with redacted secret access key sentinel",
+			method:      http.MethodPost,
+			path:        "/v1/config/storage/newstorage",
+			body:        "{\"s3-storage\":{\"bucket\":\"test\",\"s3-region\":\"us-east-1\",\"access-key-id\":\"key\",\"secret-access-key\":\"[secret]\"}}",
+			wantStatus:  http.StatusBadRequest,
+			wantBodyReg: "cannot use redacted secret.*for a new entity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := serve(t, newUnconfiguredService(t), tt.method, tt.path, tt.body)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			assert.Regexp(t, tt.wantBodyReg, w.Body.String())
+		})
+	}
+}

--- a/internal/server/api_contract_test.go
+++ b/internal/server/api_contract_test.go
@@ -283,18 +283,20 @@ func TestUnconfiguredService_SentinelSecretValidation(t *testing.T) {
 		wantBodyReg string
 	}{
 		{
-			name:        "new cluster with redacted password sentinel",
-			method:      http.MethodPost,
-			path:        "/v1/config/clusters/newcluster",
-			body:        "{\"seed-nodes\":[{\"host-name\":\"localhost\",\"port\":3000}],\"credentials\":{\"user\":\"admin\",\"password\":\"[secret]\"}}",
+			name:   "new cluster with redacted password sentinel",
+			method: http.MethodPost,
+			path:   "/v1/config/clusters/newcluster",
+			body: "{\"seed-nodes\":[{\"host-name\":\"localhost\",\"port\":3000}]," +
+				"\"credentials\":{\"user\":\"admin\",\"password\":\"[secret]\"}}",
 			wantStatus:  http.StatusBadRequest,
 			wantBodyReg: "cannot use redacted secret.*for a new entity",
 		},
 		{
-			name:        "new storage with redacted secret access key sentinel",
-			method:      http.MethodPost,
-			path:        "/v1/config/storage/newstorage",
-			body:        "{\"s3-storage\":{\"bucket\":\"test\",\"s3-region\":\"us-east-1\",\"access-key-id\":\"key\",\"secret-access-key\":\"[secret]\"}}",
+			name:   "new storage with redacted secret access key sentinel",
+			method: http.MethodPost,
+			path:   "/v1/config/storage/newstorage",
+			body: "{\"s3-storage\":{\"bucket\":\"test\",\"s3-region\":\"us-east-1\"," +
+				"\"access-key-id\":\"key\",\"secret-access-key\":\"[secret]\"}}",
 			wantStatus:  http.StatusBadRequest,
 			wantBodyReg: "cannot use redacted secret.*for a new entity",
 		},

--- a/internal/server/handlers/config.go
+++ b/internal/server/handlers/config.go
@@ -48,7 +48,10 @@ func (s *Service) UpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// GET responses redact secrets as "[secret]". Before persisting a PUT, copy real secret
 	// values from the stored config into the incoming payload wherever the sentinel appears,
 	// so a GET-edit-PUT round trip does not overwrite secrets with the literal "[secret]".
-	decoder.MergeSecrets(newConfig, oldConfig)
+	if err := decoder.MergeSecrets(newConfig, oldConfig); err != nil {
+		httpError(w, errBadRequest(err))
+		return
+	}
 
 	if err := newConfig.Validate(); err != nil {
 		httpError(w, errBadRequest(err))

--- a/internal/server/handlers/config_change.go
+++ b/internal/server/handlers/config_change.go
@@ -39,7 +39,9 @@ func (s *Service) changeBackupConfig(
 	// values from the stored config into the incoming payload wherever the sentinel appears,
 	// so a GET-edit-PUT round trip does not overwrite secrets with the literal "[secret]".
 	existingConfig := dto.NewConfigFromModel(s.config)
-	decoder.MergeSecrets(dtoConfig, existingConfig)
+	if err := decoder.MergeSecrets(dtoConfig, existingConfig); err != nil {
+		return fmt.Errorf("failed to update configuration: %w", err)
+	}
 
 	if err := dtoConfig.Validate(); err != nil {
 		return fmt.Errorf("failed to update configuration: %w", err)

--- a/pkg/dto/decoder/merge.go
+++ b/pkg/dto/decoder/merge.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"errors"
 	"reflect"
 )
 
@@ -9,6 +10,9 @@ import (
 //
 // It walks incoming recursively and, for every Secret field equal to redactedSecret,
 // copies the value from the matching field in existing.
+//
+// Returns an error if a redacted Secret is found in incoming but there is no
+// corresponding existing value to restore from.
 //
 // Example:
 //
@@ -44,121 +48,163 @@ import (
 //	    }
 //	  }
 //	}
-func MergeSecrets(incoming, existing any) {
+func MergeSecrets(incoming, existing any) error {
 	if incoming == nil || existing == nil {
-		return
+		return nil
 	}
 
-	mergeValue(reflect.ValueOf(incoming), reflect.ValueOf(existing))
+	return mergeValue(reflect.ValueOf(incoming), reflect.ValueOf(existing))
 }
 
 //nolint:gocognit,gocyclo,funlen // recursive reflect walk over nested DTO values
-func mergeValue(incoming, existing reflect.Value) {
-	if !incoming.IsValid() || !existing.IsValid() {
-		return
+func mergeValue(incoming, existing reflect.Value) error {
+	if !incoming.IsValid() {
+		return nil
 	}
 
 	if incoming.Type() == secretType {
-		inSecret, ok := incoming.Interface().(Secret)
-		if !ok || !inSecret.IsRedacted() {
-			return
-		}
-
-		if existing.Type() != secretType || !incoming.CanSet() {
-			return
-		}
-
-		incoming.Set(existing)
-
-		return
+		return setSecretValue(incoming, existing)
 	}
 
 	if shouldSkipDeepCopy(incoming) {
-		return
+		return nil
 	}
 
 	switch incoming.Kind() {
 	case reflect.Pointer:
 		if incoming.IsNil() {
-			return
+			return nil
 		}
 
 		incomingElem := incoming.Elem()
 		if existing.Kind() == reflect.Pointer {
-			if existing.IsNil() {
-				return
+			if !existing.IsValid() {
+				return mergeValue(incomingElem, reflect.Value{})
 			}
 
-			mergeValue(incomingElem, existing.Elem())
-			return
+			if existing.IsNil() {
+				return mergeValue(incomingElem, reflect.Value{})
+			}
+
+			return mergeValue(incomingElem, existing.Elem())
 		}
 
-		mergeValue(incomingElem, existing)
+		if !existing.IsValid() {
+			return mergeValue(incomingElem, reflect.Value{})
+		}
+
+		return mergeValue(incomingElem, existing)
 
 	case reflect.Interface:
 		if incoming.IsNil() {
-			return
+			return nil
+		}
+
+		if !existing.IsValid() {
+			return nil
 		}
 
 		if existing.IsNil() {
-			return
+			return nil
 		}
 
-		mergeValue(incoming.Elem(), existing.Elem())
+		return mergeValue(incoming.Elem(), existing.Elem())
 
 	case reflect.Struct:
-		if existing.Kind() != reflect.Struct || incoming.Type() != existing.Type() {
-			return
+		if existing.IsValid() && (existing.Kind() != reflect.Struct || incoming.Type() != existing.Type()) {
+			return nil
 		}
 
 		for i := 0; i < incoming.NumField(); i++ {
-			mergeValue(incoming.Field(i), existing.Field(i))
+			var existingField reflect.Value
+			if existing.IsValid() {
+				existingField = existing.Field(i)
+			}
+			if err := mergeValue(incoming.Field(i), existingField); err != nil {
+				return err
+			}
 		}
+
+		return nil
 
 	case reflect.Map:
 		if existing.Kind() != reflect.Map || incoming.Type() != existing.Type() {
-			return
+			return nil
 		}
 
 		for _, key := range incoming.MapKeys() {
-			existingVal := existing.MapIndex(key)
-			if !existingVal.IsValid() {
-				continue
-			}
-
 			incomingVal := incoming.MapIndex(key)
+			existingVal := existing.MapIndex(key)
+
 			if incomingVal.Kind() != reflect.Pointer && !incomingVal.CanSet() {
 				mutable := reflect.New(incomingVal.Type()).Elem()
 				mutable.Set(incomingVal)
-				mergeValue(mutable, existingVal)
+				if err := mergeValue(mutable, existingVal); err != nil {
+					return err
+				}
 				incoming.SetMapIndex(key, mutable)
 				continue
 			}
 
-			mergeValue(incomingVal, existingVal)
+			if err := mergeValue(incomingVal, existingVal); err != nil {
+				return err
+			}
 		}
+
+		return nil
 
 	case reflect.Slice:
 		if existing.Kind() != reflect.Slice {
-			return
+			return nil
 		}
 
 		n := min(existing.Len(), incoming.Len())
 
 		for i := range n {
-			mergeValue(incoming.Index(i), existing.Index(i))
+			if err := mergeValue(incoming.Index(i), existing.Index(i)); err != nil {
+				return err
+			}
 		}
+
+		return nil
 
 	case reflect.Array:
 		if existing.Kind() != reflect.Array || incoming.Type() != existing.Type() {
-			return
+			return nil
 		}
 
 		for i := 0; i < incoming.Len(); i++ {
-			mergeValue(incoming.Index(i), existing.Index(i))
+			if err := mergeValue(incoming.Index(i), existing.Index(i)); err != nil {
+				return err
+			}
 		}
+		return nil
 
 	default:
-		return
+		return nil
 	}
+}
+
+func setSecretValue(incoming reflect.Value, existing reflect.Value) error {
+	inSecret, ok := incoming.Interface().(Secret)
+	if !ok || !inSecret.IsRedacted() {
+		return nil
+	}
+
+	if !incoming.CanSet() {
+		return nil
+	}
+
+	if !existing.IsValid() || existing.Type() != secretType {
+		return errors.New("cannot use redacted secret \"[secret]\" for a new entity with no existing value")
+	}
+
+	existingSecret := existing.Interface().(Secret)
+	if existingSecret.IsRedacted() {
+		return errors.New("cannot use redacted secret \"[secret]\" for a new entity with no existing value")
+	}
+
+	incoming.Set(existing)
+
+	return nil
 }

--- a/pkg/dto/decoder/merge_test.go
+++ b/pkg/dto/decoder/merge_test.go
@@ -19,7 +19,8 @@ func TestMergeSecrets_ComplexFixture(t *testing.T) {
 		SecretAccessKey: redactedSecret,
 	}
 
-	MergeSecrets(&redacted, original)
+	err := MergeSecrets(&redacted, original)
+	require.NoError(t, err)
 
 	t.Run("restores literal secrets", func(t *testing.T) {
 		assert.Equal(t, Secret(literalPassword), redacted.AerospikeClusters["cluster1"].Credentials.Password)
@@ -53,7 +54,7 @@ func TestMergeSecrets_ComplexFixture(t *testing.T) {
 	})
 }
 
-func TestMergeSecrets_NewMapEntryWithSentinel(t *testing.T) {
+func TestMergeSecrets_NewMapEntryWithSentinel_ReturnsError(t *testing.T) {
 	existing := testConfig{
 		AerospikeClusters: map[string]*testCluster{},
 	}
@@ -69,9 +70,9 @@ func TestMergeSecrets_NewMapEntryWithSentinel(t *testing.T) {
 		},
 	}
 
-	MergeSecrets(&incoming, existing)
-
-	assert.Equal(t, Secret(redactedSecret), incoming.AerospikeClusters["new-cluster"].Credentials.Password)
+	err := MergeSecrets(&incoming, existing)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use redacted secret")
 }
 
 func TestMergeSecrets_ExplicitSecretUpdate(t *testing.T) {
@@ -97,7 +98,8 @@ func TestMergeSecrets_ExplicitSecretUpdate(t *testing.T) {
 		},
 	}
 
-	MergeSecrets(&incoming, existing)
+	err := MergeSecrets(&incoming, existing)
+	require.NoError(t, err)
 
 	assert.Equal(t, Secret("new-password"), incoming.AerospikeClusters["cluster1"].Credentials.Password)
 }
@@ -125,7 +127,8 @@ func TestMergeSecrets_ClearSecretWithEmptyString(t *testing.T) {
 		},
 	}
 
-	MergeSecrets(&incoming, existing)
+	err := MergeSecrets(&incoming, existing)
+	require.NoError(t, err)
 
 	assert.Empty(t, incoming.AerospikeClusters["cluster1"].Credentials.Password)
 }
@@ -134,10 +137,61 @@ func TestMergeSecrets_NilInput(t *testing.T) {
 	original := testComplexConfig()
 
 	require.NotPanics(t, func() {
-		MergeSecrets(nil, original)
-		MergeSecrets(&original, nil)
-		MergeSecrets(nil, nil)
+		err1 := MergeSecrets(nil, original)
+		assert.NoError(t, err1)
+		err2 := MergeSecrets(&original, nil)
+		assert.NoError(t, err2)
+		err3 := MergeSecrets(nil, nil)
+		assert.NoError(t, err3)
 	})
+}
+
+func TestMergeSecrets_NewEntityWithSentinel_StorageSecret(t *testing.T) {
+	existing := testConfig{
+		StorageProviders: map[string]testStorage{},
+	}
+
+	incoming := testConfig{
+		StorageProviders: map[string]testStorage{
+			"new-storage": {
+				Name:            "new-bucket",
+				AccessKeyID:     redactedSecret,
+				SecretAccessKey: redactedSecret,
+			},
+		},
+	}
+
+	err := MergeSecrets(&incoming, existing)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use redacted secret")
+}
+
+func TestMergeSecrets_ExistingEntityWithSentinel_RestoredCorrectly(t *testing.T) {
+	existing := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: literalPassword,
+				},
+			},
+		},
+	}
+
+	incoming := testConfig{
+		AerospikeClusters: map[string]*testCluster{
+			"cluster1": {
+				Credentials: &testCredentials{
+					User:     "testUser",
+					Password: redactedSecret,
+				},
+			},
+		},
+	}
+
+	err := MergeSecrets(&incoming, existing)
+	require.NoError(t, err)
+	assert.Equal(t, Secret(literalPassword), incoming.AerospikeClusters["cluster1"].Credentials.Password)
 }
 
 func TestSecret_IsRedacted(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes BKRS-393: When creating new entities (Aerospike clusters, storage providers, or backup policies) with the redacted sentinel `"[secret]"` as the actual secret value, the API now rejects the request with a 400 Bad Request error instead of silently accepting and storing the literal text.

## Changes

- Modified `MergeSecrets()` to return an error when a redacted Secret field is encountered on new entities with no corresponding existing value to restore from
- Updated `mergeValue()` recursive logic to properly traverse nested structures even when existing values are invalid/missing, enabling sentinel detection deep in the object graph
- Updated error handling in config handlers to catch and return merge errors before general validation
- Added comprehensive unit tests for sentinel validation across different entity types
- Added HTTP contract tests verifying 400 rejection through REST endpoints

## Testing

All tests pass:
- Unit tests: `TestMergeSecrets_*` verify sentinel detection and error propagation
- HTTP contract tests: `TestUnconfiguredService_SentinelSecretValidation` verify REST endpoint behavior
- Existing tests ensure backward compatibility for normal secret restoration

## Impact

Per the migration guide (v3.6 → v3.7), sending `"[secret]"` for a newly added entity is now properly rejected. The xfail tests in `aerospike-tests-python` that document this behavior will now pass.